### PR TITLE
운동 완료 페이지 구현

### DIFF
--- a/HowManySet.xcodeproj/project.pbxproj
+++ b/HowManySet.xcodeproj/project.pbxproj
@@ -123,6 +123,14 @@
 			);
 			target = 669358BA2DE9AA8C00956214 /* HowManySet */;
 		};
+		66329E0B2E014961003405F2 /* Exceptions for "HowManySetUITests" folder in "HowManySet" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				HowManySetUITests.swift,
+				HowManySetUITestsLaunchTests.swift,
+			);
+			target = 669358BA2DE9AA8C00956214 /* HowManySet */;
+		};
 		667A8E412DF27B2200BFDC86 /* Exceptions for "HowManySet" folder in "HowManySetWidgetExtension" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -142,23 +150,21 @@
 		669358E32DE9AA8E00956214 /* Exceptions for "HowManySet" folder in "HowManySet" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
-				HowManySetUITests/HowManySetUITests.swift,
-				HowManySetUITests/HowManySetUITestsLaunchTests.swift,
 				Resources/Info.plist,
 			);
 			target = 669358BA2DE9AA8C00956214 /* HowManySet */;
 		};
-		AA2538932DF012BE00463BC6 /* Exceptions for "HowManySet" folder in "HowManySetUITests" target */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				HowManySetUITests/HowManySetUITests.swift,
-				HowManySetUITests/HowManySetUITestsLaunchTests.swift,
-			);
-			target = 669358DA2DE9AA8E00956214 /* HowManySetUITests */;
-		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		66329E042E014905003405F2 /* HowManySetUITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				66329E0B2E014961003405F2 /* Exceptions for "HowManySetUITests" folder in "HowManySet" target */,
+			);
+			path = HowManySetUITests;
+			sourceTree = "<group>";
+		};
 		668CB1202DE9BE7000924340 /* HowManySetWidget */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
@@ -172,7 +178,6 @@
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
 				669358E32DE9AA8E00956214 /* Exceptions for "HowManySet" folder in "HowManySet" target */,
-				AA2538932DF012BE00463BC6 /* Exceptions for "HowManySet" folder in "HowManySetUITests" target */,
 				667A8E412DF27B2200BFDC86 /* Exceptions for "HowManySet" folder in "HowManySetWidgetExtension" target */,
 			);
 			path = HowManySet;
@@ -253,6 +258,7 @@
 				668CB11B2DE9BE7000924340 /* Frameworks */,
 				669358BC2DE9AA8C00956214 /* Products */,
 				AA25388A2DEFF9AA00463BC6 /* TestPlan.xctestplan */,
+				66329E042E014905003405F2 /* HowManySetUITests */,
 			);
 			sourceTree = "<group>";
 		};
@@ -310,6 +316,7 @@
 				668CB12F2DE9BE7300924340 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
+				66329E042E014905003405F2 /* HowManySetUITests */,
 				669358BD2DE9AA8C00956214 /* HowManySet */,
 			);
 			name = HowManySet;
@@ -372,6 +379,9 @@
 			);
 			dependencies = (
 				669358DD2DE9AA8E00956214 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				66329E042E014905003405F2 /* HowManySetUITests */,
 			);
 			name = HowManySetUITests;
 			packageProductDependencies = (

--- a/HowManySet/App/Coordinator/HomeCoordinator.swift
+++ b/HowManySet/App/Coordinator/HomeCoordinator.swift
@@ -96,15 +96,12 @@ final class HomeCoordinator: HomeCoordinatorProtocol {
                 /// 종료 버튼 누를 시에 해당 클로저(reactor.action) 즉시 실행
                 let workoutSummary = onConfirm()
                 
-                // 약간의 지연을 두고 데이터 업데이트 완료 후 화면 전환
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                    // HomeVC 초기화
-                    self.navigationController.popToRootViewController(animated: false)
-                    let newHomeVC = self.container.makeHomeViewController(coordinator: self)
-                    self.navigationController.setViewControllers([newHomeVC], animated: false)
-                    
-                    self.pushRoutineCompleteView(with: workoutSummary)
-                }
+                // HomeVC 초기화
+                self.navigationController.popToRootViewController(animated: false)
+                let newHomeVC = self.container.makeHomeViewController(coordinator: self)
+                self.navigationController.setViewControllers([newHomeVC], animated: false)
+                
+                self.pushRoutineCompleteView(with: workoutSummary)
             })
         
         navigationController.present(endWorkoutVC, animated: true)

--- a/HowManySet/App/Coordinator/HomeCoordinator.swift
+++ b/HowManySet/App/Coordinator/HomeCoordinator.swift
@@ -8,11 +8,11 @@
 import UIKit
 
 protocol HomeCoordinatorProtocol: Coordinator {
-    func presentEditAndMemoView()
-    func presentEditRoutineView()
-    func pushRoutineCompleteView()
-    func popUpEndWorkoutAlert() -> Bool
-    func popUpCompletedWorkoutAlert() -> Bool
+    func presentWorkoutOptionView()
+    func pushEditRoutineView()
+    func pushRoutineCompleteView(with workoutSummary: WorkoutSummary)
+    func popUpEndWorkoutAlert(with workoutSummary: WorkoutSummary) -> Bool
+    func popUpCompletedWorkoutAlert(with workoutSummary: WorkoutSummary) -> Bool
 }
 
 /// 홈 흐름 담당 coordinator
@@ -76,12 +76,12 @@ final class HomeCoordinator: HomeCoordinatorProtocol {
     }
 
     /// 운동 완료 화면으로 이동
