### PR TITLE
Feature/#62 - 루틴 페이지 reactor, Coodinator 편집

### DIFF
--- a/HowManySet/App/Coordinator/HomeCoordinator.swift
+++ b/HowManySet/App/Coordinator/HomeCoordinator.swift
@@ -10,7 +10,7 @@ import UIKit
 protocol HomeCoordinatorProtocol: Coordinator {
     func presentRoutineListView()
     func presentEditAndMemoView()
-    func presentEditExerciseView()
+    func presentEditExerciseView(routineName: String)
     func presentEditRoutineView()
     func pushRoutineCompleteView(with workoutSummary: WorkoutSummary)
     func popUpEndWorkoutAlert(onConfirm: @escaping () -> WorkoutSummary)
@@ -66,8 +66,11 @@ final class HomeCoordinator: HomeCoordinatorProtocol {
     }
     
     /// 운동 카드 가운데 회색 버튼 클릭시 해당 운동 종목 편집 화면 present
-    func presentEditExerciseView() {
-        let reactor = EditExcerciseViewReactor()
+    func presentEditExerciseView(routineName: String) {
+        let realmService: RealmServiceProtocol = RealmService()
+        let routineRepository = RoutineRepositoryImpl(realmService: realmService)
+        let saveRoutineUseCase = SaveRoutineUseCase(repository: routineRepository)
+        let reactor = EditExcerciseViewReactor(routineName: routineName, saveRoutineUseCase: saveRoutineUseCase)
         let editExerciseVC = EditExcerciseViewController(reactor: reactor)
         
         if let sheet = editExerciseVC.sheetPresentationController {

--- a/HowManySet/App/Coordinator/RoutineListCoordinator.swift
+++ b/HowManySet/App/Coordinator/RoutineListCoordinator.swift
@@ -74,7 +74,11 @@ final class RoutineListCoordinator: RoutineListCoordinatorProtocol {
     
     /// 운동 편집 화면 전체 화면으로 push
     func pushEditExcerciseView(routineName: String) {
-        let reactor = EditExcerciseViewReactor(routineName: routineName)
+        let realmService: RealmServiceProtocol = RealmService()
+        let routineRepository = RoutineRepositoryImpl(realmService: realmService)
+        let saveRoutineUseCase = SaveRoutineUseCase(repository: routineRepository)
+        
+        let reactor = EditExcerciseViewReactor(routineName: routineName, saveRoutineUseCase: saveRoutineUseCase)
         let editExcerciseVC = EditExcerciseViewController(reactor: reactor)
         
         navigationController.pushViewController(editExcerciseVC, animated: true)

--- a/HowManySet/App/Coordinator/RoutineListCoordinator.swift
+++ b/HowManySet/App/Coordinator/RoutineListCoordinator.swift
@@ -9,7 +9,7 @@ import UIKit
 
 protocol RoutineListCoordinatorProtocol: Coordinator {
     func presentRoutineNameView()
-    func pushEditExcerciseView()
+    func pushEditExcerciseView(routineName: String)
     func pushEditRoutineView(with: WorkoutRoutine)
 }
 
@@ -52,10 +52,8 @@ final class RoutineListCoordinator: RoutineListCoordinatorProtocol {
         guard let routineListVC = navigationController.viewControllers.first(
             where: { $0 is RoutineListViewController }
         ) as? RoutineListViewController else { return }
-        let saveRoutineUseCase = routineListVC.reactor?.publicSaveRoutineUseCase
-        guard let saveRoutineUseCase = saveRoutineUseCase else { return }
         
-        let reactor = RoutineNameReactor(saveRoutineUseCase: saveRoutineUseCase)
+        let reactor = RoutineNameReactor()
         let routineNameVC = RoutineNameViewController(reactor: reactor, coordinator: self)
 
         if let sheet = routineNameVC.sheetPresentationController {
@@ -75,8 +73,8 @@ final class RoutineListCoordinator: RoutineListCoordinatorProtocol {
     }
     
     /// 운동 편집 화면 전체 화면으로 push
-    func pushEditExcerciseView() {
-        let reactor = EditExcerciseViewReactor()
+    func pushEditExcerciseView(routineName: String) {
+        let reactor = EditExcerciseViewReactor(routineName: routineName)
         let editExcerciseVC = EditExcerciseViewController(reactor: reactor)
         
         navigationController.pushViewController(editExcerciseVC, animated: true)

--- a/HowManySet/Domain/Entity/WorkoutRoutine.swift
+++ b/HowManySet/Domain/Entity/WorkoutRoutine.swift
@@ -20,7 +20,7 @@ struct WorkoutRoutine: Hashable {
     /// 루틴에 포함된 운동 목록입니다.
     ///
     /// 각 `Workout`은 루틴을 구성하는 개별 운동을 나타냅니다.
-    let workouts: [Workout]
+    var workouts: [Workout]
 }
 
 extension WorkoutRoutine {

--- a/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseContentView/EditExcerciseContentHeaderView.swift
+++ b/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseContentView/EditExcerciseContentHeaderView.swift
@@ -8,12 +8,17 @@
 import UIKit
 import SnapKit
 import Then
+import RxSwift
+import RxCocoa
 
 /// 운동 정보 입력 화면 상단에 사용되는 헤더 뷰입니다.
 ///
 /// 좌측에는 "운동정보 입력"이라는 제목이 표시되며,
 /// 우측에는 단위 선택을 위한 커스텀 세그먼트 컨트롤(`kg`, `lbs`)이 배치됩니다.
 final class EditExcerciseContentHeaderView: UIView {
+    
+    private let disposeBag = DisposeBag()
+    private(set) var unitSelectionRelay = BehaviorRelay<String>(value: "kg")
     
     /// 운동 정보 입력 안내 문구를 표시하는 라벨입니다.
     private let titleLabel = UILabel().then {
@@ -31,7 +36,6 @@ final class EditExcerciseContentHeaderView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupUI()
-        unitSegmentControl.addTarget(self, action: #selector(segmentChanged), for: .valueChanged)
     }
     
     /// 스토리보드 또는 XIB 초기화는 지원하지 않습니다.
@@ -39,22 +43,27 @@ final class EditExcerciseContentHeaderView: UIView {
     required init(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    /// 세그먼트 컨트롤의 값이 변경될 때 호출되는 액션입니다.
-    @objc func segmentChanged() {
-        // 단위 변경 시 필요한 동작을 이곳에 구현합니다.
-    }
 }
 
 // MARK: - UI 구성 관련 메서드
 
 private extension EditExcerciseContentHeaderView {
     
+
     /// 전체 UI 구성 흐름을 정의합니다.
     func setupUI() {
         setViewHierarchy()
         setConstraints()
         setAppearance()
+        bind()
+    }
+    
+    func bind() {
+        unitSegmentControl.rx.selectedSegmentIndex
+            .distinctUntilChanged()
+            .map{ if $0 == 0 { return "kg" } else { return "lbs" } }
+            .bind(to: unitSelectionRelay)
+            .disposed(by: disposeBag)
     }
     
     /// 배경색 등 외형 스타일을 설정합니다.

--- a/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseContentView/EditExcerciseContentView.swift
+++ b/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseContentView/EditExcerciseContentView.swift
@@ -118,7 +118,7 @@ final class EditExcerciseContentView: UIView {
         excerciseInfoRelay.accept(excerciseInfoRelay.value + [[-1, -1]])
         
         contentView.weightRepsRelay
-            .subscribe(with: self) { [order] owner, element in
+            .subscribe(with: self) { owner, element in
                 if owner.excerciseInfoRelay.value.count > contentView.order {
                     var newValue = owner.excerciseInfoRelay.value
                     newValue[contentView.order] = element
@@ -140,6 +140,16 @@ final class EditExcerciseContentView: UIView {
         for _ in 1...3 {
             addContentView()
         }
+    }
+    
+    func returnInitialState() {
+        verticalContentStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        verticalContentStackView.addArrangedSubviews(
+            horizontalContentTitleStackView,
+            addContentButton
+        )
+        excerciseInfoRelay.accept([[]])
+        setThreeCells()
     }
 }
 

--- a/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseContentView/EditExcerciseContentView.swift
+++ b/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseContentView/EditExcerciseContentView.swift
@@ -31,6 +31,7 @@ final class EditExcerciseContentView: UIView {
     /// 상단 단위 선택 헤더 뷰입니다.
     private let headerView = EditExcerciseContentHeaderView()
     private(set) var unitSelectionRelay = BehaviorRelay<String>(value: "kg")
+    private(set) var excerciseInfoRelay = BehaviorRelay<[[Int]]>(value: [[]])
     
     /// 세트 정보와 추가 버튼을 포함하는 수직 스택뷰입니다.
     private let verticalContentStackView = UIStackView().then {
@@ -109,6 +110,20 @@ final class EditExcerciseContentView: UIView {
                 owner.verticalContentStackView.removeArrangedSubview(contentView)
                 contentView.removeFromSuperview()
                 owner.reorder()
+                var newValue = owner.excerciseInfoRelay.value
+                newValue.remove(at: contentView.order)
+                owner.excerciseInfoRelay.accept(newValue)
+            }.disposed(by: disposeBag)
+        
+        excerciseInfoRelay.accept(excerciseInfoRelay.value + [[-1, -1]])
+        
+        contentView.weightRepsRelay
+            .subscribe(with: self) { [order] owner, element in
+                if owner.excerciseInfoRelay.value.count > contentView.order {
+                    var newValue = owner.excerciseInfoRelay.value
+                    newValue[contentView.order] = element
+                    owner.excerciseInfoRelay.accept(newValue)
+                }
             }.disposed(by: disposeBag)
     }
     

--- a/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseContentView/EditExcerciseContentView.swift
+++ b/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseContentView/EditExcerciseContentView.swift
@@ -30,6 +30,7 @@ final class EditExcerciseContentView: UIView {
     
     /// 상단 단위 선택 헤더 뷰입니다.
     private let headerView = EditExcerciseContentHeaderView()
+    private(set) var unitSelectionRelay = BehaviorRelay<String>(value: "kg")
     
     /// 세트 정보와 추가 버튼을 포함하는 수직 스택뷰입니다.
     private let verticalContentStackView = UIStackView().then {
@@ -82,12 +83,6 @@ final class EditExcerciseContentView: UIView {
         setupUI()
         setThreeCells()  // 기본 3개의 세트 생성
         
-        // "+ 세트 추가하기" 버튼 탭 시 새 세트 추가
-        addContentButton.rx.tap
-            .observe(on: MainScheduler.instance)
-            .subscribe(with: self) { owner, _ in
-                owner.addContentView()
-            }.disposed(by: disposeBag)
     }
     
     /// XIB/Storyboard 초기화는 지원하지 않습니다.
@@ -142,6 +137,19 @@ private extension EditExcerciseContentView {
         setViewHierarchy()
         setConstraints()
         setAppearance()
+        bind()
+    }
+    func bind() {
+        // "+ 세트 추가하기" 버튼 탭 시 새 세트 추가
+        addContentButton.rx.tap
+            .observe(on: MainScheduler.instance)
+            .subscribe(with: self) { owner, _ in
+                owner.addContentView()
+            }.disposed(by: disposeBag)
+        
+        headerView.unitSelectionRelay
+            .bind(to: unitSelectionRelay)
+            .disposed(by: disposeBag)
     }
     
     /// 배경색 등 외형을 설정합니다.

--- a/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseContentView/EditExcerciseHorizontalContentStackView.swift
+++ b/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseContentView/EditExcerciseHorizontalContentStackView.swift
@@ -45,6 +45,7 @@ final class EditExcerciseHorizontalContentStackView: UIStackView {
         $0.clipsToBounds = true
         $0.layer.cornerRadius = 12
         $0.textColor = .white
+        $0.keyboardType = .numberPad
         let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: 15, height: $0.frame.height))
         $0.leftView = paddingView
         $0.leftViewMode = .always
@@ -57,6 +58,7 @@ final class EditExcerciseHorizontalContentStackView: UIStackView {
         $0.clipsToBounds = true
         $0.textColor = .white
         $0.layer.cornerRadius = 12
+        $0.keyboardType = .numberPad
         let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: 15, height: $0.frame.height))
         $0.leftView = paddingView
         $0.leftViewMode = .always

--- a/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseContentView/EditExcerciseHorizontalContentStackView.swift
+++ b/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseContentView/EditExcerciseHorizontalContentStackView.swift
@@ -16,7 +16,7 @@ import RxCocoa
 /// 구성 요소:
 /// - 순서 라벨 (`orderLabel`)
 /// - 무게 입력 필드 (`weightTextField`)
-/// - 횟수 입력 필드 (`countTextField`)
+/// - 횟수 입력 필드 (`repsTextField`)
 /// - 삭제 버튼 (`removeButton`)
 ///
 /// Rx로 삭제 버튼의 탭 이벤트를 외부에 전달할 수 있도록 `removeButtonTap`을 제공합니다.
@@ -27,6 +27,9 @@ final class EditExcerciseHorizontalContentStackView: UIStackView {
     
     /// 삭제 버튼이 탭되었을 때 이벤트를 방출하는 PublishRelay입니다.
     private(set) var removeButtonTap = PublishRelay<Void>()
+    private(set) var weightRepsRelay = BehaviorRelay<[Int]>(value: [-1, -1])
+    
+    var order: Int = 0
     
     /// 현재 세트의 순서를 표시하는 라벨입니다.
     private let orderLabel = UILabel().then {
@@ -52,7 +55,7 @@ final class EditExcerciseHorizontalContentStackView: UIStackView {
     }
     
     /// 반복 횟수를 입력받는 텍스트 필드입니다.
-    private let countTextField = UITextField().then {
+    private let repsTextField = UITextField().then {
         $0.placeholder = "입력"
         $0.backgroundColor = .bottomSheetBG
         $0.clipsToBounds = true
@@ -82,11 +85,6 @@ final class EditExcerciseHorizontalContentStackView: UIStackView {
         isLayoutMarginsRelativeArrangement = true
         layoutMargins = .init(top: 8, left: 0, bottom: 8, right: 0)
         setupUI()
-        
-        // 삭제 버튼 탭 이벤트 바인딩
-        removeButton.rx.tap
-            .bind(to: removeButtonTap)
-            .disposed(by: disposeBag)
     }
     
     /// XIB/Storyboard 초기화는 지원하지 않습니다.
@@ -101,6 +99,7 @@ final class EditExcerciseHorizontalContentStackView: UIStackView {
     convenience init(order: Int) {
         self.init(frame: .zero)
         self.orderLabel.text = "\(order)"
+        self.order = order
     }
     
     /// 외부에서 순서를 재설정할 때 사용하는 메서드입니다.
@@ -108,6 +107,7 @@ final class EditExcerciseHorizontalContentStackView: UIStackView {
     /// - Parameter order: 변경할 순서 값
     func reOrderLabel(order: Int) {
         self.orderLabel.text = "\(order)"
+        self.order = order
     }
 }
 
@@ -120,6 +120,23 @@ private extension EditExcerciseHorizontalContentStackView {
         setViewHierarchy()
         setConstraints()
         setAppearance()
+        bind()
+    }
+    
+    func bind() {
+        Observable
+            .combineLatest(
+                weightTextField.rx.text.orEmpty,
+                repsTextField.rx.text.orEmpty
+            )
+            .map{ [Int($0) ?? -1, Int($1) ?? -1] }
+            .bind(to: weightRepsRelay)
+            .disposed(by: disposeBag)
+
+        // 삭제 버튼 탭 이벤트 바인딩
+        removeButton.rx.tap
+            .bind(to: removeButtonTap)
+            .disposed(by: disposeBag)
     }
     
     /// 배경색 등 외형 스타일을 설정합니다.
@@ -129,7 +146,7 @@ private extension EditExcerciseHorizontalContentStackView {
     
     /// 스택뷰에 포함될 서브뷰들을 추가합니다.
     func setViewHierarchy() {
-        self.addArrangedSubviews(orderLabel, weightTextField, countTextField, removeButton)
+        self.addArrangedSubviews(orderLabel, weightTextField, repsTextField, removeButton)
     }
     
     /// 스택뷰 내부 컴포넌트에 대한 오토레이아웃을 설정합니다.

--- a/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseCurrentView/EditExcerciseCurrentStackView.swift
+++ b/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseCurrentView/EditExcerciseCurrentStackView.swift
@@ -76,6 +76,15 @@ final class EditExcerciseCurrentStackView: UIStackView {
         // 개수 라벨 갱신
         self.excerciseCountLabel.text = "\(self.arrangedSubviews.count - 1)개의 운동"
     }
+    
+    func addExcercise(workout: Workout) {
+        let view = SavedExcerciseView(workout: workout)
+        self.removeArrangedSubview(emptyTextLabel)
+        emptyTextLabel.removeFromSuperview()
+        
+        self.addArrangedSubviews(view)
+        self.excerciseCountLabel.text = "\(self.arrangedSubviews.count - 1)개의 운동"
+    }
 }
 
 // MARK: - UI 구성 관련 메서드

--- a/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseCurrentView/SavedExcerciseView.swift
+++ b/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseCurrentView/SavedExcerciseView.swift
@@ -48,6 +48,12 @@ final class SavedExcerciseView: UIView {
         self.setCountLabel.text = "\(setCount)세트"
     }
     
+    convenience init(workout: Workout) {
+        self.init(frame: .zero)
+        self.excerciseNameLabel.text = workout.name
+        self.setCountLabel.text = "\(workout.sets.count)세트 * \(workout.sets.map{ $0.weight }.max()!)\(workout.sets[0].unit) * 총 \(workout.sets.map{ $0.reps }.reduce(0, +))회"
+    }
+    
     /// 스토리보드 사용 불가
     @available(*, unavailable)
     required init(coder: NSCoder) {

--- a/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseHeaderView.swift
+++ b/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseHeaderView.swift
@@ -8,11 +8,16 @@
 import UIKit
 import SnapKit
 import Then
+import RxCocoa
+import RxSwift
 
 /// 운동 이름을 입력받는 화면 상단 헤더 뷰입니다.
 ///
 /// `UILabel`과 `UITextField`를 포함하며, 사용자가 운동명을 입력할 수 있도록 구성되어 있습니다.
 final class EditExcerciseHeaderView: UIView {
+    
+    private let disposeBag = DisposeBag()
+    private(set) var exerciseNameRelay = BehaviorRelay<String>(value: "")
     
     /// 운동명 입력 안내 텍스트를 보여주는 라벨입니다.
     private let titleLabel = UILabel().then {
@@ -41,6 +46,7 @@ final class EditExcerciseHeaderView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupUI()
+        
     }
     
     /// 스토리보드나 XIB를 통한 초기화는 지원하지 않습니다.
@@ -59,6 +65,15 @@ private extension EditExcerciseHeaderView {
         setViewHierarchy()
         setConstraints()
         setAppearance()
+        bind()
+    }
+    
+    func bind() {
+        exerciseNameTextField.rx.text
+            .compactMap{ $0 }
+            .distinctUntilChanged()
+            .bind(to: exerciseNameRelay)
+            .disposed(by: disposeBag)
     }
     
     /// 뷰의 외형(배경색 등)을 설정합니다.

--- a/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseHeaderView.swift
+++ b/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseHeaderView.swift
@@ -54,6 +54,11 @@ final class EditExcerciseHeaderView: UIView {
     required init(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    func returnInitialState() {
+        self.exerciseNameTextField.text = ""
+        exerciseNameRelay.accept("")
+    }
 }
 
 // MARK: - UI Methods

--- a/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseHeaderView.swift
+++ b/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseHeaderView.swift
@@ -13,24 +13,31 @@ import RxSwift
 
 /// 운동 이름을 입력받는 화면 상단 헤더 뷰입니다.
 ///
-/// `UILabel`과 `UITextField`를 포함하며, 사용자가 운동명을 입력할 수 있도록 구성되어 있습니다.
+/// `UILabel`과 `UITextField`로 구성되어 있으며, 사용자가 운동명을 입력하면
+/// 내부적으로 `exerciseNameRelay`를 통해 Reactive하게 해당 값을 전달합니다.
 final class EditExcerciseHeaderView: UIView {
     
+    // MARK: - Properties
+    
     private let disposeBag = DisposeBag()
+    
+    /// 사용자 입력 운동명을 바인딩하는 Relay입니다.
+    ///
+    /// 외부에서는 읽기만 가능하며, 내부 텍스트 필드 변경 시 자동으로 값이 업데이트됩니다.
     private(set) var exerciseNameRelay = BehaviorRelay<String>(value: "")
     
-    /// 운동명 입력 안내 텍스트를 보여주는 라벨입니다.
+    /// 운동명 입력 안내 문구를 보여주는 라벨입니다.
     private let titleLabel = UILabel().then {
         $0.text = "운동명을 입력해주세요"
         $0.font = .boldSystemFont(ofSize: 20)
         $0.textColor = .textSecondary
     }
     
-    /// 사용자가 운동명을 입력할 수 있는 텍스트 필드입니다.
+    /// 사용자로부터 운동명을 입력받는 텍스트 필드입니다.
     ///
-    /// 좌측에 패딩이 들어가며, 둥근 테두리와 배경색이 적용되어 있습니다.
+    /// 왼쪽에 패딩이 있으며, 둥근 테두리 및 배경색이 적용되어 있습니다.
     private let exerciseNameTextField = UITextField().then {
-        $0.placeholder = "예)벤치프레스, 체스트 프레스"
+        $0.placeholder = "예) 벤치프레스, 체스트 프레스"
         $0.backgroundColor = .bottomSheetBG
         $0.clipsToBounds = true
         $0.layer.cornerRadius = 12
@@ -40,32 +47,35 @@ final class EditExcerciseHeaderView: UIView {
         $0.leftViewMode = .always
     }
     
-    /// 코드로 초기화할 때 사용되는 이니셜라이저입니다.
-    ///
-    /// - Parameter frame: 뷰의 프레임.
+    // MARK: - Initializers
+    
+    /// 코드 기반으로 초기화될 때 호출됩니다.
+    /// - Parameter frame: 뷰의 초기 프레임
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupUI()
-        
     }
     
-    /// 스토리보드나 XIB를 통한 초기화는 지원하지 않습니다.
+    /// 스토리보드/인터페이스 빌더 초기화는 지원하지 않습니다.
     @available(*, unavailable)
     required init(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // MARK: - Public Methods
+    
+    /// 텍스트 필드 및 Relay를 초기 상태로 되돌립니다.
     func returnInitialState() {
         self.exerciseNameTextField.text = ""
         exerciseNameRelay.accept("")
     }
 }
 
-// MARK: - UI Methods
+// MARK: - Private UI Methods
 
 private extension EditExcerciseHeaderView {
     
-    /// UI를 구성하는 전체 흐름을 정의합니다.
+    /// 전체 UI 구성 메서드입니다.
     func setupUI() {
         setViewHierarchy()
         setConstraints()
@@ -73,30 +83,34 @@ private extension EditExcerciseHeaderView {
         bind()
     }
     
+    /// 내부 바인딩 설정 메서드입니다.
+    ///
+    /// 텍스트 필드 변경을 `exerciseNameRelay`에 바인딩합니다.
     func bind() {
         exerciseNameTextField.rx.text
-            .compactMap{ $0 }
+            .compactMap { $0 }
             .distinctUntilChanged()
             .bind(to: exerciseNameRelay)
             .disposed(by: disposeBag)
     }
     
-    /// 뷰의 외형(배경색 등)을 설정합니다.
+    /// 배경색 등 외형을 설정합니다.
     func setAppearance() {
         self.backgroundColor = .background
     }
     
-    /// 서브뷰들을 계층에 추가합니다.
+    /// 서브뷰를 계층에 추가합니다.
     func setViewHierarchy() {
         self.addSubviews(titleLabel, exerciseNameTextField)
     }
     
-    /// 각 서브뷰에 대한 오토레이아웃 제약을 설정합니다.
+    /// 오토레이아웃 제약 조건을 설정합니다.
     func setConstraints() {
         titleLabel.snp.makeConstraints {
             $0.horizontalEdges.equalTo(self.safeAreaLayoutGuide).inset(20)
             $0.top.equalTo(self.safeAreaLayoutGuide).inset(8)
         }
+        
         exerciseNameTextField.snp.makeConstraints {
             $0.horizontalEdges.equalTo(self.safeAreaLayoutGuide).inset(20)
             $0.top.equalTo(titleLabel.snp.bottom).offset(16)

--- a/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseViewController.swift
+++ b/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseViewController.swift
@@ -93,6 +93,11 @@ final class EditExcerciseViewController: UIViewController, View {
             .map{ Reactor.Action.changeExerciseName($0) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
+        
+        contentView.unitSelectionRelay
+            .map{ Reactor.Action.changeUnit($0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
         let tapGesture = UITapGestureRecognizer()
         tapGesture.cancelsTouchesInView = false
 

--- a/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseViewController.swift
+++ b/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseViewController.swift
@@ -130,21 +130,29 @@ final class EditExcerciseViewController: UIViewController, View {
             .observe(on: MainScheduler.instance)
             .subscribe(with: self) { owner, vaild in
                 switch vaild {
-                case .failure:
+                case .excerciseSavefailure:
                     let alert = UIAlertController(title: "입력 오류", message: "운동 항목을 올바르게 입력해 주세요.", preferredStyle: .alert)
                     alert.addAction(UIAlertAction(title: "확인", style: .default))
                     owner.present(alert, animated: true)
-                case .success:
+                case .excerciseSaveSuccess:
                     let alert = UIAlertController(title: "저장 완료", message: "운동이 저장되었습니다", preferredStyle: .alert)
                     alert.addAction(UIAlertAction(title: "확인", style: .default))
                     owner.present(alert, animated: true) {
                         owner.headerView.returnInitialState()
                         owner.contentView.returnInitialState()
                     }
+                case .saveRoutineFailure:
+                    let alert = UIAlertController(title: "저장 실패", message: "현재 저장된 운동목록이 없습니다.", preferredStyle: .alert)
+                    alert.addAction(UIAlertAction(title: "확인", style: .default))
+                    owner.present(alert, animated: true)
                 }
-                
-            }
->>>>>>> 56816b2 (feat: #62 - 운동 추가 버튼 클릭시 입력된 운동 정보를 저장하고 UI그리도록 리액터 연결 / 빈 텍스트필드가 있는 경우 alert 표시 / 성공해도 alert 표시)
+            }.disposed(by: disposeBag)
+        
+        reactor.dismissRelay
+            .observe(on: MainScheduler.instance)
+            .subscribe(with: self) { owner, _ in
+                owner.navigationController?.popViewController(animated: true)
+            }.disposed(by: disposeBag)
     }
 }
 

--- a/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseViewController.swift
+++ b/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseViewController.swift
@@ -115,7 +115,6 @@ final class EditExcerciseViewController: UIViewController, View {
             .map { Reactor.Action.changeExcerciseWeightSet($0) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
-<<<<<<< HEAD
         let tapGesture = UITapGestureRecognizer()
         tapGesture.cancelsTouchesInView = false
 
@@ -126,7 +125,6 @@ final class EditExcerciseViewController: UIViewController, View {
                 self.view.endEditing(true)
             }
             .disposed(by: disposeBag)
-=======
         
         // 운동 항목이 추가되었을 때 현재 뷰에 반영
         reactor.state

--- a/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseViewController.swift
+++ b/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseViewController.swift
@@ -103,6 +103,7 @@ final class EditExcerciseViewController: UIViewController, View {
             .map{ Reactor.Action.changeExcerciseWeightSet($0) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
+<<<<<<< HEAD
         let tapGesture = UITapGestureRecognizer()
         tapGesture.cancelsTouchesInView = false
 
@@ -113,6 +114,37 @@ final class EditExcerciseViewController: UIViewController, View {
                 self.view.endEditing(true)
             }
             .disposed(by: disposeBag)
+=======
+        
+        reactor.state
+            .map{ $0.currentRoutine.workouts }
+            .distinctUntilChanged()
+            .skip(1)
+            .observe(on: MainScheduler.instance)
+            .subscribe(with: self) { owner, workout in
+                guard let workout = workout.last else { return  }
+                owner.currentView.addExcercise(workout: workout)
+            }.disposed(by: disposeBag)
+        
+        reactor.alertRelay
+            .observe(on: MainScheduler.instance)
+            .subscribe(with: self) { owner, vaild in
+                switch vaild {
+                case .failure:
+                    let alert = UIAlertController(title: "입력 오류", message: "운동 항목을 올바르게 입력해 주세요.", preferredStyle: .alert)
+                    alert.addAction(UIAlertAction(title: "확인", style: .default))
+                    owner.present(alert, animated: true)
+                case .success:
+                    let alert = UIAlertController(title: "저장 완료", message: "운동이 저장되었습니다", preferredStyle: .alert)
+                    alert.addAction(UIAlertAction(title: "확인", style: .default))
+                    owner.present(alert, animated: true) {
+                        owner.headerView.returnInitialState()
+                        owner.contentView.returnInitialState()
+                    }
+                }
+                
+            }
+>>>>>>> 56816b2 (feat: #62 - 운동 추가 버튼 클릭시 입력된 운동 정보를 저장하고 UI그리도록 리액터 연결 / 빈 텍스트필드가 있는 경우 alert 표시 / 성공해도 alert 표시)
     }
 }
 

--- a/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseViewController.swift
+++ b/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseViewController.swift
@@ -98,6 +98,11 @@ final class EditExcerciseViewController: UIViewController, View {
             .map{ Reactor.Action.changeUnit($0) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
+        
+        contentView.excerciseInfoRelay
+            .map{ Reactor.Action.changeExcerciseWeightSet($0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
         let tapGesture = UITapGestureRecognizer()
         tapGesture.cancelsTouchesInView = false
 

--- a/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseViewController.swift
+++ b/HowManySet/Presentation/Feature/EditExcercise/EditExcerciseViewController.swift
@@ -14,52 +14,51 @@ import ReactorKit
 
 /// 운동 루틴 편집 화면을 담당하는 뷰 컨트롤러입니다.
 ///
-/// 주요 구성 요소:
-/// - 상단 헤더 (`EditExcerciseHeaderView`)
-/// - 세트 편집 영역 (`EditExcerciseContentView`)
-/// - 현재 저장된 운동 목록 (`EditExcerciseCurrentStackView`)
-/// - 하단 푸터 버튼 (`EditExcerciseFooterView`)
-///
-/// 사용자가 세트를 추가하고, 운동을 저장하는 등 편집 기능을 제공합니다.
+/// 주요 기능:
+/// - 운동 이름 입력
+/// - 세트(중량/횟수) 편집
+/// - 운동 항목 추가 및 루틴 저장
+/// - 유효성 검증 실패 시 Alert 표시
 final class EditExcerciseViewController: UIViewController, View {
     
     typealias Reactor = EditExcerciseViewReactor
     
     // MARK: - Properties
     
-    /// 메모리 해제를 위한 DisposeBag (RxSwift)
+    /// Rx 리소스 해제를 위한 DisposeBag입니다.
     var disposeBag = DisposeBag()
     
     // MARK: - UI Components
     
-    /// 전체 콘텐츠를 스크롤 가능하게 하는 스크롤 뷰입니다.
+    /// 전체 화면을 스크롤 가능하게 만드는 스크롤 뷰입니다.
     private let scrollView = UIScrollView()
     
-    /// 상단 타이틀/설명 등을 포함하는 헤더 뷰입니다.
+    /// 운동명을 입력하는 헤더 뷰입니다.
     private let headerView = EditExcerciseHeaderView()
     
-    /// 헤더와 콘텐츠 사이 구분선
+    /// 헤더 하단 구분선입니다.
     private let headerBorderLineView = UIView().then {
         $0.backgroundColor = .systemGray3
     }
     
-    /// 세트 편집을 위한 콘텐츠 뷰입니다.
+    /// 세트 정보를 입력받는 콘텐츠 뷰입니다.
     private let contentView = EditExcerciseContentView()
     
-    /// 콘텐츠와 현재 운동 리스트 사이 구분선
+    /// 콘텐츠 하단 구분선입니다.
     private let contentBorderLineView = UIView().then {
         $0.backgroundColor = .systemGray3
     }
     
-    /// 현재 추가된 운동 목록을 보여주는 뷰입니다.
+    /// 현재까지 저장된 운동 리스트를 보여주는 뷰입니다.
     private let currentView = EditExcerciseCurrentStackView()
     
-    /// 하단 고정된 액션 버튼(운동 추가, 저장)을 포함하는 푸터 뷰입니다.
+    /// 운동 추가 및 저장 버튼을 포함하는 하단 푸터 뷰입니다.
     private let footerView = EditExcerciseFooterView()
     
     // MARK: - Initializer
     
-    /// 외부에서 리액터를 주입받아 초기화합니다.
+    /// 리액터를 주입받아 초기화합니다.
+    /// - Parameter reactor: 운동 편집 기능을 제어하는 Reactor
     init(reactor: EditExcerciseViewReactor) {
         super.init(nibName: nil, bundle: nil)
         self.reactor = reactor
@@ -73,34 +72,47 @@ final class EditExcerciseViewController: UIViewController, View {
     
     // MARK: - LifeCycle
     
-    /// 뷰 로드 후 UI 및 바인딩 설정을 수행합니다.
+    /// 뷰가 로드되었을 때 호출됩니다.
+    /// UI 구성 및 레이아웃을 설정합니다.
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
     }
     
+    // MARK: - Binding
+    
+    /// 리액터 바인딩을 통해 View와 Reactor를 연결합니다.
+    ///
+    /// 버튼 탭, 입력값 변경, 상태 변화에 따른 Alert 및 화면 dismiss 처리를 수행합니다.
     func bind(reactor: EditExcerciseViewReactor) {
+        
+        // 운동 추가 버튼 탭
         footerView.addExcerciseButtonTapped
-            .map{ Reactor.Action.addExcerciseButtonTapped }
+            .map { Reactor.Action.addExcerciseButtonTapped }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        // 루틴 저장 버튼 탭
         footerView.saveRoutineButtonTapped
             .map { Reactor.Action.saveRoutineButtonTapped }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
+        
+        // 운동 이름 입력
         headerView.exerciseNameRelay
-            .map{ Reactor.Action.changeExerciseName($0) }
+            .map { Reactor.Action.changeExerciseName($0) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        // 단위 선택 변경
         contentView.unitSelectionRelay
-            .map{ Reactor.Action.changeUnit($0) }
+            .map { Reactor.Action.changeUnit($0) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        // 세트 정보 변경
         contentView.excerciseInfoRelay
-            .map{ Reactor.Action.changeExcerciseWeightSet($0) }
+            .map { Reactor.Action.changeExcerciseWeightSet($0) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
 <<<<<<< HEAD
@@ -116,62 +128,83 @@ final class EditExcerciseViewController: UIViewController, View {
             .disposed(by: disposeBag)
 =======
         
+        // 운동 항목이 추가되었을 때 현재 뷰에 반영
         reactor.state
-            .map{ $0.currentRoutine.workouts }
+            .map { $0.currentRoutine.workouts }
             .distinctUntilChanged()
             .skip(1)
             .observe(on: MainScheduler.instance)
-            .subscribe(with: self) { owner, workout in
-                guard let workout = workout.last else { return  }
+            .subscribe(with: self) { owner, workouts in
+                guard let workout = workouts.last else { return }
                 owner.currentView.addExcercise(workout: workout)
-            }.disposed(by: disposeBag)
+            }
+            .disposed(by: disposeBag)
         
+        // Alert 표시 (저장 성공/실패, 유효성 실패 등)
         reactor.alertRelay
             .observe(on: MainScheduler.instance)
-            .subscribe(with: self) { owner, vaild in
-                switch vaild {
+            .subscribe(with: self) { owner, alert in
+                switch alert {
                 case .excerciseSavefailure:
-                    let alert = UIAlertController(title: "입력 오류", message: "운동 항목을 올바르게 입력해 주세요.", preferredStyle: .alert)
+                    let alert = UIAlertController(
+                        title: "입력 오류",
+                        message: "운동 항목을 올바르게 입력해 주세요.",
+                        preferredStyle: .alert
+                    )
                     alert.addAction(UIAlertAction(title: "확인", style: .default))
                     owner.present(alert, animated: true)
+                    
                 case .excerciseSaveSuccess:
-                    let alert = UIAlertController(title: "저장 완료", message: "운동이 저장되었습니다", preferredStyle: .alert)
+                    let alert = UIAlertController(
+                        title: "저장 완료",
+                        message: "운동이 저장되었습니다",
+                        preferredStyle: .alert
+                    )
                     alert.addAction(UIAlertAction(title: "확인", style: .default))
                     owner.present(alert, animated: true) {
                         owner.headerView.returnInitialState()
                         owner.contentView.returnInitialState()
                     }
+                    
                 case .saveRoutineFailure:
-                    let alert = UIAlertController(title: "저장 실패", message: "현재 저장된 운동목록이 없습니다.", preferredStyle: .alert)
+                    let alert = UIAlertController(
+                        title: "저장 실패",
+                        message: "현재 저장된 운동 목록이 없습니다.",
+                        preferredStyle: .alert
+                    )
                     alert.addAction(UIAlertAction(title: "확인", style: .default))
                     owner.present(alert, animated: true)
                 }
-            }.disposed(by: disposeBag)
+            }
+            .disposed(by: disposeBag)
         
+        // 저장 후 화면 닫기
         reactor.dismissRelay
             .observe(on: MainScheduler.instance)
             .subscribe(with: self) { owner, _ in
                 owner.navigationController?.popViewController(animated: true)
-            }.disposed(by: disposeBag)
+            }
+            .disposed(by: disposeBag)
     }
 }
 
-// MARK: - UI Methods
+// MARK: - UI Layout Methods
+
 private extension EditExcerciseViewController {
     
-    /// 전체 UI 구성 메서드
+    /// 전체 UI 구성 흐름을 설정합니다.
     func setupUI() {
         setViewHierarchy()
         setConstraints()
         setAppearance()
     }
     
-    /// 배경색 설정 등 외형 설정
+    /// 기본 배경색 등 외형을 설정합니다.
     func setAppearance() {
         view.backgroundColor = .background
     }
     
-    /// 뷰 계층 구성: 스크롤뷰 및 내부 요소, 푸터 뷰 추가
+    /// 서브뷰들을 뷰 계층에 추가합니다.
     func setViewHierarchy() {
         scrollView.addSubviews(
             headerView,
@@ -180,11 +213,10 @@ private extension EditExcerciseViewController {
             contentBorderLineView,
             currentView
         )
-        
         view.addSubviews(scrollView, footerView)
     }
     
-    /// SnapKit을 이용한 오토레이아웃 구성
+    /// SnapKit을 활용한 오토레이아웃 제약 조건 설정입니다.
     func setConstraints() {
         headerView.snp.makeConstraints {
             $0.horizontalEdges.top.equalToSuperview()
@@ -226,7 +258,7 @@ private extension EditExcerciseViewController {
         
         footerView.snp.makeConstraints {
             $0.horizontalEdges.bottom.equalTo(view.safeAreaLayoutGuide)
-            $0.height.equalToSuperview().multipliedBy(0.1125) // 약 1/9 높이
+            $0.height.equalToSuperview().multipliedBy(0.1125)
         }
     }
 }

--- a/HowManySet/Presentation/Feature/EditExcercise/Reactor/EditExcerciseViewReactor.swift
+++ b/HowManySet/Presentation/Feature/EditExcercise/Reactor/EditExcerciseViewReactor.swift
@@ -17,6 +17,7 @@ final class EditExcerciseViewReactor: Reactor {
         case saveRoutineButtonTapped
         case changeExerciseName(String)
         case changeUnit(String)
+        case changeExcerciseWeightSet([[Int]])
     }
     
     // Mutate is a state manipulator which is not exposed to a view
@@ -25,6 +26,7 @@ final class EditExcerciseViewReactor: Reactor {
         case saveRoutine
         case changeExcerciseName(String)
         case changeUnit(String)
+        case changeExcerciseWeightSet([[Int]])
     }
     
     // State is a current view state
@@ -32,6 +34,7 @@ final class EditExcerciseViewReactor: Reactor {
         var currentRoutine: WorkoutRoutine
         var currentExcerciseName: String = ""
         var currentUnit: String = "kg"
+        var currentWeightSet: [[Int]] = []
     }
     
     let initialState: State
@@ -51,6 +54,8 @@ final class EditExcerciseViewReactor: Reactor {
             return .just(.changeExcerciseName(name))
         case .changeUnit(let unit):
             return .just(.changeUnit(unit))
+        case .changeExcerciseWeightSet(let newWeightSet):
+            return .just(.changeExcerciseWeightSet(newWeightSet))
         }
     }
     
@@ -69,6 +74,9 @@ final class EditExcerciseViewReactor: Reactor {
         case .changeUnit(let unit):
             print(unit)
             newState.currentUnit = unit
+        case .changeExcerciseWeightSet(let newWeightSet):
+            newState.currentWeightSet = newWeightSet
+            print(newWeightSet)
         }
         return newState
     }

--- a/HowManySet/Presentation/Feature/EditExcercise/Reactor/EditExcerciseViewReactor.swift
+++ b/HowManySet/Presentation/Feature/EditExcercise/Reactor/EditExcerciseViewReactor.swift
@@ -10,66 +10,97 @@ import RxSwift
 import RxRelay
 import ReactorKit
 
+/// 운동 편집 화면의 상태를 관리하는 Reactor 클래스입니다.
+///
+/// 사용자의 입력(Action)을 받아 상태(State)를 업데이트하고,
+/// 그에 따른 변경사항(Mutation)을 처리합니다.
+///
+/// 주요 기능:
+/// - 새로운 운동 세트 추가
+/// - 루틴 저장 처리
+/// - 운동 이름, 단위, 세트 정보 변경 처리
+/// - 유효성 검사 및 알림 처리
 final class EditExcerciseViewReactor: Reactor {
     
-    // Action is an user interaction
+    // MARK: - Action
+    
+    /// 사용자의 인터랙션을 정의합니다.
     enum Action {
-        case addExcerciseButtonTapped
-        case saveRoutineButtonTapped
-        case changeExerciseName(String)
-        case changeUnit(String)
-        case changeExcerciseWeightSet([[Int]])
+        case addExcerciseButtonTapped         // 운동 추가 버튼 클릭
+        case saveRoutineButtonTapped          // 루틴 저장 버튼 클릭
+        case changeExerciseName(String)       // 운동 이름 변경
+        case changeUnit(String)               // 단위 변경 (kg, lbs 등)
+        case changeExcerciseWeightSet([[Int]]) // 세트 정보 변경 (무게, 반복 수)
     }
     
-    // Mutate is a state manipulator which is not exposed to a view
+    // MARK: - Mutation
+    
+    /// 상태를 변경하는 내부 동작입니다.
     enum Mutation {
-        case addExcercise(Workout)
-        case saveRoutine
-        case changeExcerciseName(String)
-        case changeUnit(String)
-        case changeExcerciseWeightSet([[Int]])
+        case addExcercise(Workout)            // 새로운 운동 추가
+        case saveRoutine                      // 루틴 저장
+        case changeExcerciseName(String)      // 운동 이름 갱신
+        case changeUnit(String)               // 단위 갱신
+        case changeExcerciseWeightSet([[Int]]) // 세트 정보 갱신
     }
     
-    // State is a current view state
+    // MARK: - State
+    
+    /// 뷰의 현재 상태를 나타냅니다.
     struct State {
-        var currentRoutine: WorkoutRoutine
-        var currentExcerciseName: String = ""
-        var currentUnit: String = "kg"
-        var currentWeightSet: [[Int]] = []
+        var currentRoutine: WorkoutRoutine    // 현재 작성 중인 루틴
+        var currentExcerciseName: String = "" // 입력된 운동 이름
+        var currentUnit: String = "kg"        // 단위 기본값 (kg)
+        var currentWeightSet: [[Int]] = []    // 현재 세트 입력값 (2차원 배열: [무게, 반복수])
     }
     
+    /// 운동 저장 결과 상태
     enum VaildWorkout {
         case excerciseSaveSuccess
         case excerciseSavefailure
         case saveRoutineFailure
     }
     
+    // MARK: - Properties
+    
     let initialState: State
-    let alertRelay = PublishRelay<VaildWorkout>()
-    let dismissRelay = PublishRelay<Void>()
+    let alertRelay = PublishRelay<VaildWorkout>() // Alert 표시용 Relay
+    let dismissRelay = PublishRelay<Void>()       // 화면 종료용 Relay
     
     private let saveRoutineUseCase: SaveRoutineUseCaseProtocol
     
+    // MARK: - Initializer
+    
+    /// 초기화 메서드
+    /// - Parameters:
+    ///   - routineName: 새로 생성할 루틴 이름
+    ///   - saveRoutineUseCase: 루틴 저장을 위한 UseCase 주입
     init(routineName: String, saveRoutineUseCase: SaveRoutineUseCaseProtocol) {
         self.initialState = State(currentRoutine: WorkoutRoutine(name: routineName, workouts: []))
         self.saveRoutineUseCase = saveRoutineUseCase
     }
     
-    // Action -> Mutation
+    // MARK: - Mutation 생성
+    
+    /// 사용자 Action을 기반으로 Mutation을 생성합니다.
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case .addExcerciseButtonTapped:
             return Observable<Mutation>.create { [unowned self] observer in
                 var currentWeightSet = self.currentState.currentWeightSet
-                currentWeightSet.removeFirst()
-                let sets = currentWeightSet.map{
+                currentWeightSet.removeFirst() // 첫 행은 빈 값이므로 제거
+                
+                let sets = currentWeightSet.map {
                     WorkoutSet(weight: Double($0[0]),
                                unit: self.currentState.currentUnit,
                                reps: $0[1])
                 }
-                let newWorkout = Workout(name: self.currentState.currentExcerciseName,
-                                         sets: sets,
-                                         comment: nil)
+                
+                let newWorkout = Workout(
+                    name: self.currentState.currentExcerciseName,
+                    sets: sets,
+                    comment: nil
+                )
                 
                 if self.validationWorkout(workout: newWorkout) {
                     observer.onNext(.addExcercise(newWorkout))
@@ -80,50 +111,63 @@ final class EditExcerciseViewReactor: Reactor {
                 observer.onCompleted()
                 return Disposables.create()
             }
+            
         case .saveRoutineButtonTapped:
             return Observable.create { [unowned self] observer in
                 let routine = self.currentState.currentRoutine
                 if routine.workouts.isEmpty {
                     self.alertRelay.accept(.saveRoutineFailure)
                 } else {
-                    dismissRelay.accept(())
+                    self.dismissRelay.accept(())
                     observer.onNext(.saveRoutine)
                 }
                 observer.onCompleted()
-                
                 return Disposables.create()
             }
+            
         case .changeExerciseName(let name):
             return .just(.changeExcerciseName(name))
+            
         case .changeUnit(let unit):
             return .just(.changeUnit(unit))
+            
         case .changeExcerciseWeightSet(let newWeightSet):
             return .just(.changeExcerciseWeightSet(newWeightSet))
         }
     }
     
-    // Mutation -> State
+    // MARK: - 상태 갱신
+    
+    /// Mutation을 통해 상태를 업데이트합니다.
     func reduce(state: State, mutation: Mutation) -> State {
         var newState = state
-        
         switch mutation {
         case .addExcercise(let workout):
             newState.currentRoutine.workouts.append(workout)
+            
         case .saveRoutine:
-            // TODO: Realm Routine 저장 UID 입력 요구
+            // TODO: 실제 저장 시 UID 입력 필요
             saveRoutineUseCase.execute(uid: "", item: newState.currentRoutine)
+            
         case .changeExcerciseName(let newName):
             newState.currentExcerciseName = newName
+            
         case .changeUnit(let unit):
             newState.currentUnit = unit
+            
         case .changeExcerciseWeightSet(let newWeightSet):
             newState.currentWeightSet = newWeightSet
         }
         return newState
     }
     
+    // MARK: - 유효성 검사
+    
+    /// 입력된 운동 데이터의 유효성을 검사합니다.
+    /// - Parameter workout: 검사 대상 운동
+    /// - Returns: 유효하면 `true`, 아니면 `false`
     func validationWorkout(workout: Workout) -> Bool {
-        if workout.name == "" || workout.sets.filter{ $0.reps < 0 || $0.weight < 0 }.count > 0 {
+        if workout.name == "" || workout.sets.contains(where: { $0.reps < 0 || $0.weight < 0 }) {
             return false
         }
         return true

--- a/HowManySet/Presentation/Feature/EditExcercise/Reactor/EditExcerciseViewReactor.swift
+++ b/HowManySet/Presentation/Feature/EditExcercise/Reactor/EditExcerciseViewReactor.swift
@@ -2,7 +2,7 @@
 //  EditExcerciseViewReactor.swift
 //  HowManySet
 //
-//  Created by 정근호 on 6/4/25.
+//  Created by MJ Dev on 6/4/25.
 //
 
 import Foundation
@@ -13,32 +13,63 @@ final class EditExcerciseViewReactor: Reactor {
     
     // Action is an user interaction
     enum Action {
-        
+        case addExcerciseButtonTapped
+        case saveRoutineButtonTapped
+        case changeExerciseName(String)
+        case changeUnit(String)
     }
     
     // Mutate is a state manipulator which is not exposed to a view
     enum Mutation {
-        
+        case addExcercise
+        case saveRoutine
+        case changeExcerciseName(String)
+        case changeUnit(String)
     }
     
     // State is a current view state
     struct State {
-        
+        var currentRoutine: WorkoutRoutine
+        var currentExcerciseName: String = ""
+        var currentUnit: String = "kg"
     }
     
     let initialState: State
     
-    init() {
-        self.initialState = State()
+    init(routineName: String) {
+        self.initialState = State(currentRoutine: WorkoutRoutine(name: routineName, workouts: []))
     }
     
-    //    // Action -> Mutation
-    //    func mutate(action: Action) -> Observable<Mutation> {
-    //
-    //    }
-    //
-    //    // Mutation -> State
-    //    func reduce(state: State, mutation: Mutation) -> State {
-    //
-    //    }
+    // Action -> Mutation
+    func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .addExcerciseButtonTapped:
+            return .just(.addExcercise)
+        case .saveRoutineButtonTapped:
+            return .just(.saveRoutine)
+        case .changeExerciseName(let name):
+            return .just(.changeExcerciseName(name))
+        case .changeUnit(let unit):
+            return .just(.changeUnit(unit))
+        }
+    }
+    
+    // Mutation -> State
+    func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        
+        switch mutation {
+        case .addExcercise:
+            print(newState.currentRoutine.name)
+        case .saveRoutine:
+            print(newState.currentRoutine)
+        case .changeExcerciseName(let newName):
+            print(newName)
+            newState.currentExcerciseName = newName
+        case .changeUnit(let unit):
+            print(unit)
+            newState.currentUnit = unit
+        }
+        return newState
+    }
 }

--- a/HowManySet/Presentation/Feature/Home/HomeViewController.swift
+++ b/HowManySet/Presentation/Feature/Home/HomeViewController.swift
@@ -472,54 +472,12 @@ private extension HomeViewController {
                             cardView.weightRepsButton.transform = .identity
                         }
                     })
-                    .disposed(by: cardView.disposeBag)
-                
-                // 휴식 재생/일시정지 버튼
-                cardView.restPlayPauseButton.rx.tap
-                    .observe(on: MainScheduler.asyncInstance)
-                    .throttle(.milliseconds(500), scheduler: MainScheduler.asyncInstance)
-                    .do(onNext: {
-                        print("휴식 버튼 탭 감지 - index: \(cardView.index)")
-                    })
-                    .bind { [weak cardView] in
-                        guard let cardView else { return }
-                        cardView.restPlayPauseButton.isSelected.toggle()
-                        reactor.action.onNext(.restPauseButtonClicked)
-                    }
-                    .disposed(by: cardView.disposeBag)
-                
-                cardView.editButton.rx.tap
-                    .observe(on: MainScheduler.instance)
-                    .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
-                    .map { Reactor.Action.editAndMemoViewPresented(at: cardView.index) }
-                    .bind(onNext: { [weak self] action in
-                        guard let self else { return }
-                        self.coordinator?.presentEditAndMemoView()
-                        reactor.action.onNext(action)
-                    })
-                    .disposed(by: disposeBag)
-                
-                cardView.weightRepsButton.rx.tap
-                    .observe(on: MainScheduler.instance)
-                    .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
-                    .map { Reactor.Action.weightRepsButtonClicked(at: cardView.index) }
-                    .bind { [weak self] action in
-                        guard let self else { return }
-
-                        // 클릭 애니메이션
-                        UIView.animate(withDuration: 0.1, animations: {
-                            cardView.weightRepsButton.transform = CGAffineTransform(scaleX: 0.95, y: 0.95)
-                        }, completion: { _ in
-                            UIView.animate(withDuration: 0.1) {
-                                cardView.weightRepsButton.transform = .identity
-                            }
-                        })
-                        reactor.action.onNext(action)
-                        self.coordinator?.presentEditExerciseView(routineName: "")
-                    }
-                    .disposed(by: disposeBag)
-            }
-            print("✅ 버튼 바인딩 완료 - \(visibleCards)")
+                    reactor.action.onNext(action)
+                    self.coordinator?.presentEditExerciseView(routineName: "")
+                }
+                .disposed(by: disposeBag)
+        }
+        print("✅ 버튼 바인딩 완료 - \(visibleCards)")
     }
 }
 

--- a/HowManySet/Presentation/Feature/Home/HomeViewController.swift
+++ b/HowManySet/Presentation/Feature/Home/HomeViewController.swift
@@ -472,12 +472,54 @@ private extension HomeViewController {
                             cardView.weightRepsButton.transform = .identity
                         }
                     })
-                    reactor.action.onNext(action)
-                    self.coordinator?.presentEditExerciseView()
-                }
-                .disposed(by: disposeBag)
-        }
-        print("✅ 버튼 바인딩 완료 - \(visibleCards)")
+                    .disposed(by: cardView.disposeBag)
+                
+                // 휴식 재생/일시정지 버튼
+                cardView.restPlayPauseButton.rx.tap
+                    .observe(on: MainScheduler.asyncInstance)
+                    .throttle(.milliseconds(500), scheduler: MainScheduler.asyncInstance)
+                    .do(onNext: {
+                        print("휴식 버튼 탭 감지 - index: \(cardView.index)")
+                    })
+                    .bind { [weak cardView] in
+                        guard let cardView else { return }
+                        cardView.restPlayPauseButton.isSelected.toggle()
+                        reactor.action.onNext(.restPauseButtonClicked)
+                    }
+                    .disposed(by: cardView.disposeBag)
+                
+                cardView.editButton.rx.tap
+                    .observe(on: MainScheduler.instance)
+                    .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
+                    .map { Reactor.Action.editAndMemoViewPresented(at: cardView.index) }
+                    .bind(onNext: { [weak self] action in
+                        guard let self else { return }
+                        self.coordinator?.presentEditAndMemoView()
+                        reactor.action.onNext(action)
+                    })
+                    .disposed(by: disposeBag)
+                
+                cardView.weightRepsButton.rx.tap
+                    .observe(on: MainScheduler.instance)
+                    .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
+                    .map { Reactor.Action.weightRepsButtonClicked(at: cardView.index) }
+                    .bind { [weak self] action in
+                        guard let self else { return }
+
+                        // 클릭 애니메이션
+                        UIView.animate(withDuration: 0.1, animations: {
+                            cardView.weightRepsButton.transform = CGAffineTransform(scaleX: 0.95, y: 0.95)
+                        }, completion: { _ in
+                            UIView.animate(withDuration: 0.1) {
+                                cardView.weightRepsButton.transform = .identity
+                            }
+                        })
+                        reactor.action.onNext(action)
+                        self.coordinator?.presentEditExerciseView(routineName: "")
+                    }
+                    .disposed(by: disposeBag)
+            }
+            print("✅ 버튼 바인딩 완료 - \(visibleCards)")
     }
 }
 

--- a/HowManySet/Presentation/Feature/RoutineList/Reactor/RoutineListViewReactor.swift
+++ b/HowManySet/Presentation/Feature/RoutineList/Reactor/RoutineListViewReactor.swift
@@ -12,17 +12,17 @@ final class RoutineListViewReactor: Reactor {
 
     // MARK: - Action is an user interaction
     enum Action {
-
+        case viewWillAppear
     }
     
     // MARK: - Mutate is a state manipulator which is not exposed to a view
     enum Mutation {
-
+        case updatedRoutine([WorkoutRoutine])
     }
     
     // MARK: - State is a current view state
     struct State {
-
+        var routines: [WorkoutRoutine] = []
     }
     
     let initialState: State
@@ -38,11 +38,22 @@ final class RoutineListViewReactor: Reactor {
     
     // MARK: - Action -> Mutation
     func mutate(action: Action) -> Observable<Mutation> {
-
+        switch action {
+        case .viewWillAppear:
+            return fetchRoutineUseCase.execute(uid: "")
+                .map{ Mutation.updatedRoutine($0) }
+                .asObservable()
+        }
     }
 
     // MARK: - Mutation -> State
     func reduce(state: State, mutation: Mutation) -> State {
-
+        var newState = state
+        switch mutation {
+        case .updatedRoutine(let routines):
+            newState.routines = routines
+        }
+        
+        return newState
     }
 }

--- a/HowManySet/Presentation/Feature/RoutineList/RoutineListViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineList/RoutineListViewController.swift
@@ -34,6 +34,11 @@ final class RoutineListViewController: UIViewController, View {
     override func loadView() {
         view = routineListView
     }
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        reactor?.action.onNext(.viewWillAppear)
+        print("viewWillAppear")
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -41,7 +46,7 @@ final class RoutineListViewController: UIViewController, View {
         setRegisters()
         configureDataSource()
         // MockData 표시
-        applySnapshot(with: WorkoutRoutine.mockData)
+//        applySnapshot(with: WorkoutRoutine.mockData)
     }
 
     // MARK: - Bind
@@ -52,6 +57,15 @@ final class RoutineListViewController: UIViewController, View {
                 owner.coordinator?.presentRoutineNameView()
             }
             .disposed(by: disposeBag)
+        
+        reactor.state
+            .skip(1)
+            .map { $0.routines }
+            .distinctUntilChanged()
+            .observe(on: MainScheduler.instance)
+            .subscribe(with: self) { owner, items in
+                owner.applySnapshot(with: items)
+            }.disposed(by: disposeBag)
     }
 }
 

--- a/HowManySet/Presentation/Feature/RoutineName/Reactor/RoutineNameReactor.swift
+++ b/HowManySet/Presentation/Feature/RoutineName/Reactor/RoutineNameReactor.swift
@@ -4,12 +4,9 @@ import ReactorKit
 
 final class RoutineNameReactor: Reactor {
 
-    private let saveRoutineUseCase: SaveRoutineUseCase
-
     // MARK: - Action is an user interaction
     enum Action {
         case setRoutineName(String)
-        case saveRoutine
     }
 
     // MARK: - Mutate is a state manipulator which is not exposed to a view
@@ -25,8 +22,7 @@ final class RoutineNameReactor: Reactor {
     let initialState: State
 
     // MARK: - Init
-    init(saveRoutineUseCase: SaveRoutineUseCase) {
-        self.saveRoutineUseCase = saveRoutineUseCase
+    init() {
         self.initialState = State()
     }
 
@@ -35,11 +31,6 @@ final class RoutineNameReactor: Reactor {
         switch action {
         case let .setRoutineName(name):
             return .just(.setRoutineName(name))
-        case .saveRoutine:
-            let routine = WorkoutRoutine(name: currentState.routineName, workouts: [])
-            saveRoutineUseCase.execute(uid: "test-user", item: routine)
-            print("루틴명 저장 성공: \(routine.name)")
-            return .empty()
         }
     }
 

--- a/HowManySet/Presentation/Feature/RoutineName/RoutineNameView.swift
+++ b/HowManySet/Presentation/Feature/RoutineName/RoutineNameView.swift
@@ -81,13 +81,13 @@ private extension RoutineNameView {
         routineNameTF.snp.makeConstraints {
             $0.top.equalTo(titleLabel.snp.bottom).offset(16)
             $0.horizontalEdges.equalToSuperview().inset(28)
-            $0.height.equalToSuperview().multipliedBy(0.09)
+            $0.height.equalTo(56)
         }
 
         nextButton.snp.makeConstraints {
             $0.top.equalTo(routineNameTF.snp.bottom).offset(38)
             $0.horizontalEdges.equalToSuperview().inset(20)
-            $0.height.equalToSuperview().multipliedBy(0.09)
+            $0.height.equalTo(56)
         }
     }
 }

--- a/HowManySet/Presentation/Feature/RoutineName/RoutineNameViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineName/RoutineNameViewController.swift
@@ -57,9 +57,8 @@ extension RoutineNameViewController {
             .withLatestFrom(routineNameView.publicRoutineNameTF.rx.text.orEmpty)
             .bind(with: self) { owner, text in
                 reactor.action.onNext(.setRoutineName(text))
-                reactor.action.onNext(.saveRoutine)
                 owner.dismiss(animated: true) {
-                    owner.coordinator?.pushEditExcerciseView()
+                    owner.coordinator?.pushEditExcerciseView(routineName: text)
                 }
             }
             .disposed(by: disposeBag)


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  closed: #62 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- 루틴리스트 페이지에서 새 루틴 구성 클릭 시 루틴 명 작성
- 루틴 명 작성후 다음 버튼 클릭 시 운동 이름, 정보 입력가능
- 운동추가 버튼 클릭 시 현재 입력된 운동정보가 현재 운동 목록에 저장됨 alert 표시
- 저장되면 작성했던 기록 초기화
- 텍스트필드를 모두 채우지 않았다면 저장 실패 alert
- 현재 운동 목록에 리스트가 없는 경우 루틴 저장 버튼 클릭 시 alert 표시
- 운동 목록에 있는 경우 루틴 저장 버튼 클릭 시 dismiss


## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 이름 입력 후 Present | <img src = "https://github.com/user-attachments/assets/b86d446e-ee12-4e22-bf04-c215edc3d2d2" width ="250"> |
| 텍스트필드 모두 채워지지 않으면 저장 실패 Alert | <img src = "https://github.com/user-attachments/assets/4d02e0a5-2ed3-4937-88ec-0dab0ab2be57" width ="250"> |
| 세트 칸 제거해도 남은 세트 저장 | <img src = "https://github.com/user-attachments/assets/1e090906-2f2e-4b87-816b-c908df7d30f1" width ="250"> |
| 루틴저장 클릭 시 현재 저장된 목록이 있는 경우 dismiss | <img src = "https://github.com/user-attachments/assets/89f31ed5-b0d1-4bc3-8886-e52355f4190e" width ="250"> |


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
