### PR TITLE
Feature/#50

### DIFF
--- a/HowManySet/App/Coordinator/RoutineListCoordinator.swift
+++ b/HowManySet/App/Coordinator/RoutineListCoordinator.swift
@@ -50,8 +50,16 @@ final class RoutineListCoordinator: RoutineListCoordinatorProtocol {
         let editRoutineVC = EditRoutineViewController(reactor: reactor)
 
         if let sheet = editRoutineVC.sheetPresentationController {
-            sheet.detents = [.medium()]
+            let fixedHeight: CGFloat = UIScreen.main.bounds.height * 0.27
+
+            sheet.detents = [.custom(resolver: { _ in
+                fixedHeight
+            })]
             sheet.prefersGrabberVisible = true
+
+            sheet.prefersScrollingExpandsWhenScrolledToEdge = false
+            sheet.prefersEdgeAttachedInCompactHeight = true // iPhone에서 전체화면 방지
+            sheet.widthFollowsPreferredContentSizeWhenEdgeAttached = true
         }
 
         navigationController.present(editRoutineVC, animated: true)

--- a/HowManySet/App/Coordinator/RoutineListCoordinator.swift
+++ b/HowManySet/App/Coordinator/RoutineListCoordinator.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol RoutineListCoordinatorProtocol: Coordinator {
-    func presentEditRoutineView()
+    func presentRoutineNameView()
 }
 
 /// 루틴 리스트 화면 관련 coordinator
@@ -45,11 +45,11 @@ final class RoutineListCoordinator: RoutineListCoordinatorProtocol {
     }
     
     /// 루틴명 편집 화면으로 모달 표시
-    func presentEditRoutineView() {
-        let reactor = EditRoutinViewReactor()
-        let editRoutineVC = EditRoutineViewController(reactor: reactor)
+    func presentRoutineNameView() {
+        let reactor = RoutineNameReactor()
+        let routineNameVC = RoutineNameViewController(reactor: reactor)
 
-        if let sheet = editRoutineVC.sheetPresentationController {
+        if let sheet = routineNameVC.sheetPresentationController {
             let fixedHeight: CGFloat = UIScreen.main.bounds.height * 0.27
 
             sheet.detents = [.custom(resolver: { _ in
@@ -62,7 +62,7 @@ final class RoutineListCoordinator: RoutineListCoordinatorProtocol {
             sheet.widthFollowsPreferredContentSizeWhenEdgeAttached = true
         }
 
-        navigationController.present(editRoutineVC, animated: true)
+        navigationController.present(routineNameVC, animated: true)
     }
     
     /// 운동 편집 화면 모달 표시

--- a/HowManySet/App/Coordinator/RoutineListCoordinator.swift
+++ b/HowManySet/App/Coordinator/RoutineListCoordinator.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol RoutineListCoordinatorProtocol: Coordinator {
-    
+    func presentEditRoutineView()
 }
 
 /// 루틴 리스트 화면 관련 coordinator
@@ -44,12 +44,17 @@ final class RoutineListCoordinator: RoutineListCoordinatorProtocol {
         navigationController.present(routineListVC, animated: true)
     }
     
-    /// 루틴 편집 화면으로 푸시
-    func pushEditRoutineView() {
+    /// 루틴명 편집 화면으로 모달 표시
+    func presentEditRoutineView() {
         let reactor = EditRoutinViewReactor()
         let editRoutineVC = EditRoutineViewController(reactor: reactor)
-        
-        navigationController.pushViewController(editRoutineVC, animated: true)
+
+        if let sheet = editRoutineVC.sheetPresentationController {
+            sheet.detents = [.medium()]
+            sheet.prefersGrabberVisible = true
+        }
+
+        navigationController.present(editRoutineVC, animated: true)
     }
     
     /// 운동 편집 화면 모달 표시

--- a/HowManySet/App/Coordinator/RoutineListCoordinator.swift
+++ b/HowManySet/App/Coordinator/RoutineListCoordinator.swift
@@ -9,6 +9,7 @@ import UIKit
 
 protocol RoutineListCoordinatorProtocol: Coordinator {
     func presentRoutineNameView()
+    func pushEditExcerciseView()
 }
 
 /// 루틴 리스트 화면 관련 coordinator
@@ -47,7 +48,7 @@ final class RoutineListCoordinator: RoutineListCoordinatorProtocol {
     /// 루틴명 편집 화면으로 모달 표시
     func presentRoutineNameView() {
         let reactor = RoutineNameReactor()
-        let routineNameVC = RoutineNameViewController(reactor: reactor)
+        let routineNameVC = RoutineNameViewController(reactor: reactor, coordinator: self)
 
         if let sheet = routineNameVC.sheetPresentationController {
             let fixedHeight: CGFloat = UIScreen.main.bounds.height * 0.27
@@ -65,16 +66,11 @@ final class RoutineListCoordinator: RoutineListCoordinatorProtocol {
         navigationController.present(routineNameVC, animated: true)
     }
     
-    /// 운동 편집 화면 모달 표시
-    func presentEditExcerciseView() {
+    /// 운동 편집 화면 전체 화면으로 push
+    func pushEditExcerciseView() {
         let reactor = EditExcerciseViewReactor()
         let editExcerciseVC = EditExcerciseViewController(reactor: reactor)
         
-        if let sheet = editExcerciseVC.sheetPresentationController {
-            sheet.detents = [.medium()]
-            sheet.prefersGrabberVisible = true
-        }
-        
-        navigationController.present(editExcerciseVC, animated: true)
+        navigationController.pushViewController(editExcerciseVC, animated: true)
     }
 }

--- a/HowManySet/App/Coordinator/RoutineListCoordinator.swift
+++ b/HowManySet/App/Coordinator/RoutineListCoordinator.swift
@@ -10,6 +10,7 @@ import UIKit
 protocol RoutineListCoordinatorProtocol: Coordinator {
     func presentRoutineNameView()
     func pushEditExcerciseView()
+    func pushEditRoutineView(with: WorkoutRoutine)
 }
 
 /// 루틴 리스트 화면 관련 coordinator
@@ -79,5 +80,13 @@ final class RoutineListCoordinator: RoutineListCoordinatorProtocol {
         let editExcerciseVC = EditExcerciseViewController(reactor: reactor)
         
         navigationController.pushViewController(editExcerciseVC, animated: true)
+    }
+
+    /// 루틴 리스트 화면에서 셀 클릭 시 루틴 내 운동 리스트 화면으로 push
+    func pushEditRoutineView(with routine: WorkoutRoutine) {
+        let reactor = EditRoutinViewReactor()
+        let editRoutineVC = EditRoutineViewController(reactor: reactor)
+        
+        navigationController.pushViewController(editRoutineVC, animated: true)
     }
 }

--- a/HowManySet/App/Coordinator/RoutineListCoordinator.swift
+++ b/HowManySet/App/Coordinator/RoutineListCoordinator.swift
@@ -47,7 +47,14 @@ final class RoutineListCoordinator: RoutineListCoordinatorProtocol {
     
     /// 루틴명 편집 화면으로 모달 표시
     func presentRoutineNameView() {
-        let reactor = RoutineNameReactor()
+        // RoutineListVC에 있는 saveRoutineUseCase를 재사용하기 위해 인스턴스를 찾고 없으면 리턴
+        guard let routineListVC = navigationController.viewControllers.first(
+            where: { $0 is RoutineListViewController }
+        ) as? RoutineListViewController else { return }
+        let saveRoutineUseCase = routineListVC.reactor?.publicSaveRoutineUseCase
+        guard let saveRoutineUseCase = saveRoutineUseCase else { return }
+        
+        let reactor = RoutineNameReactor(saveRoutineUseCase: saveRoutineUseCase)
         let routineNameVC = RoutineNameViewController(reactor: reactor, coordinator: self)
 
         if let sheet = routineNameVC.sheetPresentationController {

--- a/HowManySet/Domain/Entity/Workout.swift
+++ b/HowManySet/Domain/Entity/Workout.swift
@@ -10,7 +10,7 @@ import Foundation
 /// 운동 정보를 나타내는 구조체입니다.
 ///
 /// 이 구조체는 특정 운동의 이름, 세트 목록, 세트 간 휴식 시간, 그리고 선택적인 코멘트를 포함합니다.
-struct Workout {
+struct Workout: Hashable {
     
     /// 운동 이름입니다.
     ///

--- a/HowManySet/Domain/Entity/WorkoutRoutine.swift
+++ b/HowManySet/Domain/Entity/WorkoutRoutine.swift
@@ -10,7 +10,7 @@ import Foundation
 /// 하나의 운동 루틴을 나타내는 구조체입니다.
 ///
 /// 루틴 이름과 그에 포함된 여러 개의 운동 목록을 포함합니다.
-struct WorkoutRoutine {
+struct WorkoutRoutine: Hashable {
     
     /// 운동 루틴의 이름입니다.
     ///

--- a/HowManySet/Domain/Entity/WorkoutSet.swift
+++ b/HowManySet/Domain/Entity/WorkoutSet.swift
@@ -10,7 +10,7 @@ import Foundation
 /// 운동 세트 하나를 나타내는 구조체입니다.
 ///
 /// 세트별 무게, 단위, 반복 횟수를 포함합니다.
-struct WorkoutSet {
+struct WorkoutSet: Hashable {
     
     /// 세트에서 사용한 무게입니다.
     ///

--- a/HowManySet/Presentation/Feature/EditRoutine/EditRoutineView.swift
+++ b/HowManySet/Presentation/Feature/EditRoutine/EditRoutineView.swift
@@ -1,0 +1,92 @@
+import UIKit
+import SnapKit
+import Then
+
+final class EditRoutineView: UIView {
+    // MARK: - Properties
+    private let titleLabel = UILabel()
+    private let routineNameTF = UITextField()
+    private let nextButton = UIButton()
+
+    // MARK: - Init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Computed Property
+    var publicNextButton: UIButton { nextButton }
+}
+
+// MARK: - EditRoutineView UI 관련 extension
+private extension EditRoutineView {
+    func setupUI() {
+        backgroundColor = .background
+        setAppearance()
+        setViewHierarchy()
+        setConstraints()
+    }
+
+    func setAppearance() {
+        titleLabel.do {
+            $0.text = "루틴명을 입력해주세요"
+            $0.font = .systemFont(ofSize: 20, weight: .regular)
+            $0.textColor = .white
+        }
+
+        routineNameTF.do {
+            $0.backgroundColor = .bsInputFieldBG
+            $0.placeholder = "예) 상체 루틴, 2분할 (하체/어깨)"
+            $0.minimumFontSize = 16
+            $0.layer.cornerRadius = 12
+            $0.clipsToBounds = true
+            $0.textColor = .white
+
+            // textField 왼쪽 뷰 padding 설정
+            $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 20, height: 0))
+            $0.leftViewMode = .always
+
+            // 커서 자동 위치
+            $0.becomeFirstResponder()
+        }
+
+        nextButton.do {
+            $0.backgroundColor = .disabledButton
+            $0.setTitle("다음", for: .normal)
+            $0.titleLabel?.font = .systemFont(ofSize: 18, weight: .regular)
+            $0.setTitleColor(.dbTypo, for: .normal)
+            $0.layer.cornerRadius = 12
+            $0.clipsToBounds = true
+        }
+    }
+
+    func setViewHierarchy() {
+        [
+            titleLabel,
+            routineNameTF,
+            nextButton
+        ].forEach { addSubview($0) }
+    }
+
+    func setConstraints() {
+        titleLabel.snp.makeConstraints {
+            $0.top.horizontalEdges.equalToSuperview().inset(28)
+        }
+
+        routineNameTF.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(16)
+            $0.horizontalEdges.equalToSuperview().inset(28)
+            $0.height.equalTo(56)
+        }
+
+        nextButton.snp.makeConstraints {
+            $0.top.equalTo(routineNameTF.snp.bottom).offset(38)
+            $0.horizontalEdges.equalToSuperview().inset(20)
+            $0.height.equalTo(56)
+        }
+    }
+}

--- a/HowManySet/Presentation/Feature/RoutineList/Reactor/RoutineListViewReactor.swift
+++ b/HowManySet/Presentation/Feature/RoutineList/Reactor/RoutineListViewReactor.swift
@@ -7,7 +7,9 @@ final class RoutineListViewReactor: Reactor {
     private let deleteRoutineUseCase: DeleteRoutineUseCase
     private let fetchRoutineUseCase: FetchRoutineUseCase
     private let saveRoutineUseCase: SaveRoutineUseCase
-    
+
+    var publicSaveRoutineUseCase: SaveRoutineUseCase { saveRoutineUseCase }
+
     // MARK: - Action is an user interaction
     enum Action {
 

--- a/HowManySet/Presentation/Feature/RoutineList/Reactor/RoutineListViewReactor.swift
+++ b/HowManySet/Presentation/Feature/RoutineList/Reactor/RoutineListViewReactor.swift
@@ -10,17 +10,17 @@ final class RoutineListViewReactor: Reactor {
     
     // MARK: - Action is an user interaction
     enum Action {
-        case viewDidLoad
+
     }
     
     // MARK: - Mutate is a state manipulator which is not exposed to a view
     enum Mutation {
-        case setRoutines([WorkoutRoutine])
+
     }
     
     // MARK: - State is a current view state
     struct State {
-        var routines: [WorkoutRoutine] = []
+
     }
     
     let initialState: State
@@ -36,21 +36,11 @@ final class RoutineListViewReactor: Reactor {
     
     // MARK: - Action -> Mutation
     func mutate(action: Action) -> Observable<Mutation> {
-        switch action {
-        case .viewDidLoad:
-            return Observable.just(.setRoutines(WorkoutRoutine.mockData))
-        }
+
     }
 
     // MARK: - Mutation -> State
     func reduce(state: State, mutation: Mutation) -> State {
-        var newState = state
 
-        switch mutation {
-        case let .setRoutines(routines):
-            newState.routines = routines
-        }
-
-        return newState
     }
 }

--- a/HowManySet/Presentation/Feature/RoutineList/RoutineCell.swift
+++ b/HowManySet/Presentation/Feature/RoutineList/RoutineCell.swift
@@ -6,6 +6,7 @@ final class RoutineCell: UITableViewCell {
     static let identifier = "RoutineCell"
 
     // MARK: - UI Components
+    private let labelStackView = UIStackView()
     private let nameLabel = UILabel()
     private let totalWorkoutsLabel = UILabel()
     private let totalSetsLabel = UILabel()
@@ -50,6 +51,13 @@ private extension RoutineCell {
             $0.clipsToBounds = true
         }
 
+        labelStackView.do {
+            $0.axis = .vertical
+            $0.alignment = .fill
+            $0.distribution = .fillEqually
+            $0.spacing = 12
+        }
+
         nameLabel.do {
             $0.textColor = .white
             $0.font = .systemFont(ofSize: 20, weight: .semibold)
@@ -67,29 +75,25 @@ private extension RoutineCell {
     }
 
     func setViewHierarchy() {
+        contentView.addSubview(labelStackView)
+
         [
             nameLabel,
             totalWorkoutsLabel,
             totalSetsLabel
-        ].forEach { contentView.addSubview($0) }
+        ].forEach { labelStackView.addArrangedSubview($0) }
     }
 
     func setConstraints() {
-         nameLabel.snp.makeConstraints {
-             $0.top.equalToSuperview().inset(16)
-             $0.horizontalEdges.equalToSuperview().inset(20)
-         }
+        contentView.snp.makeConstraints {
+            $0.verticalEdges.equalToSuperview().inset(8)
+            $0.horizontalEdges.equalToSuperview()
+        }
 
-         totalWorkoutsLabel.snp.makeConstraints {
-             $0.top.equalTo(nameLabel.snp.bottom).offset(12)
-             $0.horizontalEdges.equalToSuperview().inset(20)
-         }
-
-         totalSetsLabel.snp.makeConstraints {
-             $0.top.equalTo(totalWorkoutsLabel.snp.bottom).offset(12)
-             $0.horizontalEdges.equalToSuperview().inset(20)
-             $0.bottom.equalToSuperview().inset(16)
-         }
+        labelStackView.snp.makeConstraints {
+            $0.verticalEdges.equalToSuperview().inset(16)
+            $0.horizontalEdges.equalToSuperview().inset(20)
+        }
     }
 
     ///UITableViewCell에서 clear하게 setting하여 깔끔하게 보여주는 UI

--- a/HowManySet/Presentation/Feature/RoutineList/RoutineListView.swift
+++ b/HowManySet/Presentation/Feature/RoutineList/RoutineListView.swift
@@ -3,11 +3,14 @@ import SnapKit
 import Then
 
 final class RoutineListView: UIView {
+    // MARK: - Properties
     private let titleLabel = UILabel()
     private let addNewRoutineButton = UIButton()
     private let routineTableView = UITableView()
-    private let stackView = UIStackView()
+    // FooterView 구성
+    private let footerView = UIView()
 
+    // MARK: - Init
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupUI()
@@ -29,6 +32,7 @@ private extension RoutineListView {
         setAppearance()
         setViewHierarchy()
         setConstraints()
+        setupFooterView()
     }
 
     func setAppearance() {
@@ -44,39 +48,57 @@ private extension RoutineListView {
         }
 
         addNewRoutineButton.do {
-            $0.backgroundColor = .disabledButton
+            $0.backgroundColor = .brand // 임의로 색상 변경함‼️
             $0.setTitle("새 루틴 구성", for: .normal)
             $0.titleLabel?.font = .systemFont(ofSize: 18, weight: .regular)
-            $0.tintColor = .white
+            $0.setTitleColor(.black, for: .normal) // 임의로 색상 변경함‼️
             $0.layer.cornerRadius = 12
             clipsToBounds = true
         }
 
-        stackView.do {
-            $0.axis = .vertical
-            $0.spacing = 20
-            $0.alignment = .fill
-            $0.distribution = .fill
+        footerView.do {
+            $0.backgroundColor = .clear
         }
     }
 
     func setViewHierarchy() {
-        addSubview(stackView)
+        footerView.addSubview(addNewRoutineButton)
 
-        [titleLabel, routineTableView, addNewRoutineButton].forEach {
-            stackView.addArrangedSubview($0)
-        }
+        [
+            titleLabel,
+            routineTableView
+        ].forEach { addSubview($0) }
     }
 
     func setConstraints() {
-        stackView.snp.makeConstraints {
+        titleLabel.snp.makeConstraints {
             $0.top.equalTo(safeAreaLayoutGuide)
             $0.horizontalEdges.equalTo(safeAreaLayoutGuide).inset(20)
-            $0.bottom.lessThanOrEqualTo(safeAreaLayoutGuide).inset(20)
+        }
+
+        routineTableView.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(12)
+            $0.horizontalEdges.equalTo(safeAreaLayoutGuide).inset(20)
+            $0.bottom.equalTo(safeAreaLayoutGuide)
         }
 
         addNewRoutineButton.snp.makeConstraints {
-            $0.height.equalTo(safeAreaLayoutGuide.snp.height).multipliedBy(0.07)
+            $0.top.equalToSuperview().offset(20)
+            $0.horizontalEdges.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(20)
+            $0.height.equalTo(56)
         }
+    }
+
+    // MARK: - FooterView Setting
+    /// FooterView를 setup하는 메서드
+    func setupFooterView() {
+        // FooterView 높이 고정
+        let targetSize = CGSize(width: UIScreen.main.bounds.width, height: 96)
+        let fittingSize = footerView.systemLayoutSizeFitting(targetSize)
+        footerView.frame.size = fittingSize
+
+        // 테이블 뷰에 적용
+        routineTableView.tableFooterView = footerView
     }
 }

--- a/HowManySet/Presentation/Feature/RoutineList/RoutineListViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineList/RoutineListViewController.swift
@@ -5,11 +5,21 @@ import ReactorKit
 import SnapKit
 
 final class RoutineListViewController: UIViewController, View {
+    // MARK: - Properties
     var disposeBag = DisposeBag()
 
     let routineListView = RoutineListView()
     private weak var coordinator: RoutineListCoordinatorProtocol?
 
+    // DiffableDataSource 정의
+    private var dataSource: UITableViewDiffableDataSource<Section, WorkoutRoutine>!
+
+    // Section 정의
+    enum Section {
+        case main
+    }
+
+    // MARK: - Init
     init(reactor: RoutineListViewReactor, coordinator: RoutineListCoordinatorProtocol) {
         super.init(nibName: nil, bundle: nil)
         self.reactor = reactor
@@ -20,6 +30,7 @@ final class RoutineListViewController: UIViewController, View {
         fatalError("init(coder:) has not been implemented")
     }
 
+    // MARK: - LifeCycle
     override func loadView() {
         view = routineListView
     }
@@ -28,8 +39,9 @@ final class RoutineListViewController: UIViewController, View {
         super.viewDidLoad()
         setDelegates()
         setRegisters()
-
-        reactor?.action.onNext(.viewDidLoad)
+        configureDataSource()
+        // MockData 표시
+        applySnapshot(with: WorkoutRoutine.mockData)
     }
 
     // MARK: - Bind
@@ -37,6 +49,7 @@ final class RoutineListViewController: UIViewController, View {
         // routines -> tableView 바인딩
         reactor.state
             .map(\.routines)
+            .distinctUntilChanged() // optional 같은 값 방지
             .bind(to: routineListView.publicRoutineTableView.rx.items(
                 cellIdentifier: RoutineCell.identifier,
                 cellType: RoutineCell.self
@@ -56,12 +69,45 @@ private extension RoutineListViewController {
     func setRegisters() {
         routineListView.publicRoutineTableView.register(RoutineCell.self, forCellReuseIdentifier: RoutineCell.identifier)
     }
+
+    func configureDataSource() {
+        dataSource = UITableViewDiffableDataSource<Section, WorkoutRoutine>(
+            tableView: routineListView.publicRoutineTableView
+        ) { tableView, indexPath, routine in
+            guard let cell = tableView.dequeueReusableCell(
+                withIdentifier: RoutineCell.identifier,
+                for: indexPath
+            ) as? RoutineCell else {
+                return UITableViewCell()
+            }
+
+            // 데이터를 cell에 주입
+            cell.configure(with: routine)
+            return cell
+        }
+    }
+}
+
+// MARK: - Snapshot
+extension RoutineListViewController {
+    /// 현재 보여줄 데이터 전체 상태를 전달하는 메서드
+    func applySnapshot(with routines: [WorkoutRoutine], animatingDifferences: Bool = true) {
+        var snapshot = NSDiffableDataSourceSnapshot<Section, WorkoutRoutine>()
+        // Section 추가
+        snapshot.appendSections([.main])
+        // Item 추가
+        snapshot.appendItems(routines, toSection: .main)
+        // 실제 적용
+        dataSource.apply(snapshot, animatingDifferences: animatingDifferences)
+    }
 }
 
 // MARK: - Calendar buttons addTarget
 extension RoutineListViewController: UITableViewDelegate {
     /// TableView Cell의 높이를 설정하는 메서드
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        UIScreen.main.bounds.height * 0.13
+        /* height를 기본값으로 지정하는 이유
+         => 다른 기기에서 셀 내부의 내용이 다 잘림. 어차피 스크롤이 되기 때문에 기본값으로 지정해줘도 괜찮다고 생각함. */
+        132
     }
 }

--- a/HowManySet/Presentation/Feature/RoutineList/RoutineListViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineList/RoutineListViewController.swift
@@ -105,4 +105,12 @@ extension RoutineListViewController: UITableViewDelegate {
          => 다른 기기에서 셀 내부의 내용이 다 잘림. 어차피 스크롤이 되기 때문에 기본값으로 지정해줘도 괜찮다고 생각함. */
         132
     }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        guard let routine = dataSource.itemIdentifier(for: indexPath) else { return }
+
+        coordinator?.pushEditRoutineView(with: routine)
+    }
 }

--- a/HowManySet/Presentation/Feature/RoutineList/RoutineListViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineList/RoutineListViewController.swift
@@ -49,7 +49,7 @@ final class RoutineListViewController: UIViewController, View {
         // "새 루틴 추가" 버튼이 눌렸을 때 화면이 전환되고 reactor에 바인딩
         routineListView.publicAddNewRoutineButton.rx.tap
             .bind(with: self) { owner, _ in
-                owner.coordinator?.presentEditRoutineView()
+                owner.coordinator?.presentRoutineNameView()
             }
             .disposed(by: disposeBag)
     }

--- a/HowManySet/Presentation/Feature/RoutineList/RoutineListViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineList/RoutineListViewController.swift
@@ -9,7 +9,7 @@ final class RoutineListViewController: UIViewController, View {
     var disposeBag = DisposeBag()
 
     let routineListView = RoutineListView()
-    private weak var coordinator: RoutineListCoordinatorProtocol?
+    private var coordinator: RoutineListCoordinatorProtocol?
 
     // DiffableDataSource 정의
     private var dataSource: UITableViewDiffableDataSource<Section, WorkoutRoutine>!
@@ -46,15 +46,10 @@ final class RoutineListViewController: UIViewController, View {
 
     // MARK: - Bind
     func bind(reactor: RoutineListViewReactor) {
-        // routines -> tableView 바인딩
-        reactor.state
-            .map(\.routines)
-            .distinctUntilChanged() // optional 같은 값 방지
-            .bind(to: routineListView.publicRoutineTableView.rx.items(
-                cellIdentifier: RoutineCell.identifier,
-                cellType: RoutineCell.self
-            )) { _, routine, cell in
-                cell.configure(with: routine)
+        // "새 루틴 추가" 버튼이 눌렸을 때 화면이 전환되고 reactor에 바인딩
+        routineListView.publicAddNewRoutineButton.rx.tap
+            .bind(with: self) { owner, _ in
+                owner.coordinator?.presentEditRoutineView()
             }
             .disposed(by: disposeBag)
     }

--- a/HowManySet/Presentation/Feature/RoutineName/Reactor/RoutineNameReactor.swift
+++ b/HowManySet/Presentation/Feature/RoutineName/Reactor/RoutineNameReactor.swift
@@ -4,34 +4,52 @@ import ReactorKit
 
 final class RoutineNameReactor: Reactor {
 
-    // Action is an user interaction
+    private let saveRoutineUseCase: SaveRoutineUseCase
+
+    // MARK: - Action is an user interaction
     enum Action {
-
+        case setRoutineName(String)
+        case saveRoutine
     }
 
-    // Mutate is a state manipulator which is not exposed to a view
+    // MARK: - Mutate is a state manipulator which is not exposed to a view
     enum Mutation {
-
+        case setRoutineName(String)
     }
 
-    // State is a current view state
+    // MARK: - State is a current view state
     struct State {
-
+        var routineName: String = ""
     }
 
     let initialState: State
 
-    init() {
+    // MARK: - Init
+    init(saveRoutineUseCase: SaveRoutineUseCase) {
+        self.saveRoutineUseCase = saveRoutineUseCase
         self.initialState = State()
     }
 
-    //    // Action -> Mutation
-    //    func mutate(action: Action) -> Observable<Mutation> {
-    //
-    //    }
-    //
-    //    // Mutation -> State
-    //    func reduce(state: State, mutation: Mutation) -> State {
-    //
-    //    }
+    // MARK: - Action -> Mutation
+    func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case let .setRoutineName(name):
+            return .just(.setRoutineName(name))
+        case .saveRoutine:
+            let routine = WorkoutRoutine(name: currentState.routineName, workouts: [])
+            saveRoutineUseCase.execute(uid: "test-user", item: routine)
+            print("루틴명 저장 성공: \(routine.name)")
+            return .empty()
+        }
+    }
+
+    // MARK: - Mutation -> State
+    func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        switch mutation {
+        case let .setRoutineName(name):
+            newState.routineName = name
+        }
+        return newState
+    }
 }

--- a/HowManySet/Presentation/Feature/RoutineName/Reactor/RoutineNameReactor.swift
+++ b/HowManySet/Presentation/Feature/RoutineName/Reactor/RoutineNameReactor.swift
@@ -1,0 +1,37 @@
+import Foundation
+import RxSwift
+import ReactorKit
+
+final class RoutineNameReactor: Reactor {
+
+    // Action is an user interaction
+    enum Action {
+
+    }
+
+    // Mutate is a state manipulator which is not exposed to a view
+    enum Mutation {
+
+    }
+
+    // State is a current view state
+    struct State {
+
+    }
+
+    let initialState: State
+
+    init() {
+        self.initialState = State()
+    }
+
+    //    // Action -> Mutation
+    //    func mutate(action: Action) -> Observable<Mutation> {
+    //
+    //    }
+    //
+    //    // Mutation -> State
+    //    func reduce(state: State, mutation: Mutation) -> State {
+    //
+    //    }
+}

--- a/HowManySet/Presentation/Feature/RoutineName/RoutineNameView.swift
+++ b/HowManySet/Presentation/Feature/RoutineName/RoutineNameView.swift
@@ -51,9 +51,6 @@ private extension RoutineNameView {
             $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 20, height: 0))
             $0.leftViewMode = .always
 
-            // 커서 자동 위치
-            $0.becomeFirstResponder()
-
             // 키보드 관련
             $0.autocorrectionType = .no // 자동 수정 끔
             $0.spellCheckingType = .no // 맞춤법 검사 끔

--- a/HowManySet/Presentation/Feature/RoutineName/RoutineNameView.swift
+++ b/HowManySet/Presentation/Feature/RoutineName/RoutineNameView.swift
@@ -52,6 +52,11 @@ private extension RoutineNameView {
 
             // 커서 자동 위치
             $0.becomeFirstResponder()
+
+            // 키보드 관련
+            $0.autocorrectionType = .no // 자동 수정 끔
+            $0.spellCheckingType = .no // 맞춤법 검사 끔
+            $0.smartInsertDeleteType = .no // 스마트 삽입/삭제 끔
         }
 
         nextButton.do {

--- a/HowManySet/Presentation/Feature/RoutineName/RoutineNameView.swift
+++ b/HowManySet/Presentation/Feature/RoutineName/RoutineNameView.swift
@@ -2,7 +2,7 @@ import UIKit
 import SnapKit
 import Then
 
-final class EditRoutineView: UIView {
+final class RoutineNameView: UIView {
     // MARK: - Properties
     private let titleLabel = UILabel()
     private let routineNameTF = UITextField()
@@ -13,7 +13,7 @@ final class EditRoutineView: UIView {
         super.init(frame: frame)
         setupUI()
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -23,7 +23,7 @@ final class EditRoutineView: UIView {
 }
 
 // MARK: - EditRoutineView UI 관련 extension
-private extension EditRoutineView {
+private extension RoutineNameView {
     func setupUI() {
         backgroundColor = .background
         setAppearance()
@@ -80,13 +80,13 @@ private extension EditRoutineView {
         routineNameTF.snp.makeConstraints {
             $0.top.equalTo(titleLabel.snp.bottom).offset(16)
             $0.horizontalEdges.equalToSuperview().inset(28)
-            $0.height.equalTo(56)
+            $0.height.equalToSuperview().multipliedBy(0.09)
         }
 
         nextButton.snp.makeConstraints {
             $0.top.equalTo(routineNameTF.snp.bottom).offset(38)
             $0.horizontalEdges.equalToSuperview().inset(20)
-            $0.height.equalTo(56)
+            $0.height.equalToSuperview().multipliedBy(0.09)
         }
     }
 }

--- a/HowManySet/Presentation/Feature/RoutineName/RoutineNameView.swift
+++ b/HowManySet/Presentation/Feature/RoutineName/RoutineNameView.swift
@@ -20,6 +20,7 @@ final class RoutineNameView: UIView {
 
     // MARK: - Computed Property
     var publicNextButton: UIButton { nextButton }
+    var publicRoutineNameTF: UITextField { routineNameTF }
 }
 
 // MARK: - EditRoutineView UI 관련 extension
@@ -60,10 +61,8 @@ private extension RoutineNameView {
         }
 
         nextButton.do {
-            $0.backgroundColor = .disabledButton
             $0.setTitle("다음", for: .normal)
             $0.titleLabel?.font = .systemFont(ofSize: 18, weight: .regular)
-            $0.setTitleColor(.dbTypo, for: .normal)
             $0.layer.cornerRadius = 12
             $0.clipsToBounds = true
         }

--- a/HowManySet/Presentation/Feature/RoutineName/RoutineNameViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineName/RoutineNameViewController.swift
@@ -29,6 +29,12 @@ final class RoutineNameViewController: UIViewController, View {
     override func viewDidLoad() {
         super.viewDidLoad()
     }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        // 커서 자동 위치
+        routineNameView.publicRoutineNameTF.becomeFirstResponder()
+    }
 }
 
 // MARK: - extension

--- a/HowManySet/Presentation/Feature/RoutineName/RoutineNameViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineName/RoutineNameViewController.swift
@@ -1,0 +1,30 @@
+import UIKit
+import SnapKit
+import RxSwift
+import RxCocoa
+import ReactorKit
+
+final class RoutineNameViewController: UIViewController {
+
+    let routineNameView = RoutineNameView()
+    private let reactor: RoutineNameReactor
+
+    init(reactor: RoutineNameReactor) {
+        self.reactor = reactor
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - LifeCycle
+    override func loadView() {
+        view = routineNameView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+}

--- a/HowManySet/Presentation/Feature/RoutineName/RoutineNameViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineName/RoutineNameViewController.swift
@@ -8,10 +8,12 @@ final class RoutineNameViewController: UIViewController {
 
     let routineNameView = RoutineNameView()
     private let reactor: RoutineNameReactor
+    private weak var coordinator: RoutineListCoordinatorProtocol?
     private let disposeBag = DisposeBag()
 
-    init(reactor: RoutineNameReactor) {
+    init(reactor: RoutineNameReactor, coordinator: RoutineListCoordinatorProtocol) {
         self.reactor = reactor
+        self.coordinator = coordinator
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -27,6 +29,7 @@ final class RoutineNameViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         bindTextField()
+        bindButtonTapped()
     }
 }
 
@@ -41,6 +44,16 @@ private extension RoutineNameViewController {
                 button.isEnabled = isEnabled
                 button.backgroundColor = isEnabled ? .brand : .disabledButton
                 button.setTitleColor(isEnabled ? .black : .dbTypo, for: .normal)
+            }
+            .disposed(by: disposeBag)
+    }
+
+    func bindButtonTapped() {
+        routineNameView.publicNextButton.rx.tap
+            .bind(with: self) { owner, _ in
+                owner.dismiss(animated: true) {
+                    owner.coordinator?.pushEditExcerciseView()
+                }
             }
             .disposed(by: disposeBag)
     }

--- a/HowManySet/Presentation/Feature/RoutineName/RoutineNameViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineName/RoutineNameViewController.swift
@@ -8,6 +8,7 @@ final class RoutineNameViewController: UIViewController {
 
     let routineNameView = RoutineNameView()
     private let reactor: RoutineNameReactor
+    private let disposeBag = DisposeBag()
 
     init(reactor: RoutineNameReactor) {
         self.reactor = reactor
@@ -25,6 +26,22 @@ final class RoutineNameViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        bindTextField()
     }
+}
 
+// MARK: - extension
+private extension RoutineNameViewController {
+    func bindTextField() {
+        routineNameView.publicRoutineNameTF.rx.text.orEmpty
+            .map { !$0.isEmpty }
+            .distinctUntilChanged()
+            .bind(with: self) { owner, isEnabled in
+                let button = owner.routineNameView.publicNextButton
+                button.isEnabled = isEnabled
+                button.backgroundColor = isEnabled ? .brand : .disabledButton
+                button.setTitleColor(isEnabled ? .black : .dbTypo, for: .normal)
+            }
+            .disposed(by: disposeBag)
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  closed: #50 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- RoutineList에서 버튼 클릭 시 -> RoutineName 모달로 present
- RoutineName에서 텍스트 필드에 값 있을 때만 버튼 활성화
- 다음 버튼 클릭 시 텍스트 필드에 있는 값 저장 및 EditExcercise로 push
- RoutineList에서 테이블 뷰 셀 클릭시 -> EditRoutine으로 present
- 이에 맞게 RoutineListCoordinator 수정 및 구현

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/3dfa1646-a963-4bcc-8942-47b3cf354c2f" width ="250"> |

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- reactorKit으로 루틴명 저장을 WoroutRoutine에 저장함 -> 추후 수정 예정
- RoutineList 페이지에서 새 루틴 생성 버튼 피그마와 다름 -> 너무 칙칙해보여서 버튼에 브랜드 컬러 임의로 넣음
- push로 화면 넘어갈 때(EditRouine, EditExcercise 둘 다) 살짝 버퍼링 있음 -> 추후 수정 예정
- 다른 기종들은 화면비율이 별 차이가 나지 않아서 괜찮은데, se 시리즈는 어떻게 해야할지 고민중
