### PR TITLE
Feature/#73 - DTO와 RealmDataModel 분리

### DIFF
--- a/HowManySet/Data/DTO/WorkoutDTO.swift
+++ b/HowManySet/Data/DTO/WorkoutDTO.swift
@@ -8,51 +8,13 @@
 import Foundation
 import RealmSwift
 
-/// 하나의 운동(workout)을 나타내는 Realm 객체입니다.
-/// 운동 이름, 세트 정보, 휴식 시간, 코멘트 등을 포함합니다.
-final class WorkoutDTO: Object {
-    /// 운동 이름입니다. 예: "벤치 프레스"
-    @Persisted var name: String
-
-    /// 운동에 대한 메모 또는 코멘트 (옵션)
-    @Persisted var comment: String?
-
-    /// 운동에 포함된 세트 목록입니다. `WorkoutSetDTO` 객체의 리스트입니다.
-    @Persisted var sets = List<WorkoutSetDTO>()
-
-    /// 세트 리스트를 배열 형태로 다룰 수 있도록 하는 계산 속성입니다.
-    var setArray: [WorkoutSetDTO] {
-        get {
-            return sets.map { $0 }
-        }
-        set {
-            sets.removeAll()
-            sets.append(objectsIn: newValue)
-        }
-    }
-
-    /// 주어진 값들로 `WorkoutDTO` 객체를 초기화합니다.
-    /// - Parameters:
-    ///   - name: 운동 이름
-    ///   - sets: 세트 배열
-    ///   - restTime: 세트 간 휴식 시간(초)
-    ///   - comment: 운동에 대한 메모 (옵션)
-    convenience init(
-        name: String,
-        sets: [WorkoutSetDTO],
-        restTime: Int,
-        comment: String? = nil
-    ) {
-        self.init()
-        self.name = name
-        self.comment = comment
-        self.setArray = sets
-    }
+struct WorkoutDTO {
+    var name: String
+    var comment: String?
+    var sets: [WorkoutSetDTO]
 }
 
 extension WorkoutDTO {
-    /// DTO 객체를 도메인 모델 `Workout`으로 변환합니다.
-    /// - Returns: 동일한 정보를 가진 `Workout` 도메인 객체
     func toEntity() -> Workout {
         return Workout(name: self.name,
                        sets: self.sets.map { $0.toEntity() },
@@ -61,13 +23,17 @@ extension WorkoutDTO {
 }
 
 extension WorkoutDTO {
-    /// 도메인 모델 `Workout`을 기반으로 `WorkoutDTO`를 초기화합니다.
-    /// - Parameter entity: 변환할 `Workout` 도메인 객체
-    convenience init(entity: Workout) {
-        self.init()
+    init(entity: Workout) {
         self.name = entity.name
         self.comment = entity.comment
-        self.setArray = entity.sets.map { WorkoutSetDTO(entity: $0) }
+        self.sets = entity.sets.map { WorkoutSetDTO(entity: $0) }
     }
 }
 
+extension WorkoutDTO {
+    init(from model: RMWorkout) {
+        self.name = model.name
+        self.comment = model.comment
+        self.sets = model.sets.map { WorkoutSetDTO(from: $0) }
+    }
+}

--- a/HowManySet/Data/DTO/WorkoutRecordDTO.swift
+++ b/HowManySet/Data/DTO/WorkoutRecordDTO.swift
@@ -8,51 +8,15 @@
 import Foundation
 import RealmSwift
 
-/// 운동 기록을 나타내는 Realm 객체입니다.
-/// 운동 루틴, 총 운동 시간, 실제 운동 시간, 날짜 및 코멘트 정보를 포함합니다.
-final class WorkoutRecordDTO: Object {
-    /// 기록된 운동 루틴입니다. `WorkoutRoutineDTO` 객체로 저장됩니다.
-    @Persisted var workoutRoutine: WorkoutRoutineDTO?
-
-    /// 전체 운동에 소요된 시간(초)입니다.
-    @Persisted var totalTime: Int
-
-    /// 실제 운동 수행 시간(초)입니다.
-    @Persisted var workoutTime: Int
-
-    /// 해당 운동 기록에 대한 메모 또는 코멘트 (옵션)
-    @Persisted var comment: String?
-
-    /// 운동이 수행된 날짜입니다.
-    @Persisted var date: Date
-
-    /// 주어진 값들로 `WorkoutRecordDTO` 객체를 초기화합니다.
-    /// - Parameters:
-    ///   - workoutRoutine: 기록된 운동 루틴
-    ///   - totalTime: 전체 운동 시간(초)
-    ///   - workoutTime: 실제 운동 시간(초)
-    ///   - comment: 운동에 대한 메모 (옵션)
-    ///   - date: 운동 수행 날짜
-    convenience init(
-        workoutRoutine: WorkoutRoutineDTO,
-        totalTime: Int,
-        workoutTime: Int,
-        comment: String? = nil,
-        date: Date
-    ) {
-        self.init()
-        self.workoutRoutine = workoutRoutine
-        self.totalTime = totalTime
-        self.workoutTime = workoutTime
-        self.comment = comment
-        self.date = date
-    }
+struct WorkoutRecordDTO {
+    var workoutRoutine: WorkoutRoutineDTO?
+    var totalTime: Int
+    var workoutTime: Int
+    var comment: String?
+    var date: Date
 }
 
 extension WorkoutRecordDTO {
-    /// DTO 객체를 도메인 모델 `WorkoutRecord`로 변환합니다.
-    /// - Returns: 동일한 정보를 가진 `WorkoutRecord` 도메인 객체
-    /// - Note: `workoutRoutine`이 `nil`일 경우, 이름이 "MOCK"인 빈 루틴으로 대체됩니다.
     func toEntity() -> WorkoutRecord {
         return WorkoutRecord(
             workoutRoutine: self.workoutRoutine?.toEntity()
@@ -66,14 +30,21 @@ extension WorkoutRecordDTO {
 }
 
 extension WorkoutRecordDTO {
-    /// 도메인 모델 `WorkoutRecord`를 기반으로 `WorkoutRecordDTO`를 초기화합니다.
-    /// - Parameter entity: 변환할 `WorkoutRecord` 도메인 객체
-    convenience init(entity: WorkoutRecord) {
-        self.init()
+    init(entity: WorkoutRecord) {
         self.workoutRoutine = WorkoutRoutineDTO(entity: entity.workoutRoutine)
         self.totalTime = entity.totalTime
         self.workoutTime = entity.workoutTime
         self.comment = entity.comment
         self.date = entity.date
+    }
+}
+
+extension WorkoutRecordDTO {
+    init(from model: RMWorkoutRecord) {
+        self.workoutRoutine = model.workoutRoutine?.toDTO()
+        self.totalTime = model.totalTime
+        self.workoutTime = model.workoutTime
+        self.comment = model.comment
+        self.date = model.date
     }
 }

--- a/HowManySet/Data/DTO/WorkoutRoutineDTO.swift
+++ b/HowManySet/Data/DTO/WorkoutRoutineDTO.swift
@@ -8,43 +8,13 @@
 import Foundation
 import RealmSwift
 
-/// 운동 루틴 정보를 나타내는 Realm 객체입니다.
-/// 루틴 이름과 포함된 운동 목록을 저장합니다.
-final class WorkoutRoutineDTO: Object {
-    /// 운동 루틴의 이름입니다. 예: "상체 루틴"
-    @Persisted var name: String
 
-    /// 루틴에 포함된 운동 목록입니다. `WorkoutDTO` 객체의 리스트로 구성됩니다.
-    @Persisted var workouts = List<WorkoutDTO>()
-
-    /// 운동 리스트를 배열 형태로 다룰 수 있도록 하는 계산 속성입니다.
-    var workoutArray: [WorkoutDTO] {
-        get {
-            return workouts.map { $0 }
-        }
-        set {
-            workouts.removeAll()
-            workouts.append(objectsIn: newValue)
-        }
-    }
-
-    /// 주어진 값들로 `WorkoutRoutineDTO` 객체를 초기화합니다.
-    /// - Parameters:
-    ///   - name: 루틴 이름
-    ///   - workouts: 포함된 운동들의 배열
-    convenience init(
-        name: String,
-        workouts: [WorkoutDTO]
-    ) {
-        self.init()
-        self.name = name
-        self.workoutArray = workouts
-    }
+struct WorkoutRoutineDTO {
+    var name: String
+    var workouts: [WorkoutDTO]
 }
 
 extension WorkoutRoutineDTO {
-    /// DTO 객체를 도메인 모델 `WorkoutRoutine`으로 변환합니다.
-    /// - Returns: 동일한 정보를 가진 `WorkoutRoutine` 도메인 객체
     func toEntity() -> WorkoutRoutine {
         return WorkoutRoutine(name: self.name,
                               workouts: self.workouts.map { $0.toEntity() })
@@ -52,11 +22,15 @@ extension WorkoutRoutineDTO {
 }
 
 extension WorkoutRoutineDTO {
-    /// 도메인 모델 `WorkoutRoutine`을 기반으로 `WorkoutRoutineDTO`를 초기화합니다.
-    /// - Parameter entity: 변환할 `WorkoutRoutine` 도메인 객체
-    convenience init(entity: WorkoutRoutine) {
-        self.init()
+    init(entity: WorkoutRoutine) {
         self.name = entity.name
-        self.workoutArray = entity.workouts.map { WorkoutDTO(entity: $0) }
+        self.workouts = entity.workouts.map { WorkoutDTO(entity: $0) }
+    }
+}
+
+extension WorkoutRoutineDTO {
+    init(from model: RMWorkoutRoutine) {
+        self.name = model.name
+        self.workouts = model.workouts.map{ WorkoutDTO(from: $0) }
     }
 }

--- a/HowManySet/Data/DTO/WorkoutSetDTO.swift
+++ b/HowManySet/Data/DTO/WorkoutSetDTO.swift
@@ -8,52 +8,31 @@
 import Foundation
 import RealmSwift
 
-/// 운동 세트의 정보를 나타내는 Realm 객체입니다.
-/// 무게, 단위, 반복 횟수를 포함합니다.
-final class WorkoutSetDTO: Object {
-    /// 세트에서 들어올린 무게입니다.
-    @Persisted var weight: Double
-
-    /// 무게의 단위입니다. 예: "kg", "lb"
-    @Persisted var unit: String
-
-    /// 해당 세트에서 수행한 반복 횟수입니다.
-    @Persisted var reps: Int
-
-    /// 주어진 값들로 `WorkoutSetDTO` 객체를 초기화합니다.
-    /// - Parameters:
-    ///   - weight: 들어올린 무게
-    ///   - unit: 무게의 단위
-    ///   - reps: 반복 횟수
-    convenience init(
-        weight: Double,
-        unit: String,
-        reps: Int
-    ) {
-        self.init()
-        self.weight = weight
-        self.unit = unit
-        self.reps = reps
-    }
+struct WorkoutSetDTO {
+    var weight: Double
+    var unit: String
+    var reps: Int
 }
 
 extension WorkoutSetDTO {
-    /// DTO 객체를 도메인 모델인 `WorkoutSet`으로 변환합니다.
-    /// - Returns: 동일한 값을 갖는 `WorkoutSet` 객체
     func toEntity() -> WorkoutSet {
         return WorkoutSet(weight: self.weight,
                           unit: self.unit,
                           reps: self.reps)
     }
 }
-
 extension WorkoutSetDTO {
-    /// 도메인 모델 `WorkoutSet`을 기반으로 `WorkoutSetDTO`를 초기화합니다.
-    /// - Parameter entity: 변환할 `WorkoutSet` 객체
-    convenience init(entity: WorkoutSet) {
-        self.init()
+    init(entity: WorkoutSet) {
         self.weight = entity.weight
         self.unit = entity.unit
         self.reps = entity.reps
+    }
+}
+
+extension WorkoutSetDTO {
+    init(from model: RMWorkoutSet) {
+        self.weight = model.weight
+        self.unit = model.unit
+        self.reps = model.reps
     }
 }

--- a/HowManySet/Data/PersistentStorages/Model/RMWorkout.swift
+++ b/HowManySet/Data/PersistentStorages/Model/RMWorkout.swift
@@ -1,0 +1,54 @@
+//
+//  RMWorkout.swift
+//  HowManySet
+//
+//  Created by MJ Dev on 6/3/25.
+//
+
+import Foundation
+import RealmSwift
+
+final class RMWorkout: Object {
+    @Persisted var name: String
+    @Persisted var comment: String?
+    @Persisted var sets = List<RMWorkoutSet>()
+
+    var setArray: [RMWorkoutSet] {
+        get {
+            return sets.map { $0 }
+        }
+        set {
+            sets.removeAll()
+            sets.append(objectsIn: newValue)
+        }
+    }
+    
+    convenience init(
+        name: String,
+        sets: [RMWorkoutSet],
+        restTime: Int,
+        comment: String? = nil
+    ) {
+        self.init()
+        self.name = name
+        self.comment = comment
+        self.setArray = sets
+    }
+}
+
+extension RMWorkout {
+    func toDTO() -> WorkoutDTO {
+        return WorkoutDTO(name: self.name,
+                          comment: self.comment,
+                          sets: self.sets.map { $0.toDTO() })
+    }
+}
+
+extension RMWorkout {
+    convenience init(dto: WorkoutDTO) {
+        self.init()
+        self.name = dto.name
+        self.comment = dto.comment
+        self.setArray = dto.sets.map{ RMWorkoutSet(dto: $0) }
+    }
+}

--- a/HowManySet/Data/PersistentStorages/Model/RMWorkoutRecord.swift
+++ b/HowManySet/Data/PersistentStorages/Model/RMWorkoutRecord.swift
@@ -1,0 +1,57 @@
+//
+//  WorkoutRecord.swift
+//  HowManySet
+//
+//  Created by MJ Dev on 6/3/25.
+//
+
+import Foundation
+import RealmSwift
+
+
+final class RMWorkoutRecord: Object {
+    @Persisted var workoutRoutine: RMWorkoutRoutine?
+    @Persisted var totalTime: Int
+    @Persisted var workoutTime: Int
+    @Persisted var comment: String?
+    @Persisted var date: Date
+
+    convenience init(
+        workoutRoutine: RMWorkoutRoutine,
+        totalTime: Int,
+        workoutTime: Int,
+        comment: String? = nil,
+        date: Date
+    ) {
+        self.init()
+        self.workoutRoutine = workoutRoutine
+        self.totalTime = totalTime
+        self.workoutTime = workoutTime
+        self.comment = comment
+        self.date = date
+    }
+}
+
+extension RMWorkoutRecord {
+    func toDTO() -> WorkoutRecordDTO {
+        return WorkoutRecordDTO(
+            workoutRoutine: self.workoutRoutine?.toDTO()
+            ?? WorkoutRoutineDTO(name: "MOCK", workouts: []),
+            totalTime: self.totalTime,
+            workoutTime: self.workoutTime,
+            comment: self.comment,
+            date: self.date
+        )
+    }
+}
+
+extension RMWorkoutRecord {
+    convenience init(dto: WorkoutRecordDTO) {
+        self.init()
+        self.workoutRoutine = RMWorkoutRoutine(dto: dto.workoutRoutine ?? WorkoutRoutineDTO(name: "MOCK", workouts: []))
+        self.totalTime = dto.totalTime
+        self.workoutTime = dto.workoutTime
+        self.comment = dto.comment
+        self.date = dto.date
+    }
+}

--- a/HowManySet/Data/PersistentStorages/Model/RMWorkoutRoutine.swift
+++ b/HowManySet/Data/PersistentStorages/Model/RMWorkoutRoutine.swift
@@ -1,0 +1,48 @@
+//
+//  WorkoutRoutineDTO.swift
+//  HowManySet
+//
+//  Created by MJ Dev on 6/3/25.
+//
+
+import Foundation
+import RealmSwift
+
+final class RMWorkoutRoutine: Object {
+
+    @Persisted var name: String
+    @Persisted var workouts = List<RMWorkout>()
+
+    var workoutArray: [RMWorkout] {
+        get {
+            return workouts.map { $0 }
+        }
+        set {
+            workouts.removeAll()
+            workouts.append(objectsIn: newValue)
+        }
+    }
+    convenience init(
+        name: String,
+        workouts: [RMWorkout]
+    ) {
+        self.init()
+        self.name = name
+        self.workoutArray = workouts
+    }
+}
+
+extension RMWorkoutRoutine {
+    func toDTO() -> WorkoutRoutineDTO {
+        return WorkoutRoutineDTO(name: self.name,
+                              workouts: self.workouts.map { $0.toDTO() })
+    }
+}
+
+extension RMWorkoutRoutine {
+    convenience init(dto: WorkoutRoutineDTO) {
+        self.init()
+        self.name = name
+        self.workoutArray = dto.workouts.map { RMWorkout(dto: $0) }
+    }
+}

--- a/HowManySet/Data/PersistentStorages/Model/RMWorkoutRoutine.swift
+++ b/HowManySet/Data/PersistentStorages/Model/RMWorkoutRoutine.swift
@@ -42,7 +42,7 @@ extension RMWorkoutRoutine {
 extension RMWorkoutRoutine {
     convenience init(dto: WorkoutRoutineDTO) {
         self.init()
-        self.name = name
+        self.name = dto.name
         self.workoutArray = dto.workouts.map { RMWorkout(dto: $0) }
     }
 }

--- a/HowManySet/Data/PersistentStorages/Model/RMWorkoutSet.swift
+++ b/HowManySet/Data/PersistentStorages/Model/RMWorkoutSet.swift
@@ -1,0 +1,44 @@
+//
+//  RMWorkoutSet.swift
+//  HowManySet
+//
+//  Created by MJ Dev on 6/3/25.
+//
+
+import Foundation
+import RealmSwift
+
+final class RMWorkoutSet: Object {
+    
+    @Persisted var weight: Double
+    @Persisted var unit: String
+    @Persisted var reps: Int
+
+    convenience init(
+        weight: Double,
+        unit: String,
+        reps: Int
+    ) {
+        self.init()
+        self.weight = weight
+        self.unit = unit
+        self.reps = reps
+    }
+}
+
+extension RMWorkoutSet {
+    func toDTO() -> WorkoutSetDTO {
+        return WorkoutSetDTO(weight: self.weight,
+                          unit: self.unit,
+                          reps: self.reps)
+    }
+}
+
+extension RMWorkoutSet {
+    convenience init(dto: WorkoutSetDTO) {
+        self.init()
+        self.weight = dto.weight
+        self.unit = dto.unit
+        self.reps = dto.reps
+    }
+}

--- a/HowManySet/Data/PersistentStorages/RealmDataType.swift
+++ b/HowManySet/Data/PersistentStorages/RealmDataType.swift
@@ -32,13 +32,13 @@ enum RealmDataType<T: Object>: RealmDataTypeProtocol {
     var type: T.Type {
         switch self {
         case .workoutSet:
-            return WorkoutSetDTO.self as! T.Type
+            return RMWorkoutSet.self as! T.Type
         case .workout:
-            return WorkoutDTO.self as! T.Type
+            return RMWorkout.self as! T.Type
         case .workoutRoutine:
-            return WorkoutRoutineDTO.self as! T.Type
+            return RMWorkoutRoutine.self as! T.Type
         case .workoutRecord:
-            return WorkoutRecordDTO.self as! T.Type
+            return RMWorkoutRecord.self as! T.Type
         }
     }
 }

--- a/HowManySet/Data/Repositories/RecordRepositoryImpl.swift
+++ b/HowManySet/Data/Repositories/RecordRepositoryImpl.swift
@@ -27,7 +27,7 @@ final class RecordRepositoryImpl: RecordRepository {
     ///   - item: 저장할 운동 기록 모델 (`WorkoutRecord`)
     func saveRecord(uid: String, item: WorkoutRecord) {
         // TODO: 운동 기록 저장 구현
-        let record = WorkoutRecordDTO(entity: item)
+        let record = RMWorkoutRecord(dto: WorkoutRecordDTO(entity: item))
         realmService.create(item: record)
     }
 
@@ -37,11 +37,12 @@ final class RecordRepositoryImpl: RecordRepository {
     /// - Returns: 운동 기록 배열을 성공 시 반환, 실패 시 `RealmErrorType.dataNotFound` 발생
     func fetchRecord(uid: String) -> Single<[WorkoutRecord]> {
         return Single.create { [weak self] observer in
-            guard let records = self?.realmService.read(type: .workoutRecord) as? [WorkoutRecordDTO] else {
+            guard let records = self?.realmService.read(type: .workoutRecord) else {
                 observer(.failure(RealmErrorType.dataNotFound))
                 return Disposables.create()
             }
-            observer(.success(records.map { $0.toEntity() }))
+            let recordDTO = records.map{ ($0 as! RMWorkoutRecord).toDTO() }
+            observer(.success(recordDTO.map { $0.toEntity() }))
             return Disposables.create()
         }
     }
@@ -51,7 +52,8 @@ final class RecordRepositoryImpl: RecordRepository {
     ///   - uid: 사용자 식별자 (현재 사용되지 않음)
     ///   - item: 삭제할 운동 기록 모델
     func deleteRecord(uid: String, item: WorkoutRecord) {
-        realmService.delete(item: WorkoutRecordDTO(entity: item))
+        let record = RMWorkoutRecord(dto: WorkoutRecordDTO(entity: item))
+        realmService.delete(item: record)
     }
 
     /// 모든 운동 루틴(기록 포함)을 삭제합니다.

--- a/HowManySet/Data/Repositories/RoutineRepositoryImpl.swift
+++ b/HowManySet/Data/Repositories/RoutineRepositoryImpl.swift
@@ -25,13 +25,14 @@ final class RoutineRepositoryImpl: RoutineRepository {
     /// - Returns: `Single`로 감싸진 `WorkoutRoutine` 배열, 조회 성공 시 배열을 방출하고 실패 시 에러를 방출합니다.
     func fetchRoutine(uid: String) -> Single<[WorkoutRoutine]> {
         return Single.create { [weak self] observer in
-            guard let routines = self?.realmService.read(type: .workoutRecord) as? [WorkoutRoutineDTO] else {
+            guard let routines = self?.realmService.read(type: .workoutRecord) else {
                 observer(.failure(RealmErrorType.dataNotFound))
                 return Disposables.create()
             }
-            
+             
+            let routineDTO: [WorkoutRoutineDTO] = routines.map{ ($0 as! RMWorkoutRoutine).toDTO()}
             // 예시: 빈 배열 반환
-            observer(.success(routines.map{$0.toEntity()}))
+            observer(.success(routineDTO.map{$0.toEntity()}))
             
             return Disposables.create()
         }
@@ -43,7 +44,7 @@ final class RoutineRepositoryImpl: RoutineRepository {
     ///   - uid: 운동 루틴을 삭제할 사용자의 고유 식별자
     ///   - item: 삭제할 `WorkoutRoutine` 객체
     func deleteRoutine(uid: String, item: WorkoutRoutine) {
-        let routine = WorkoutRoutineDTO(entity: item)
+        let routine = RMWorkoutRoutine(dto: WorkoutRoutineDTO(entity: item))
         realmService.delete(item: routine)
     }
     
@@ -53,7 +54,7 @@ final class RoutineRepositoryImpl: RoutineRepository {
     ///   - uid: 운동 루틴을 저장할 사용자의 고유 식별자
     ///   - item: 저장할 `WorkoutRoutine` 객체
     func saveRoutine(uid: String, item: WorkoutRoutine) {
-        let routine = WorkoutRoutineDTO(entity: item)
+        let routine = RMWorkoutRoutine(dto: WorkoutRoutineDTO(entity: item))
         realmService.create(item: routine)
     }
     
@@ -67,9 +68,9 @@ final class RoutineRepositoryImpl: RoutineRepository {
         let routines = realmService.read(type: .workoutRoutine)
         routines?.forEach{ object in
             realmService.update(item: object) { routine in
-                let data = routine as! WorkoutRoutineDTO
+                let data = routine as! RMWorkoutRoutine
                 if data.name == item.name {
-                    data.workoutArray = item.workouts.map{ WorkoutDTO(entity: $0) }
+                    data.workoutArray = item.workouts.map{ RMWorkout(dto: WorkoutDTO(entity: $0)) }
                 }
             }
         }

--- a/HowManySet/Domain/Entity/WorkoutRoutine.swift
+++ b/HowManySet/Domain/Entity/WorkoutRoutine.swift
@@ -16,7 +16,7 @@ struct WorkoutRoutine: Hashable {
     ///
     /// 예: `"전신 루틴"`, `"상체 집중 루틴"` 등
     let name: String
-    
+    let uid = UUID()
     /// 루틴에 포함된 운동 목록입니다.
     ///
     /// 각 `Workout`은 루틴을 구성하는 개별 운동을 나타냅니다.

--- a/HowManySetTests/Routine/FetchRoutineUseCaseTests.swift
+++ b/HowManySetTests/Routine/FetchRoutineUseCaseTests.swift
@@ -25,7 +25,7 @@ final class FetchRoutineUseCaseTests: XCTestCase {
     func test_저장된루틴이_정상적으로불러와지는가() {
         // given
         let routine = WorkoutRoutine(name: "test", workouts: [])
-        realmServiceStub.create(item: WorkoutRoutineDTO(entity: routine))
+        realmServiceStub.create(item: RMWorkoutRoutine(dto: WorkoutRoutineDTO(entity: routine)))
         
         // when
         let routines = realmServiceStub.read(type: .workoutRoutine)


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  Closed: #73 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- 이전에는 DTO파일이 RealmDataModel
- 파이어베이스 데이터모델도 사용하기 위해 DTO와 RMDataModel로 분리
- Entity <--> DTO <--> RMDataModel, FSDataModel Flow
- 데이터모델 변경에 따라 RepositoryImpl도 수정

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "" width ="250"> |

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