-    func pushRoutineCompleteView() {
-        let routineCompleteCoordinator = RoutineCompleteCoordinator(navigationController: navigationController, container: container)
+    func pushRoutineCompleteView(with workoutSummary: WorkoutSummary) {
+        let routineCompleteCoordinator = RoutineCompleteCoordinator(navigationController: navigationController, container: container, workoutSummary: workoutSummary)
         routineCompleteCoordinator.start()
     }
     
-    func popUpEndWorkoutAlert() -> Bool {
+    func popUpEndWorkoutAlert(with workoutSummary: WorkoutSummary) -> Bool {
         
         var workoutEnded = false
         
@@ -101,7 +101,7 @@ final class HomeCoordinator: HomeCoordinatorProtocol {
                 
                 workoutEnded = true
                 
-                self.pushRoutineCompleteView()
+                self.pushRoutineCompleteView(with: workoutSummary)
                 
             })
         
@@ -111,7 +111,7 @@ final class HomeCoordinator: HomeCoordinatorProtocol {
     }
     
     
-    func popUpCompletedWorkoutAlert() -> Bool {
+    func popUpCompletedWorkoutAlert(with workoutSummary: WorkoutSummary) -> Bool {
         
         var workoutEnded = false
         
@@ -131,8 +131,7 @@ final class HomeCoordinator: HomeCoordinatorProtocol {
                 
                 workoutEnded = true
                 
-                self.pushRoutineCompleteView()
-                
+                self.pushRoutineCompleteView(with: workoutSummary)
             })
         
         navigationController.present(endWorkoutVC, animated: true)

--- a/HowManySet/App/Coordinator/RoutineCompleteCoordinator.swift
+++ b/HowManySet/App/Coordinator/RoutineCompleteCoordinator.swift
@@ -16,14 +16,20 @@ final class RoutineCompleteCoordinator: RoutineCompleteCoordinatorProtocol {
     
     private let navigationController: UINavigationController
     private let container: DIContainer
+    private let workoutSummary: WorkoutSummary
 
-    init(navigationController: UINavigationController, container: DIContainer) {
+    init(navigationController: UINavigationController, container: DIContainer, workoutSummary: WorkoutSummary) {
         self.navigationController = navigationController
         self.container = container
+        self.workoutSummary = workoutSummary
     }
     
     func start() {
         let routineCompleteVC = container.makeRoutineCompleteViewController(coordinator: self)
+        
+        if let routineCompleteVC = routineCompleteVC as? RoutineCompleteViewController {
+            routineCompleteVC.configure(with: workoutSummary)
+        }
         
         navigationController.pushViewController(routineCompleteVC, animated: false)
     }

--- a/HowManySet/App/Coordinator/RoutineCompleteCoordinator.swift
+++ b/HowManySet/App/Coordinator/RoutineCompleteCoordinator.swift
@@ -25,12 +25,8 @@ final class RoutineCompleteCoordinator: RoutineCompleteCoordinatorProtocol {
     }
     
     func start() {
-        let routineCompleteVC = container.makeRoutineCompleteViewController(coordinator: self)
-        
-        if let routineCompleteVC = routineCompleteVC as? RoutineCompleteViewController {
-            routineCompleteVC.configure(with: workoutSummary)
-        }
-        
+        let routineCompleteVC = container.makeRoutineCompleteViewController(coordinator: self, workoutSummary: workoutSummary)
+
         navigationController.pushViewController(routineCompleteVC, animated: false)
     }
     

--- a/HowManySet/App/DIContainer.swift
+++ b/HowManySet/App/DIContainer.swift
@@ -92,12 +92,12 @@ final class DIContainer {
     }
     
     /// 루틴 완료 화면을 생성하여 반환
-    func makeRoutineCompleteViewController(coordinator: RoutineCompleteCoordinator) -> UIViewController {
+    func makeRoutineCompleteViewController(coordinator: RoutineCompleteCoordinator, workoutSummary: WorkoutSummary) -> UIViewController {
         
         let realmService: RealmServiceProtocol = RealmService()
         let recordRepository = RecordRepositoryImpl(realmService: realmService)
         let saveRecordUseCase = SaveRecordUseCase(repository: recordRepository)
         
-        return RoutineCompleteViewController(coordinator: coordinator)
+        return RoutineCompleteViewController(coordinator: coordinator, workoutSummary: workoutSummary)
     }
 }

--- a/HowManySet/App/DIContainer.swift
+++ b/HowManySet/App/DIContainer.swift
@@ -97,9 +97,7 @@ final class DIContainer {
         let realmService: RealmServiceProtocol = RealmService()
         let recordRepository = RecordRepositoryImpl(realmService: realmService)
         let saveRecordUseCase = SaveRecordUseCase(repository: recordRepository)
-
-        let reactor = RoutineCompleteViewReactor(saveRecordUseCase: saveRecordUseCase)
         
-        return RoutineCompleteViewController(reactor: reactor, coordinator: coordinator)
+        return RoutineCompleteViewController(coordinator: coordinator)
     }
 }

--- a/HowManySet/Presentation/Common/ArchProgressView.swift
+++ b/HowManySet/Presentation/Common/ArchProgressView.swift
@@ -24,13 +24,13 @@ final class ArchProgressView: UIView {
         }
     }
     
-    var progressColor: UIColor = UIColor.systemGreen {
+    var progressColor: UIColor = UIColor.brand {
         didSet {
             progressLayer.strokeColor = progressColor.cgColor
         }
     }
     
-    var lineWidth: CGFloat = 12 {
+    var lineWidth: CGFloat = 22 {
         didSet {
             trackLayer.lineWidth = lineWidth
             progressLayer.lineWidth = lineWidth

--- a/HowManySet/Presentation/Common/ArchProgressView.swift
+++ b/HowManySet/Presentation/Common/ArchProgressView.swift
@@ -12,32 +12,121 @@ import Then
 final class ArchProgressView: UIView {
     
     // MARK: - Properties
+    var progress: CGFloat = 0.0 {
+        didSet {
+            progressLayer.strokeEnd = progress
+        }
+    }
     
-    // MARK: - UI Components
+    var trackColor: UIColor = UIColor.systemGray4 {
+        didSet {
+            trackLayer.strokeColor = trackColor.cgColor
+        }
+    }
     
+    var progressColor: UIColor = UIColor.systemGreen {
+        didSet {
+            progressLayer.strokeColor = progressColor.cgColor
+        }
+    }
+    
+    var lineWidth: CGFloat = 12 {
+        didSet {
+            trackLayer.lineWidth = lineWidth
+            progressLayer.lineWidth = lineWidth
+        }
+    }
+    
+    private let trackLayer = CAShapeLayer()
+    private let progressLayer = CAShapeLayer()
+        
     // MARK: - Initializer
     override init(frame: CGRect) {
         super.init(frame: frame)
+        setupUI()
+
     }
     
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: coder)
     }
     
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        setupLayers()
+    }
 }
 
 // MARK: - UI Methods
 private extension ArchProgressView {
     
     func setupUI() {
+        backgroundColor = .clear
         
+        setupLayers()
     }
     
-    func setViewHiearchy() {
+    func setupLayers() {
+        let center = CGPoint(x: bounds.width / 2, y: bounds.height / 2)
+        let radius = min(bounds.width, bounds.height * 2) / 2 - lineWidth / 2
+
+        // 시작 각도: 왼쪽 아래 (180도)
+        // 끝 각도: 오른쪽 아래 (360도)
+        // -> 라디언으로 변환
+        let startAngle = CGFloat(180 * Double.pi / 180)
+        let endAngle = CGFloat(360 * Double.pi / 180)
         
+        let arcPath = UIBezierPath(
+            arcCenter: center,
+            radius: radius,
+            startAngle: startAngle,
+            endAngle: endAngle,
+            clockwise: true
+        )
+        
+        // Track Layer (배경)
+        trackLayer.removeFromSuperlayer()
+        trackLayer.path = arcPath.cgPath
+        trackLayer.strokeColor = trackColor.cgColor
+        trackLayer.fillColor = UIColor.clear.cgColor
+        trackLayer.lineWidth = lineWidth
+        trackLayer.lineCap = .round
+        layer.addSublayer(trackLayer)
+        
+        // Progress Layer (진행 상태)
+        progressLayer.removeFromSuperlayer()
+        progressLayer.path = arcPath.cgPath
+        progressLayer.strokeColor = progressColor.cgColor
+        progressLayer.fillColor = UIColor.clear.cgColor
+        progressLayer.lineWidth = lineWidth
+        progressLayer.lineCap = .round
+        progressLayer.strokeEnd = progress
+        layer.addSublayer(progressLayer)
     }
+}
+
+// MARK: - Public Methods
+extension ArchProgressView {
     
-    func setConstraints() {
+    /// 애니메이션과 함께 프로그레스 설정
+    func setProgress(_ progress: CGFloat, animated: Bool = true, duration: TimeInterval = 1.0) {
+        let clampedProgress = max(0, min(1, progress))
         
+        if animated {
+            let animation = CABasicAnimation(keyPath: "strokeEnd")
+            animation.fromValue = self.progress
+            animation.toValue = clampedProgress
+            animation.duration = duration
+            animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            
+            progressLayer.add(animation, forKey: "progressAnimation")
+            
+            // 라벨 애니메이션
+            UIView.animate(withDuration: duration) { [weak self] in
+                self?.progress = clampedProgress
+            }
+        } else {
+            self.progress = clampedProgress
+        }
     }
 }

--- a/HowManySet/Presentation/Common/ArchProgressView.swift
+++ b/HowManySet/Presentation/Common/ArchProgressView.swift
@@ -1,0 +1,43 @@
+//
+//  ArchProgressView.swift
+//  HowManySet
+//
+//  Created by 정근호 on 6/16/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+final class ArchProgressView: UIView {
+    
+    // MARK: - Properties
+    
+    // MARK: - UI Components
+    
+    // MARK: - Initializer
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+// MARK: - UI Methods
+private extension ArchProgressView {
+    
+    func setupUI() {
+        
+    }
+    
+    func setViewHiearchy() {
+        
+    }
+    
+    func setConstraints() {
+        
+    }
+}

--- a/HowManySet/Presentation/Common/Extension/Date+Extension.swift
+++ b/HowManySet/Presentation/Common/Extension/Date+Extension.swift
@@ -19,4 +19,11 @@ extension Date {
         formatter.dateFormat = "MM.dd"
         return formatter.string(from: self)
     }
+    
+    /// Date에서 "yyyy.MM.dd" 형태의 String으로 반환하는 메서드
+    func toDateLabelWithYear() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy.MM.dd"
+        return formatter.string(from: self)
+    }
 }

--- a/HowManySet/Presentation/Common/Extension/UIView+Extension.swift
+++ b/HowManySet/Presentation/Common/Extension/UIView+Extension.swift
@@ -25,4 +25,12 @@ extension UIView {
         self.layer.shadowRadius = shadowRad
         self.layer.shadowOpacity = shadowOpacity
     }
+    
+    /// 스크린샷 캡쳐용
+    func asImage() -> UIImage? {
+        let renderer = UIGraphicsImageRenderer(bounds: bounds)
+        return renderer.image { rendererContext in
+            layer.render(in: rendererContext.cgContext)
+        }
+    }
 }

--- a/HowManySet/Presentation/Feature/Home/HomePagingCardView.swift
+++ b/HowManySet/Presentation/Feature/Home/HomePagingCardView.swift
@@ -250,7 +250,6 @@ extension HomePagingCardView {
         restPlayPauseButton.alpha = 0
         setCompleteButton.isUserInteractionEnabled = true
         setCompleteButton.alpha = 1
-        
     }
     
     func showRestUI() {
@@ -265,11 +264,6 @@ extension HomePagingCardView {
         setCompleteButton.alpha = 0
     }
     
-}
-
-// MARK: - Internal Methods
-extension HomePagingCardView {
-    
     func configure(with state: WorkoutCardState) {
                 
         exerciseNameLabel.text = state.currentExerciseName
@@ -282,6 +276,7 @@ extension HomePagingCardView {
             self.setProgressBar.setupSegments(totalSets: state.totalSetCount)
         }
     }
+    
 }
 
 

--- a/HowManySet/Presentation/Feature/Home/HomePagingCardView.swift
+++ b/HowManySet/Presentation/Feature/Home/HomePagingCardView.swift
@@ -271,7 +271,7 @@ extension HomePagingCardView {
 extension HomePagingCardView {
     
     func configure(with state: WorkoutCardState) {
-        
+                
         exerciseNameLabel.text = state.currentExerciseName
         exerciseSetLabel.text = "\(state.currentSetNumber) / \(state.totalSetCount)"
         weightLabel.text = "\(Int(state.currentWeight))\(state.currentUnit)"

--- a/HowManySet/Presentation/Feature/Home/HomeViewController.swift
+++ b/HowManySet/Presentation/Feature/Home/HomeViewController.swift
@@ -300,6 +300,60 @@ private extension HomeViewController {
         
     }
     
+    // MARK: - 현재 운동 카드 삭제 시 레이아웃 조정, 변경된 transform 초기화, 리바인딩
+    func setExerciseCardViewslayout(
+        cardContainer: [HomePagingCardView],
+        newPage: Int) {
+            
+        // hidden이 아닌 카드들만
+        let visibleCards = cardContainer.filter { !$0.isHidden }
+
+        for (i, cardView) in visibleCards.enumerated() {
+            cardView.snp.remakeConstraints {
+                $0.top.bottom.equalToSuperview()
+                $0.width.equalTo(cardWidth)
+                $0.leading.equalToSuperview()
+                    .offset(cardInset + CGFloat(i) * screenWidth)
+            }
+            UIView.performWithoutAnimation {
+                cardView.transform = .identity
+                cardView.alpha = 1
+            }
+        }
+
+        pagingScrollContentView.snp.remakeConstraints {
+            $0.height.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview()
+            
+            if visibleCards.last != visibleCards.first {
+                $0.width.equalToSuperview().multipliedBy(visibleCards.count)
+            } else {
+                $0.width.equalToSuperview()
+            }
+        }
+        
+        // 페이지 업데이트
+        print("변경 전 - previousPage: \(self.previousPage), currentPage: \(self.currentPage) ")
+
+        self.previousPage = newPage
+        self.currentPage = newPage
+        self.pageController.currentPage = newPage
+        self.pageController.numberOfPages = visibleCards.count
+
+        print("변경 후 - previousPage: \(self.previousPage), currentPage: \(self.currentPage) ")
+
+        // 현재 페이지 업데이트 후 offsetX 조정
+        let offsetX = CGFloat(newPage) * UIScreen.main.bounds.width
+        self.pagingScrollView.setContentOffset(CGPoint(x: offsetX, y: 0), animated: true)
+
+        // 카드 재정렬 후 버튼 바인딩 재설정 (약간의 지연 추가)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            guard let self = self, let reactor = self.reactor else { return }
+            print("🔄 레이아웃 재설정 후 버튼 바인딩 재실행")
+            self.bindSetCompleteButtons(reactor: reactor)
+        }
+    }
+    
     // MARK: - Animation
     /// 페이징 시 애니메이션 및 내부 콘텐츠 offset 수정
     func handlePageChanged(currentPage: Int = 0) {
@@ -537,10 +591,11 @@ extension HomeViewController {
         
         stopButton.rx.tap
             .map { Reactor.Action.stopButtonClicked }
-            .observe(on: MainScheduler.asyncInstance)
+            .observe(on: MainScheduler.instance)
             .bind(onNext: { [weak self] stop in
                 guard let self else { return }
-                let workoutEnded = self.coordinator?.popUpEndWorkoutAlert()
+                let workoutRecord = reactor.currentState.workoutRecord
+                let workoutEnded = self.coordinator?.popUpEndWorkoutAlert(with: reactor.currentState.workoutSummary)
                 reactor.action.onNext(stop(workoutEnded ?? false))
             })
             .disposed(by: disposeBag)
@@ -792,7 +847,7 @@ extension HomeViewController {
                     let visibleCards = self.pagingCardViewContainer.filter { !$0.isHidden }
                     if visibleCards.isEmpty {
                         print("🎉 모든 운동 완료!")
-                        let workoutEnded = self.coordinator?.popUpCompletedWorkoutAlert()
+                        let workoutEnded = self.coordinator?.popUpCompletedWorkoutAlert(with: reactor.currentState.workoutSummary)
                         reactor.action.onNext(.stopButtonClicked(with: workoutEnded ?? false))
                         return
                     }

--- a/HowManySet/Presentation/Feature/Home/HomeViewController.swift
+++ b/HowManySet/Presentation/Feature/Home/HomeViewController.swift
@@ -594,7 +594,6 @@ extension HomeViewController {
             .observe(on: MainScheduler.instance)
             .bind(onNext: { [weak self] stop in
                 guard let self else { return }
-                let workoutRecord = reactor.currentState.workoutRecord
                 let workoutEnded = self.coordinator?.popUpEndWorkoutAlert(with: reactor.currentState.workoutSummary)
                 reactor.action.onNext(stop(workoutEnded ?? false))
             })

--- a/HowManySet/Presentation/Feature/Home/Reactor/HomeViewReactor.swift
+++ b/HowManySet/Presentation/Feature/Home/Reactor/HomeViewReactor.swift
@@ -314,6 +314,7 @@ final class HomeViewReactor: Reactor {
     
     
     // MARK: - Mutation -> State (Reduce)
+    /// state를 바꿀 수 있는 유일한 곳
     func reduce(state: State, mutation: Mutation) -> State {
         
         var state = state

--- a/HowManySet/Presentation/Feature/Home/Reactor/HomeViewReactor.swift
+++ b/HowManySet/Presentation/Feature/Home/Reactor/HomeViewReactor.swift
@@ -80,6 +80,7 @@ final class HomeViewReactor: Reactor {
         case restRemainingSecondsUpdating
         case pauseAndPlayWorkout(Bool)
         case pauseAndPlayRest(Bool)
+        /// 운동 종료
         case endCurrentWorkout(with: Bool)
         /// 스킵(다음) 버튼 클릭 시 다음 세트로
         case moveToNextSetOrExercise(isRoutineCompleted: Bool)
@@ -157,6 +158,14 @@ final class HomeViewReactor: Reactor {
                 allSetsCompleted: false
             ))
         }
+        
+        let initialWorkoutRecord = WorkoutRecord(
+            workoutRoutine: initialRoutine,
+            totalTime: 0,
+            workoutTime: 0,
+            comment: nil,
+            date: Date()
+        )
         
         self.initialState = State(
             workoutRoutine: initialRoutine,
@@ -373,6 +382,13 @@ final class HomeViewReactor: Reactor {
         case let .endCurrentWorkout(isEnded):
             if isEnded {
                 state.isWorkingout = false
+                
+                state.workoutRecord = WorkoutRecord(
+                    workoutRoutine: currentState.workoutRoutine,
+                    totalTime: currentState.workoutTime,
+                    workoutTime: currentState.workoutTime,
+                    comment: currentState.memoInRoutine,
+                    date: Date())
             }
             
         case let .setTrueCurrentCardViewCompleted(cardIndex):

--- a/HowManySet/Presentation/Feature/RoutineComplete/RoutineCompleteViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineComplete/RoutineCompleteViewController.swift
@@ -15,6 +15,9 @@ final class RoutineCompleteViewController: UIViewController {
     // MARK: - Properties
     private weak var coordinator: RoutineCompleteCoordinatorProtocol?
     
+    // UI에 보여질 운동 통계 요약 데이터
+    var workoutSummary: WorkoutSummary?
+    
     var disposeBag = DisposeBag()
     
     private let exerciseCompletedText = "운동 완료! 수고했어요"
@@ -127,9 +130,10 @@ final class RoutineCompleteViewController: UIViewController {
     }
     
     // MARK: - Initializer
-    init(coordinator: RoutineCompleteCoordinatorProtocol) {
+    init(coordinator: RoutineCompleteCoordinatorProtocol, workoutSummary: WorkoutSummary) {
         super.init(nibName: nil, bundle: nil)
         self.coordinator = coordinator
+        self.workoutSummary = workoutSummary
         
         self.hidesBottomBarWhenPushed = true
         self.navigationItem.hidesBackButton = true
@@ -147,6 +151,12 @@ final class RoutineCompleteViewController: UIViewController {
         memoTextView.delegate = self
 
         setupUI()
+        
+        if let workoutSummary {
+            print("configure 호출")
+            print("🎬 [WorkoutSummary]: \(workoutSummary)")
+            configure(with: workoutSummary)
+        }
     }
 }
 

--- a/HowManySet/Presentation/Feature/RoutineComplete/RoutineCompleteViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineComplete/RoutineCompleteViewController.swift
@@ -18,8 +18,117 @@ final class RoutineCompleteViewController: UIViewController, View {
     
     var disposeBag = DisposeBag()
     
-    // MARK: - UI Components
+    private let exerciseCompletedText = "운동 완료! 수고했어요"
+    private let exerciseRecordSavedText = "운동 기록 저장됨"
+    private let memoPlaceHolderText = "메모를 입력해 주세요."
+    private let confirmText = "확인"
     
+    // MARK: - UI Components
+    private lazy var topLabelVStack = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = 14
+    }
+    
+    private lazy var exerciseCompletedLabel = UILabel().then {
+        $0.text = exerciseCompletedText
+        $0.font = .systemFont(ofSize: 24, weight: .medium)
+        $0.textColor = .white
+        $0.textAlignment = .center
+    }
+    
+    private lazy var exerciseInfoLabel = UILabel().then {
+        $0.text = "루틴명 | 2025.06.06 운동 기록 저장됨"
+        $0.font = .systemFont(ofSize: 12, weight: .regular)
+        $0.textColor = .lightGray
+        $0.textAlignment = .center
+    }
+    
+    private lazy var cardContentsContainer = UIView().then {
+        $0.backgroundColor = .cardBackground
+        $0.layer.cornerRadius = 20
+    }
+    
+    private lazy var progressView = UIImageView(image: UIImage(systemName: "rainbow")).then {
+        $0.tintColor = .brand
+        $0.contentMode = .scaleAspectFit
+    }
+    
+    private lazy var percentageLabel = UILabel().then {
+        $0.text = "80%"
+        $0.font = .systemFont(ofSize: 36, weight: .semibold)
+        $0.textColor = .white
+        $0.textAlignment = .center
+    }
+    
+    private lazy var exerciseTimeLabel = UILabel().then {
+        $0.text = "40:38"
+        $0.font = .systemFont(ofSize: 20, weight: .regular)
+        $0.textColor = .white
+        $0.textAlignment = .center
+    }
+    
+    private lazy var exerciseAndSetInfoLabel = UILabel().then {
+        $0.text = "5개 운동, 25세트"
+        $0.font = .systemFont(ofSize: 20, weight: .regular)
+        $0.textColor = .white
+        $0.textAlignment = .center
+    }
+    
+    private lazy var timeIcon = UIImageView().then {
+        $0.image = UIImage(systemName: "clock")
+        $0.tintColor = .white
+        $0.contentMode = .scaleAspectFit
+    }
+    
+    private lazy var exerciseIcon = UIImageView().then {
+        $0.image = UIImage(systemName: "dumbbell")
+        $0.tintColor = .white
+        $0.contentMode = .scaleAspectFit
+    }
+    
+    private lazy var timeInfoHStack = UIStackView().then {
+        $0.axis = .horizontal
+        $0.spacing = 16
+        $0.alignment = .leading
+    }
+    
+    private lazy var exerciseInfoHStack = UIStackView().then {
+        $0.axis = .horizontal
+        $0.spacing = 16
+        $0.alignment = .leading
+    }
+    
+    private lazy var routineStatisticsVStack = UIStackView().then {
+        $0.axis = .vertical
+        $0.distribution = .equalSpacing
+        $0.backgroundColor = .tabBarBG
+        $0.layer.cornerRadius = 20
+    }
+    
+    private lazy var shareButton = UIButton().then {
+        $0.setPreferredSymbolConfiguration(UIImage.SymbolConfiguration(pointSize: 24), forImageIn: .normal)
+        $0.setImage(UIImage(systemName: "square.and.arrow.up"), for: .normal)
+        $0.tintColor = .white
+        $0.backgroundColor = .disabledButton
+        $0.layer.cornerRadius = 22
+    }
+    
+    private lazy var memoTextView = UITextView().then {
+        $0.backgroundColor = .black
+        $0.textColor = .placeholderText
+        $0.font = .systemFont(ofSize: 16, weight: .regular)
+        $0.layer.cornerRadius = 12
+        $0.text = memoPlaceHolderText
+        $0.textContainerInset = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+    }
+    
+    private lazy var confirmButton = UIButton().then {
+        $0.setTitle(confirmText, for: .normal)
+        $0.setTitleColor(.background, for: .normal)
+        $0.backgroundColor = .brand
+        $0.titleLabel?.font = .systemFont(ofSize: 18, weight: .medium)
+        $0.layer.cornerRadius = 12
+    }
     
     // MARK: - Initializer
     init(reactor: RoutineCompleteViewReactor, coordinator: RoutineCompleteCoordinatorProtocol) {
@@ -28,40 +137,125 @@ final class RoutineCompleteViewController: UIViewController, View {
         self.coordinator = coordinator
         
         self.hidesBottomBarWhenPushed = true
-//        self.navigationItem.hidesBackButton = true
+        self.navigationItem.hidesBackButton = true
     }
     
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
     // MARK: - LifeCycle
     override func viewDidLoad() {
-       
         super.viewDidLoad()
+        
+        memoTextView.delegate = self
+
+        setupUI()
     }
-    
 }
 
 // MARK: - UI Methods
 private extension RoutineCompleteViewController {
     
     func setupUI() {
+        view.backgroundColor = .background
         
+        setViewHiearchy()
+        setConstraints()
     }
     
     func setViewHiearchy() {
         
+        view.addSubviews(
+            topLabelVStack,
+            cardContentsContainer,
+            percentageLabel,
+            memoTextView,
+            confirmButton
+        )
+        
+        topLabelVStack.addArrangedSubviews(exerciseCompletedLabel, exerciseInfoLabel)
+        cardContentsContainer.addSubviews(progressView, routineStatisticsVStack, shareButton)
     }
     
     func setConstraints() {
         
+        topLabelVStack.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide).inset(52)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(20)
+        }
+        
+        cardContentsContainer.snp.makeConstraints {
+            $0.top.equalTo(topLabelVStack.snp.bottom).offset(14)
+            $0.height.equalToSuperview().multipliedBy(0.43)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(20)
+        }
+        
+        shareButton.snp.makeConstraints {
+            $0.top.trailing.equalToSuperview().inset(28)
+            $0.width.height.equalTo(44)
+        }
+        
+        progressView.snp.makeConstraints {
+            $0.centerX.equalTo(cardContentsContainer)
+            $0.top.equalToSuperview().inset(72)
+            $0.width.height.equalTo(100)
+        }
+                
+        percentageLabel.snp.makeConstraints {
+            $0.center.equalTo(cardContentsContainer)
+        }
+        
+        routineStatisticsVStack.snp.makeConstraints {
+            $0.height.equalTo(cardContentsContainer.snp.height).multipliedBy(0.31)
+            $0.horizontalEdges.equalTo(cardContentsContainer.snp.horizontalEdges).inset(28)
+            $0.bottom.equalTo(cardContentsContainer.snp.bottom).inset(28)
+        }
+        
+        timeIcon.snp.makeConstraints {
+            $0.width.height.equalTo(20)
+        }
+        
+        exerciseIcon.snp.makeConstraints {
+            $0.width.height.equalTo(20)
+        }
+        
+        memoTextView.snp.makeConstraints {
+            $0.top.equalTo(cardContentsContainer.snp.bottom).offset(16)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(20)
+            $0.height.equalTo(cardContentsContainer.snp.height).multipliedBy(0.39)
+        }
+        
+        confirmButton.snp.makeConstraints {
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(16)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(20)
+            $0.height.equalTo(56)
+        }
+    }
+}
+
+// MARK: - UITextViewDelegate
+extension RoutineCompleteViewController: UITextViewDelegate {
+    
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if textView.text == memoPlaceHolderText {
+            textView.text = ""
+            textView.textColor = .white
+        }
+    }
+    
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if textView.text.isEmpty {
+            textView.text = memoPlaceHolderText
+            textView.textColor = .placeholderText
+        }
     }
 }
 
 // MARK: - Reactor Binding
 extension RoutineCompleteViewController {
-    
+ 
     func bind(reactor: RoutineCompleteViewReactor) {
         
     }

--- a/HowManySet/Presentation/Feature/RoutineComplete/RoutineCompleteViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineComplete/RoutineCompleteViewController.swift
@@ -9,9 +9,8 @@ import UIKit
 import SnapKit
 import Then
 import RxSwift
-import ReactorKit
 
-final class RoutineCompleteViewController: UIViewController, View {
+final class RoutineCompleteViewController: UIViewController {
     
     // MARK: - Properties
     private weak var coordinator: RoutineCompleteCoordinatorProtocol?
@@ -132,9 +131,8 @@ final class RoutineCompleteViewController: UIViewController, View {
     }
     
     // MARK: - Initializer
-    init(reactor: RoutineCompleteViewReactor, coordinator: RoutineCompleteCoordinatorProtocol) {
+    init(coordinator: RoutineCompleteCoordinatorProtocol) {
         super.init(nibName: nil, bundle: nil)
-        self.reactor = reactor
         self.coordinator = coordinator
         
         self.hidesBottomBarWhenPushed = true
@@ -266,10 +264,17 @@ extension RoutineCompleteViewController: UITextViewDelegate {
     }
 }
 
-// MARK: - Reactor Binding
+// MARK: - Internal Methods
 extension RoutineCompleteViewController {
  
-    func bind(reactor: RoutineCompleteViewReactor) {
+    func configure(with workoutSummary: WorkoutSummary) {
+        let routineName = workoutSummary.routineName
+        let todayDate = workoutSummary.date
+        let totalTime = workoutSummary.totalTime
+        let exerciseDidCount = workoutSummary.exerciseDidCount
+        let setDidCount = workoutSummary.setDidCount
+        let routineMemo = workoutSummary.routineMemo
+        
         
     }
 }

--- a/HowManySet/Presentation/Feature/RoutineComplete/RoutineCompleteViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineComplete/RoutineCompleteViewController.swift
@@ -363,12 +363,18 @@ private extension RoutineCompleteViewController {
         // 공유할 텍스트 생성
         let shareText = createShareText(from: workoutSummary)
         // 공유할 아이템들
-        let activityItems: [Any] = [shareText]
+        var activityItems: [Any] = [shareText]
         
         let activityViewController = UIActivityViewController(
             activityItems: activityItems,
             applicationActivities: nil
         )
+        
+        // 공유 버튼 누를 시 자동으로 운동 카드 부분 캡쳐
+        // 실기기 테스트 필요
+        if let screenshot = captureWorkoutSummaryScreenshot() {
+            activityItems.append(screenshot)
+        }
         
         // 제외할 정보들
         activityViewController.excludedActivityTypes = [
@@ -402,5 +408,10 @@ private extension RoutineCompleteViewController {
         """
         
         return shareText
+    }
+    
+    func captureWorkoutSummaryScreenshot() -> UIImage? {
+        // 운동 요약 카드 부분만 캡처
+        return cardContentsContainer.asImage()
     }
 }

--- a/HowManySet/Presentation/Feature/RoutineComplete/RoutineCompleteViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineComplete/RoutineCompleteViewController.swift
@@ -312,6 +312,13 @@ private extension RoutineCompleteViewController {
                 self.navigationController?.popToRootViewController(animated: true)
             }
             .disposed(by: disposeBag)
+        
+        shareButton.rx.tap
+            .bind { [weak self] _ in
+                guard let self else { return }
+                self.presentShareActivity()
+            }
+            .disposed(by: disposeBag)
     }
 }
 
@@ -343,5 +350,57 @@ private extension RoutineCompleteViewController {
                 }
             })
             .disposed(by: disposeBag)
+    }
+}
+
+// MARK: - Share Methods
+private extension RoutineCompleteViewController {
+    
+    func presentShareActivity() {
+        
+        guard let workoutSummary else { return }
+        
+        // 공유할 텍스트 생성
+        let shareText = createShareText(from: workoutSummary)
+        // 공유할 아이템들
+        let activityItems: [Any] = [shareText]
+        
+        let activityViewController = UIActivityViewController(
+            activityItems: activityItems,
+            applicationActivities: nil
+        )
+        
+        // 제외할 정보들
+        activityViewController.excludedActivityTypes = [
+            .addToReadingList,
+            .assignToContact
+        ]
+        
+        present(activityViewController, animated: true)
+    }
+    
+    
+    func createShareText(from summary: WorkoutSummary) -> String {
+        
+        let routineName = summary.routineName
+        let date = summary.date.toDateLabelWithYear()
+        let totalTime = summary.totalTime.toWorkOutTimeLabel()
+        let progress = Int(summary.routineDidProgress * 100)
+        let exerciseCount = summary.exerciseDidCount
+        let setCount = summary.setDidCount
+        
+        let shareText = """
+        운동 완료!
+        
+        📋 루틴: \(routineName)
+        📅 날짜: \(date)
+        ⏱️ 운동시간: \(totalTime)
+        📊 진행률: \(progress)%
+        💪 \(exerciseCount)개 운동, \(setCount)세트
+        
+        #운동 #헬스 #HowManySet
+        """
+        
+        return shareText
     }
 }

--- a/HowManySet/Presentation/Feature/RoutineComplete/RoutineCompleteViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineComplete/RoutineCompleteViewController.swift
@@ -48,8 +48,11 @@ final class RoutineCompleteViewController: UIViewController, View {
         $0.layer.cornerRadius = 20
     }
     
-    private lazy var progressView = UIImageView(image: UIImage(systemName: "rainbow")).then {
-        $0.tintColor = .brand
+    private lazy var progressView = ArchProgressView().then {
+        $0.progress = 0.8
+        $0.trackColor = .textTertiary
+        $0.progressColor = .brand
+        $0.lineWidth = 22
         $0.contentMode = .scaleAspectFit
     }
     
@@ -98,18 +101,16 @@ final class RoutineCompleteViewController: UIViewController, View {
         $0.alignment = .leading
     }
     
-    private lazy var routineStatisticsVStack = UIStackView().then {
-        $0.axis = .vertical
-        $0.distribution = .equalSpacing
+    private lazy var routineStatisticsContainer = UIView().then {
         $0.backgroundColor = .tabBarBG
         $0.layer.cornerRadius = 20
     }
     
     private lazy var shareButton = UIButton().then {
-        $0.setPreferredSymbolConfiguration(UIImage.SymbolConfiguration(pointSize: 24), forImageIn: .normal)
+        $0.setPreferredSymbolConfiguration(UIImage.SymbolConfiguration(pointSize: 20), forImageIn: .normal)
         $0.setImage(UIImage(systemName: "square.and.arrow.up"), for: .normal)
         $0.tintColor = .white
-        $0.backgroundColor = .disabledButton
+        $0.backgroundColor = .systemGray2
         $0.layer.cornerRadius = 22
     }
     
@@ -176,13 +177,16 @@ private extension RoutineCompleteViewController {
         )
         
         topLabelVStack.addArrangedSubviews(exerciseCompletedLabel, exerciseInfoLabel)
-        cardContentsContainer.addSubviews(progressView, routineStatisticsVStack, shareButton)
+        cardContentsContainer.addSubviews(progressView, routineStatisticsContainer, shareButton)
+        routineStatisticsContainer.addSubviews(timeInfoHStack, exerciseInfoHStack)
+        timeInfoHStack.addArrangedSubviews(timeIcon, exerciseTimeLabel)
+        exerciseInfoHStack.addArrangedSubviews(exerciseIcon, exerciseAndSetInfoLabel)
     }
     
     func setConstraints() {
         
         topLabelVStack.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide).inset(52)
+            $0.top.equalTo(view.safeAreaLayoutGuide).inset(16)
             $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(20)
         }
         
@@ -198,18 +202,27 @@ private extension RoutineCompleteViewController {
         }
         
         progressView.snp.makeConstraints {
-            $0.centerX.equalTo(cardContentsContainer)
+            $0.centerX.equalToSuperview()
             $0.top.equalToSuperview().inset(72)
-            $0.width.height.equalTo(100)
+            $0.width.height.equalTo(cardContentsContainer.snp.width).multipliedBy(0.63)
         }
                 
         percentageLabel.snp.makeConstraints {
-            $0.center.equalTo(cardContentsContainer)
+            $0.centerX.equalTo(progressView)
+            $0.centerY.equalTo(progressView).offset(-10)
         }
         
-        routineStatisticsVStack.snp.makeConstraints {
+        timeInfoHStack.snp.makeConstraints {
+            $0.top.leading.equalToSuperview().inset(24)
+        }
+        
+        exerciseInfoHStack.snp.makeConstraints {
+            $0.bottom.leading.equalToSuperview().inset(24)
+        }
+        
+        routineStatisticsContainer.snp.makeConstraints {
             $0.height.equalTo(cardContentsContainer.snp.height).multipliedBy(0.31)
-            $0.horizontalEdges.equalTo(cardContentsContainer.snp.horizontalEdges).inset(28)
+            $0.horizontalEdges.equalTo(cardContentsContainer).inset(28)
             $0.bottom.equalTo(cardContentsContainer.snp.bottom).inset(28)
         }
         

--- a/HowManySet/Presentation/Feature/RoutineComplete/RoutineCompleteViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineComplete/RoutineCompleteViewController.swift
@@ -149,6 +149,7 @@ final class RoutineCompleteViewController: UIViewController {
         memoTextView.delegate = self
 
         setupUI()
+        bindUIEvents()
         
         if let workoutSummary {
             print("configure 호출")
@@ -286,5 +287,20 @@ private extension RoutineCompleteViewController {
         exerciseTimeLabel.text = totalTime
         exerciseAndSetInfoLabel.text = "\(exerciseDidCount)개 운동, \(setDidCount)세트"
         memoTextView.text = routineMemo
+    }
+}
+
+// MARK: - Rx Binding
+private extension RoutineCompleteViewController {
+    
+    func bindUIEvents() {
+        
+        confirmButton.rx.tap
+            .bind { [weak self] _ in
+                guard let self else { return }
+                
+                self.navigationController?.popToRootViewController(animated: true)
+            }
+            .disposed(by: disposeBag)
     }
 }

--- a/HowManySet/Presentation/Feature/RoutineComplete/RoutineCompleteViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineComplete/RoutineCompleteViewController.swift
@@ -114,10 +114,8 @@ final class RoutineCompleteViewController: UIViewController {
     
     private lazy var memoTextView = UITextView().then {
         $0.backgroundColor = .black
-        $0.textColor = .placeholderText
         $0.font = .systemFont(ofSize: 16, weight: .regular)
         $0.layer.cornerRadius = 12
-        $0.text = memoPlaceHolderText
         $0.textContainerInset = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
     }
     
@@ -270,8 +268,8 @@ extension RoutineCompleteViewController: UITextViewDelegate {
     }
 }
 
-// MARK: - Internal Methods
-extension RoutineCompleteViewController {
+// MARK: - Private Methods
+private extension RoutineCompleteViewController {
  
     func configure(with workoutSummary: WorkoutSummary) {
         let routineName = workoutSummary.routineName
@@ -284,7 +282,7 @@ extension RoutineCompleteViewController {
         
         exerciseInfoLabel.text = "\(routineName) | \(todayDate) \(exerciseRecordSavedText)"
         progressView.progress = CGFloat(routineDidProgress)
-        percentageLabel.text = "\(Int(routineDidProgress))%"
+        percentageLabel.text = "\(Int(routineDidProgress * 100))%"
         exerciseTimeLabel.text = totalTime
         exerciseAndSetInfoLabel.text = "\(exerciseDidCount)개 운동, \(setDidCount)세트"
         memoTextView.text = routineMemo

--- a/HowManySet/Presentation/Feature/RoutineComplete/RoutineCompleteViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineComplete/RoutineCompleteViewController.swift
@@ -36,7 +36,6 @@ final class RoutineCompleteViewController: UIViewController {
     }
     
     private lazy var exerciseInfoLabel = UILabel().then {
-        $0.text = "루틴명 | 2025.06.06 운동 기록 저장됨"
         $0.font = .systemFont(ofSize: 12, weight: .regular)
         $0.textColor = .lightGray
         $0.textAlignment = .center
@@ -48,7 +47,7 @@ final class RoutineCompleteViewController: UIViewController {
     }
     
     private lazy var progressView = ArchProgressView().then {
-        $0.progress = 0.8
+        $0.progress = 0
         $0.trackColor = .textTertiary
         $0.progressColor = .brand
         $0.lineWidth = 22
@@ -56,21 +55,18 @@ final class RoutineCompleteViewController: UIViewController {
     }
     
     private lazy var percentageLabel = UILabel().then {
-        $0.text = "80%"
         $0.font = .systemFont(ofSize: 36, weight: .semibold)
         $0.textColor = .white
         $0.textAlignment = .center
     }
     
     private lazy var exerciseTimeLabel = UILabel().then {
-        $0.text = "40:38"
         $0.font = .systemFont(ofSize: 20, weight: .regular)
         $0.textColor = .white
         $0.textAlignment = .center
     }
     
     private lazy var exerciseAndSetInfoLabel = UILabel().then {
-        $0.text = "5개 운동, 25세트"
         $0.font = .systemFont(ofSize: 20, weight: .regular)
         $0.textColor = .white
         $0.textAlignment = .center
@@ -269,12 +265,18 @@ extension RoutineCompleteViewController {
  
     func configure(with workoutSummary: WorkoutSummary) {
         let routineName = workoutSummary.routineName
-        let todayDate = workoutSummary.date
-        let totalTime = workoutSummary.totalTime
+        let todayDate = workoutSummary.date.toDateLabelWithYear()
+        let totalTime = workoutSummary.totalTime.toWorkOutTimeLabel()
+        let routineDidProgress = workoutSummary.routineDidProgress
         let exerciseDidCount = workoutSummary.exerciseDidCount
         let setDidCount = workoutSummary.setDidCount
         let routineMemo = workoutSummary.routineMemo
         
-        
+        exerciseInfoLabel.text = "\(routineName) | \(todayDate) \(exerciseRecordSavedText)"
+        progressView.progress = CGFloat(routineDidProgress)
+        percentageLabel.text = "\(Int(routineDidProgress))%"
+        exerciseTimeLabel.text = totalTime
+        exerciseAndSetInfoLabel.text = "\(exerciseDidCount)개 운동, \(setDidCount)세트"
+        memoTextView.text = routineMemo
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  - closed: #30 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- 운동 완료 화면 구현
- 현재 임시로 WorkoutSummary로 완료 시 데이터 전달
- 데이터 전달 과정에서 Coordinator 변경 사항 있음
- 공유 버튼 누를 시 공유 기능
- 공유할 때 화면의 카드 부분만 캡쳐 (테스트 필요)
- 로직 구현 과정에서 기존 로직 오류 일부분 해결


## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/b9659ca5-6a83-4f41-866f-fbdf6b17d386" width ="250"> |

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 기존 로직 오류 어느정도 해결
- 현재 세트 완료 버튼 클릭 시 해당 버튼을 계속 클릭하면 휴식시간이 증가되어 보여지는 휴식시간이 종료되어도 세트 프로그레스바가 증가가 안되는 오류가 있음. 
이는 기존에 만들어둔 Fix 브랜치에서 해결 예정.
