### PR TITLE
Feature/#99 - Workout, Record, Routine UseCase와 Repository 수정 및 구현

### DIFF
--- a/HowManySet/App/Coordinator/HomeCoordinator.swift
+++ b/HowManySet/App/Coordinator/HomeCoordinator.swift
@@ -70,7 +70,7 @@ final class HomeCoordinator: HomeCoordinatorProtocol {
     /// 운동 카드 가운데 회색 버튼 클릭시 해당 운동 종목 편집 화면 present
     func presentEditExerciseView(
         routineName: String,
-        workoutStateForEdit: WorkoutStateForEdit,
+        workoutStateForEdit: WorkoutStateForEdit
     ) {
         let routineRepository = RoutineRepositoryImpl()
         let saveRoutineUseCase = SaveRoutineUseCase(repository: routineRepository)

--- a/HowManySet/Data/DTO/WorkoutDTO.swift
+++ b/HowManySet/Data/DTO/WorkoutDTO.swift
@@ -9,6 +9,7 @@ import Foundation
 import RealmSwift
 
 struct WorkoutDTO {
+    var id: String
     var name: String
     var comment: String?
     var sets: [WorkoutSetDTO]
@@ -17,6 +18,7 @@ struct WorkoutDTO {
 extension WorkoutDTO {
     func toEntity() -> Workout {
         return Workout(
+            id: self.id,
             name: self.name,
             sets: self.sets.map { $0.toEntity() },
             comment: self.comment)
@@ -25,6 +27,7 @@ extension WorkoutDTO {
 
 extension WorkoutDTO {
     init(entity: Workout) {
+        self.id = entity.id
         self.name = entity.name
         self.comment = entity.comment
         self.sets = entity.sets.map { WorkoutSetDTO(entity: $0) }
@@ -33,6 +36,7 @@ extension WorkoutDTO {
 
 extension WorkoutDTO {
     init(from model: RMWorkout) {
+        self.id = model.id
         self.name = model.name
         self.comment = model.comment
         self.sets = model.sets.map { WorkoutSetDTO(from: $0) }
@@ -41,6 +45,7 @@ extension WorkoutDTO {
 
 extension WorkoutDTO {
     init(from fsModel: FSWorkout) {
+        self.id = fsModel.id ?? ""
         self.name = fsModel.name
         self.comment = fsModel.comment
         self.sets = fsModel.sets.map { WorkoutSetDTO(from: $0) }
@@ -50,6 +55,7 @@ extension WorkoutDTO {
 extension WorkoutDTO {
     func toFSModel() -> FSWorkout {
         return FSWorkout(
+            rmID: self.id,
             name: self.name,
             sets: self.sets.map { $0.toFSModel() },
             comment: self.comment

--- a/HowManySet/Data/Firestore/Model/FSWorkout.swift
+++ b/HowManySet/Data/Firestore/Model/FSWorkout.swift
@@ -10,6 +10,7 @@ import FirebaseFirestore
 
 struct FSWorkout: Codable {
     @DocumentID var id: String?
+    var rmID: String?
     var name: String
     var comment: String?
     var sets: [FSWorkoutSet]
@@ -26,11 +27,15 @@ struct FSWorkout: Codable {
     }
     
     init(
+        // TODO: 검토 필요
+        rmID: String?,
         name: String,
         sets: [FSWorkoutSet],
         comment: String? = nil
     ) {
         self.id = nil
+        // TODO: 검토 필요
+        self.rmID = rmID
         self.name = name
         self.comment = comment
         self.sets = sets
@@ -42,6 +47,8 @@ struct FSWorkout: Codable {
 extension FSWorkout {
     func toDTO() -> WorkoutDTO {
         return WorkoutDTO(
+            // TODO: 검토 필요
+            id: self.rmID ?? "",
             name: self.name,
             comment: self.comment,
             sets: self.sets.map { $0.toDTO() }

--- a/HowManySet/Data/Firestore/Repositories/FSRecordRepositoryImpl.swift
+++ b/HowManySet/Data/Firestore/Repositories/FSRecordRepositoryImpl.swift
@@ -11,6 +11,10 @@ import RxSwift
 /// Firestore 기반 운동 기록 저장소 구현체입니다.
 /// 기존 RecordRepository 프로토콜을 구현하여 일관된 인터페이스를 제공합니다.
 final class FSRecordRepositoryImpl: RecordRepository {
+    func updateRecord(uid: String, item: WorkoutRecord) {
+        // TODO: 구현 필요
+    }
+    
     
     private let firestoreService: FirestoreServiceProtocol
 

--- a/HowManySet/Data/PersistentStorages/Model/RMWorkout.swift
+++ b/HowManySet/Data/PersistentStorages/Model/RMWorkout.swift
@@ -9,6 +9,7 @@ import Foundation
 import RealmSwift
 
 final class RMWorkout: Object {
+    @Persisted(primaryKey: true) var id: String
     @Persisted var name: String
     @Persisted var comment: String?
     @Persisted var sets = List<RMWorkoutSet>()
@@ -34,11 +35,16 @@ final class RMWorkout: Object {
         self.comment = comment
         self.setArray = sets
     }
+    
+    override static func primaryKey() -> String? {
+        return "id"
+    }
 }
 
 extension RMWorkout {
     func toDTO() -> WorkoutDTO {
         return WorkoutDTO(
+            id: self.id,
             name: self.name,
             comment: self.comment,
             sets: self.sets.map { $0.toDTO() })
@@ -48,6 +54,7 @@ extension RMWorkout {
 extension RMWorkout {
     convenience init(dto: WorkoutDTO) {
         self.init()
+        self.id = dto.id
         self.name = dto.name
         self.comment = dto.comment
         self.setArray = dto.sets.map{ RMWorkoutSet(dto: $0) }

--- a/HowManySet/Data/PersistentStorages/RealmDataType.swift
+++ b/HowManySet/Data/PersistentStorages/RealmDataType.swift
@@ -19,8 +19,6 @@ protocol RealmDataTypeProtocol {
 /// 다양한 Realm DTO 타입을 나타내는 열거형입니다.
 /// 타입 캐스팅을 통해 구체 타입 정보를 제공합니다.
 enum RealmDataType<T: Object>: RealmDataTypeProtocol {
-    /// WorkoutSetDTO 타입
-    case workoutSet
     /// WorkoutDTO 타입
     case workout
     /// WorkoutRoutineDTO 타입
@@ -31,8 +29,6 @@ enum RealmDataType<T: Object>: RealmDataTypeProtocol {
     /// 각 케이스에 해당하는 Realm 객체 타입 반환
     var type: T.Type {
         switch self {
-        case .workoutSet:
-            return RMWorkoutSet.self as! T.Type
         case .workout:
             return RMWorkout.self as! T.Type
         case .workoutRoutine:

--- a/HowManySet/Data/PersistentStorages/RealmService.swift
+++ b/HowManySet/Data/PersistentStorages/RealmService.swift
@@ -14,22 +14,13 @@ final class RealmService: RealmServiceProtocol {
     
     static let shared = RealmService()
     
-    /// Realm 인스턴스
-    private let realm: Realm
-    
-    private init() {
-        do {
-            realm = try Realm()
-        } catch {
-            print("RealmManager Realm Init Failed: \(error.localizedDescription)")
-            fatalError()
-        }
-    }
+    private init() { }
 
     /// Realm에 객체를 생성(저장)합니다.
     /// - Parameter item: 저장할 Realm 객체
     func create<T: Object>(item: T) {
         do {
+            let realm = try Realm()
             try realm.write {
                 realm.add(item)
             }
@@ -42,7 +33,8 @@ final class RealmService: RealmServiceProtocol {
     /// - Parameter type: 조회할 Realm 객체 타입 (`RealmDataType`)
     /// - Returns: 조회된 객체의 리스트 (`Results<T>`), 없으면 `nil`
     func read<T: Object>(type: RealmDataType<T>) -> Results<T>? {
-        return realm.objects(type.type)
+        let realm = try? Realm()
+        return realm?.objects(type.type)
     }
 
     /// Realm에서 특정 인덱스에 해당하는 객체를 조회합니다.
@@ -51,10 +43,11 @@ final class RealmService: RealmServiceProtocol {
     ///   - type: 조회할 Realm 객체 타입 (`RealmDataType`)
     /// - Returns: 조회된 객체가 존재하면 반환, 없으면 `nil`
     func read<T>(at index: Int, type: RealmDataType<T>) -> Object? {
-        if index >= realm.objects(type.type).count {
+        let realm = try? Realm()
+        if index >= realm?.objects(type.type).count ?? 0 {
             return nil
         }
-        return realm.objects(type.type)[index]
+        return realm?.objects(type.type)[index]
     }
 
     /// Realm에 저장된 객체를 업데이트합니다.
@@ -63,6 +56,7 @@ final class RealmService: RealmServiceProtocol {
     ///   - completion: 변경 사항을 적용할 클로저
     func update<T: Object>(item: T, completion: @escaping (T) -> Void) {
         do {
+            let realm = try Realm()
             try realm.write {
                 completion(item)
             }
@@ -74,7 +68,7 @@ final class RealmService: RealmServiceProtocol {
     /// Realm에서 특정 객체를 삭제합니다.
     /// - Parameter item: 삭제할 Realm 객체
     func delete<T: Object>(item: T) {
-        let realm = try! Realm()
+        let realm = try? Realm()
         guard let primaryKey = T.primaryKey() else {
             print("⚠️ \(T.self)는 primaryKey가 없어서 안전한 삭제가 불가능합니다.")
             return
@@ -85,13 +79,13 @@ final class RealmService: RealmServiceProtocol {
             print("⚠️ 객체에서 primary key 값을 가져올 수 없습니다.")
             return
         }
-        guard let objToDelete = realm.object(ofType: T.self, forPrimaryKey: keyValue) else {
+        guard let objToDelete = realm?.object(ofType: T.self, forPrimaryKey: keyValue) else {
             print("❌ Realm에 해당 객체가 존재하지 않습니다.")
             return
         }
         do {
-            try realm.write {
-                realm.delete(objToDelete)
+            try realm?.write {
+                realm?.delete(objToDelete)
             }
         } catch {
             print("delete Failed: \(error.localizedDescription)")
@@ -102,6 +96,7 @@ final class RealmService: RealmServiceProtocol {
     /// - Parameter type: 삭제할 Realm 객체 타입 (`RealmDataType`)
     func deleteAll<T: Object>(type: RealmDataType<T>) {
         do {
+            let realm = try Realm()
             try realm.write {
                 if let datas = read(type: type) {
                     realm.delete(datas)
@@ -115,6 +110,7 @@ final class RealmService: RealmServiceProtocol {
     /// Realm에 저장된 모든 객체를 삭제합니다.
     func deleteAll() {
         do {
+            let realm = try Realm()
             try realm.write {
                 realm.deleteAll()
             }

--- a/HowManySet/Data/PersistentStorages/RealmService.swift
+++ b/HowManySet/Data/PersistentStorages/RealmService.swift
@@ -36,6 +36,16 @@ final class RealmService: RealmServiceProtocol {
         let realm = try? Realm()
         return realm?.objects(type.type)
     }
+    
+    func read<T: Object>(type: RealmDataType<T>, primaryKey: String) -> Object? {
+        do {
+            let realm = try Realm()
+            guard let data = realm.object(ofType: type.type.self, forPrimaryKey: primaryKey) else { return nil }
+            return data
+        } catch {
+            return nil
+        }
+    }
 
     /// Realm에서 특정 인덱스에 해당하는 객체를 조회합니다.
     /// - Parameters:

--- a/HowManySet/Data/Repositories/RecordRepositoryImpl.swift
+++ b/HowManySet/Data/Repositories/RecordRepositoryImpl.swift
@@ -16,7 +16,7 @@ final class RecordRepositoryImpl: RecordRepository {
     /// - Parameters:
     ///   - uid: 사용자 식별자 (현재 사용되지 않음, 확장 가능성 대비)
     ///   - item: 저장할 운동 기록 모델 (`WorkoutRecord`)
-    func saveRecord(item: WorkoutRecord) {
+    func saveRecord(uid: String, item: WorkoutRecord) {
         // TODO: 운동 기록 저장 구현
         let record = RMWorkoutRecord(dto: WorkoutRecordDTO(entity: item))
         RealmService.shared.create(item: record)
@@ -26,7 +26,7 @@ final class RecordRepositoryImpl: RecordRepository {
     /// RxSwift의 Single로 비동기 데이터를 반환합니다.
     /// - Parameter uid: 사용자 식별자 (현재 사용되지 않음, 향후 사용자별 데이터 필터링에 활용 가능)
     /// - Returns: 운동 기록 배열을 성공 시 반환, 실패 시 `RealmErrorType.dataNotFound` 발생
-    func fetchRecord() -> Single<[WorkoutRecord]> {
+    func fetchRecord(uid: String) -> Single<[WorkoutRecord]> {
         return Single.create { observer in
             guard let records = RealmService.shared.read(type: .workoutRecord) else {
                 observer(.failure(RealmErrorType.dataNotFound))
@@ -42,18 +42,18 @@ final class RecordRepositoryImpl: RecordRepository {
     /// - Parameters:
     ///   - uid: 사용자 식별자 (현재 사용되지 않음)
     ///   - item: 삭제할 운동 기록 모델
-    func deleteRecord(item: WorkoutRecord) {
+    func deleteRecord(uid: String, item: WorkoutRecord) {
         let record = RMWorkoutRecord(dto: WorkoutRecordDTO(entity: item))
         RealmService.shared.delete(item: record)
     }
 
     /// 모든 운동 루틴(기록 포함)을 삭제합니다.
     /// - Parameter uid: 사용자 식별자 (현재 사용되지 않음)
-    func deleteAllRecord() {
+    func deleteAllRecord(uid: String) {
         RealmService.shared.deleteAll(type: .workoutRecord)
     }
     
-    func updateRecord(item: WorkoutRecord) {
+    func updateRecord(uid: String, item: WorkoutRecord) {
         if let record = RealmService.shared.read(type: .workoutRecord) as? RMWorkoutRecord {
             RealmService.shared.update(item: record) { (savedRecord: RMWorkoutRecord) in
                 savedRecord.comment = item.comment

--- a/HowManySet/Data/Repositories/RecordRepositoryImpl.swift
+++ b/HowManySet/Data/Repositories/RecordRepositoryImpl.swift
@@ -16,7 +16,7 @@ final class RecordRepositoryImpl: RecordRepository {
     /// - Parameters:
     ///   - uid: 사용자 식별자 (현재 사용되지 않음, 확장 가능성 대비)
     ///   - item: 저장할 운동 기록 모델 (`WorkoutRecord`)
-    func saveRecord(uid: String, item: WorkoutRecord) {
+    func saveRecord(item: WorkoutRecord) {
         // TODO: 운동 기록 저장 구현
         let record = RMWorkoutRecord(dto: WorkoutRecordDTO(entity: item))
         RealmService.shared.create(item: record)
@@ -26,7 +26,7 @@ final class RecordRepositoryImpl: RecordRepository {
     /// RxSwift의 Single로 비동기 데이터를 반환합니다.
     /// - Parameter uid: 사용자 식별자 (현재 사용되지 않음, 향후 사용자별 데이터 필터링에 활용 가능)
     /// - Returns: 운동 기록 배열을 성공 시 반환, 실패 시 `RealmErrorType.dataNotFound` 발생
-    func fetchRecord(uid: String) -> Single<[WorkoutRecord]> {
+    func fetchRecord() -> Single<[WorkoutRecord]> {
         return Single.create { observer in
             guard let records = RealmService.shared.read(type: .workoutRecord) else {
                 observer(.failure(RealmErrorType.dataNotFound))
@@ -42,18 +42,18 @@ final class RecordRepositoryImpl: RecordRepository {
     /// - Parameters:
     ///   - uid: 사용자 식별자 (현재 사용되지 않음)
     ///   - item: 삭제할 운동 기록 모델
-    func deleteRecord(uid: String, item: WorkoutRecord) {
+    func deleteRecord(item: WorkoutRecord) {
         let record = RMWorkoutRecord(dto: WorkoutRecordDTO(entity: item))
         RealmService.shared.delete(item: record)
     }
 
     /// 모든 운동 루틴(기록 포함)을 삭제합니다.
     /// - Parameter uid: 사용자 식별자 (현재 사용되지 않음)
-    func deleteAllRecord(uid: String) {
+    func deleteAllRecord() {
         RealmService.shared.deleteAll(type: .workoutRecord)
     }
     
-    func updateRecord(uid: String, item: WorkoutRecord) {
+    func updateRecord(item: WorkoutRecord) {
         if let record = RealmService.shared.read(type: .workoutRecord) as? RMWorkoutRecord {
             RealmService.shared.update(item: record) { (savedRecord: RMWorkoutRecord) in
                 savedRecord.comment = item.comment

--- a/HowManySet/Data/Repositories/RecordRepositoryImpl.swift
+++ b/HowManySet/Data/Repositories/RecordRepositoryImpl.swift
@@ -27,7 +27,7 @@ final class RecordRepositoryImpl: RecordRepository {
     /// - Parameter uid: 사용자 식별자 (현재 사용되지 않음, 향후 사용자별 데이터 필터링에 활용 가능)
     /// - Returns: 운동 기록 배열을 성공 시 반환, 실패 시 `RealmErrorType.dataNotFound` 발생
     func fetchRecord(uid: String) -> Single<[WorkoutRecord]> {
-        return Single.create { [weak self] observer in
+        return Single.create { observer in
             guard let records = RealmService.shared.read(type: .workoutRecord) else {
                 observer(.failure(RealmErrorType.dataNotFound))
                 return Disposables.create()
@@ -52,4 +52,17 @@ final class RecordRepositoryImpl: RecordRepository {
     func deleteAllRecord(uid: String) {
         RealmService.shared.deleteAll(type: .workoutRecord)
     }
+    
+    func updateRecord(uid: String, item: WorkoutRecord) {
+        if let record = RealmService.shared.read(type: .workoutRecord) as? RMWorkoutRecord {
+            RealmService.shared.update(item: record) { (savedRecord: RMWorkoutRecord) in
+                savedRecord.comment = item.comment
+                savedRecord.date = item.date
+                savedRecord.totalTime = item.totalTime
+                savedRecord.workoutRoutine = RMWorkoutRoutine(dto: WorkoutRoutineDTO(entity: item.workoutRoutine))
+                savedRecord.workoutTime = item.workoutTime
+            }
+        }
+    }
+    
 }

--- a/HowManySet/Data/Repositories/RoutineRepositoryImpl.swift
+++ b/HowManySet/Data/Repositories/RoutineRepositoryImpl.swift
@@ -16,7 +16,7 @@ final class RoutineRepositoryImpl: RoutineRepository {
     /// 주어진 사용자 ID에 해당하는 운동 루틴 리스트를 비동기적으로 조회합니다.
     ///
     /// - Returns: `Single`로 감싸진 `WorkoutRoutine` 배열, 조회 성공 시 배열을 방출하고 실패 시 에러를 방출합니다.
-    func fetchRoutine() -> Single<[WorkoutRoutine]> {
+    func fetchRoutine(uid: String) -> Single<[WorkoutRoutine]> {
         return Single.create { observer in
             guard let routines = RealmService.shared.read(type: .workoutRoutine) else {
                 observer(.failure(RealmErrorType.dataNotFound))

--- a/HowManySet/Data/Repositories/RoutineRepositoryImpl.swift
+++ b/HowManySet/Data/Repositories/RoutineRepositoryImpl.swift
@@ -15,9 +15,8 @@ final class RoutineRepositoryImpl: RoutineRepository {
     
     /// 주어진 사용자 ID에 해당하는 운동 루틴 리스트를 비동기적으로 조회합니다.
     ///
-    /// - Parameter uid: 운동 루틴을 조회할 사용자의 고유 식별자
     /// - Returns: `Single`로 감싸진 `WorkoutRoutine` 배열, 조회 성공 시 배열을 방출하고 실패 시 에러를 방출합니다.
-    func fetchRoutine(uid: String) -> Single<[WorkoutRoutine]> {
+    func fetchRoutine() -> Single<[WorkoutRoutine]> {
         return Single.create { observer in
             guard let routines = RealmService.shared.read(type: .workoutRoutine) else {
                 observer(.failure(RealmErrorType.dataNotFound))
@@ -35,7 +34,6 @@ final class RoutineRepositoryImpl: RoutineRepository {
     /// 주어진 사용자 ID에 해당하는 운동 루틴을 삭제합니다.
     ///
     /// - Parameters:
-    ///   - uid: 운동 루틴을 삭제할 사용자의 고유 식별자
     ///   - item: 삭제할 `WorkoutRoutine` 객체
     func deleteRoutine(uid: String, item: WorkoutRoutine) {
         let routine = RMWorkoutRoutine(dto: WorkoutRoutineDTO(entity: item))
@@ -45,7 +43,6 @@ final class RoutineRepositoryImpl: RoutineRepository {
     /// 주어진 사용자 ID에 해당하는 운동 루틴을 저장합니다.
     ///
     /// - Parameters:
-    ///   - uid: 운동 루틴을 저장할 사용자의 고유 식별자
     ///   - item: 저장할 `WorkoutRoutine` 객체
     func saveRoutine(uid: String, item: WorkoutRoutine) {
         let routine = RMWorkoutRoutine(dto: WorkoutRoutineDTO(entity: item))
@@ -55,7 +52,6 @@ final class RoutineRepositoryImpl: RoutineRepository {
     /// 주어진 사용자 ID에 해당하는 운동 루틴을 수정합니다.
     ///
     /// - Parameters:
-    ///   - uid: 운동 루틴을 수정할 사용자의 고유 식별자
     ///   - item: 수정할 `WorkoutRoutine` 객체 덮어쓰기
     func updateRoutine(uid: String, item: WorkoutRoutine) {
         if let routine = RealmService.shared.read(type: .workoutRoutine,

--- a/HowManySet/Data/Repositories/RoutineRepositoryImpl.swift
+++ b/HowManySet/Data/Repositories/RoutineRepositoryImpl.swift
@@ -18,7 +18,7 @@ final class RoutineRepositoryImpl: RoutineRepository {
     /// - Parameter uid: 운동 루틴을 조회할 사용자의 고유 식별자
     /// - Returns: `Single`로 감싸진 `WorkoutRoutine` 배열, 조회 성공 시 배열을 방출하고 실패 시 에러를 방출합니다.
     func fetchRoutine(uid: String) -> Single<[WorkoutRoutine]> {
-        return Single.create { [weak self] observer in
+        return Single.create { observer in
             guard let routines = RealmService.shared.read(type: .workoutRoutine) else {
                 observer(.failure(RealmErrorType.dataNotFound))
                 return Disposables.create()
@@ -61,7 +61,7 @@ final class RoutineRepositoryImpl: RoutineRepository {
         if let routine = RealmService.shared.read(type: .workoutRoutine,
                                                   primaryKey: item.id)
             as? RMWorkoutRoutine {
-            RealmService.shared.update(item: routine) { savedRoutine in
+            RealmService.shared.update(item: routine) { (savedRoutine: RMWorkoutRoutine) in
                 savedRoutine.name = item.name
                 savedRoutine.workoutArray = item.workouts.map{ RMWorkout(dto: WorkoutDTO(entity: $0)) }
             }

--- a/HowManySet/Data/Repositories/RoutineRepositoryImpl.swift
+++ b/HowManySet/Data/Repositories/RoutineRepositoryImpl.swift
@@ -23,7 +23,7 @@ final class RoutineRepositoryImpl: RoutineRepository {
                 observer(.failure(RealmErrorType.dataNotFound))
                 return Disposables.create()
             }
-             
+            
             let routineDTO: [WorkoutRoutineDTO] = routines.map{ ($0 as! RMWorkoutRoutine).toDTO()}
             // 예시: 빈 배열 반환
             observer(.success(routineDTO.map{$0.toEntity()}))
@@ -58,14 +58,12 @@ final class RoutineRepositoryImpl: RoutineRepository {
     ///   - uid: 운동 루틴을 수정할 사용자의 고유 식별자
     ///   - item: 수정할 `WorkoutRoutine` 객체 덮어쓰기
     func updateRoutine(uid: String, item: WorkoutRoutine) {
-        // TODO: 운동 루틴 수정 구현 (테스트 필요)
-        let routines = RealmService.shared.read(type: .workoutRoutine)
-        routines?.forEach{ object in
-            RealmService.shared.update(item: object) { routine in
-                let data = routine as! RMWorkoutRoutine
-                if data.name == item.name {
-                    data.workoutArray = item.workouts.map{ RMWorkout(dto: WorkoutDTO(entity: $0)) }
-                }
+        if let routine = RealmService.shared.read(type: .workoutRoutine,
+                                                  primaryKey: item.id)
+            as? RMWorkoutRoutine {
+            RealmService.shared.update(item: routine) { savedRoutine in
+                savedRoutine.name = item.name
+                savedRoutine.workoutArray = item.workouts.map{ RMWorkout(dto: WorkoutDTO(entity: $0)) }
             }
         }
     }

--- a/HowManySet/Data/Repositories/UserSettingRepositoryImpl.swift
+++ b/HowManySet/Data/Repositories/UserSettingRepositoryImpl.swift
@@ -11,11 +11,11 @@ import RxSwift
 // 대략적으로 세팅
 final class UserSettingRepositoryImpl: UserSettingRepository {
     
-    func fetchUserSetting(uid: String) -> Single<UserSetting> {
+    func fetchUserSetting() -> Single<UserSetting> {
         return Single<UserSetting>.just(UserSetting(pushNotificationEnabled: false, unit: "metric", darkmode: true, locale: "ko_KR"))
     }
     
-    func saveUserSetting(uid: String, settings: UserSetting) {
+    func saveUserSetting(settings: UserSetting) {
 
     }
     

--- a/HowManySet/Data/Repositories/UserSettingRepositoryImpl.swift
+++ b/HowManySet/Data/Repositories/UserSettingRepositoryImpl.swift
@@ -11,11 +11,11 @@ import RxSwift
 // 대략적으로 세팅
 final class UserSettingRepositoryImpl: UserSettingRepository {
     
-    func fetchUserSetting() -> Single<UserSetting> {
+    func fetchUserSetting(uid: String) -> Single<UserSetting> {
         return Single<UserSetting>.just(UserSetting(pushNotificationEnabled: false, unit: "metric", darkmode: true, locale: "ko_KR"))
     }
     
-    func saveUserSetting(settings: UserSetting) {
+    func saveUserSetting(uid: String, settings: UserSetting) {
 
     }
     

--- a/HowManySet/Data/Repositories/WorkoutRepositoryImpl.swift
+++ b/HowManySet/Data/Repositories/WorkoutRepositoryImpl.swift
@@ -1,0 +1,20 @@
+//
+//  WorkoutRepositoryImpl.swift
+//  HowManySet
+//
+//  Created by MJ Dev on 6/23/25.
+//
+
+import Foundation
+
+final class WorkoutRepositoryImpl: WorkoutRepository {
+    func updateWorkout(uid: String, workout: Workout) {
+        if let workout = RealmService.shared.read(type: .workout, primaryKey: workout.id) as? RMWorkout {
+            RealmService.shared.update(item: workout) { savedWorkout in
+                savedWorkout.name = workout.name
+                savedWorkout.comment = workout.comment
+                savedWorkout.sets = workout.sets
+            }
+        }
+    }
+}

--- a/HowManySet/Data/Repositories/WorkoutRepositoryImpl.swift
+++ b/HowManySet/Data/Repositories/WorkoutRepositoryImpl.swift
@@ -17,7 +17,7 @@ final class WorkoutRepositoryImpl: WorkoutRepository {
     
     func updateWorkout(uid: String, workout: Workout) {
         if let workout = RealmService.shared.read(type: .workout, primaryKey: workout.id) as? RMWorkout {
-            RealmService.shared.update(item: workout) { savedWorkout in
+            RealmService.shared.update(item: workout) { (savedWorkout: RMWorkout) in
                 savedWorkout.name = workout.name
                 savedWorkout.comment = workout.comment
                 savedWorkout.sets = workout.sets

--- a/HowManySet/Data/Repositories/WorkoutRepositoryImpl.swift
+++ b/HowManySet/Data/Repositories/WorkoutRepositoryImpl.swift
@@ -9,13 +9,13 @@ import Foundation
 
 final class WorkoutRepositoryImpl: WorkoutRepository {
     
-    func deleteWorkout(uid: String, workout: Workout) {
+    func deleteWorkout(workout: Workout) {
         if let workout = RealmService.shared.read(type: .workout, primaryKey: workout.id) as? RMWorkout {
             RealmService.shared.delete(item: workout)
         }
     }
     
-    func updateWorkout(uid: String, workout: Workout) {
+    func updateWorkout(workout: Workout) {
         if let workout = RealmService.shared.read(type: .workout, primaryKey: workout.id) as? RMWorkout {
             RealmService.shared.update(item: workout) { (savedWorkout: RMWorkout) in
                 savedWorkout.name = workout.name

--- a/HowManySet/Data/Repositories/WorkoutRepositoryImpl.swift
+++ b/HowManySet/Data/Repositories/WorkoutRepositoryImpl.swift
@@ -8,6 +8,13 @@
 import Foundation
 
 final class WorkoutRepositoryImpl: WorkoutRepository {
+    
+    func deleteWorkout(uid: String, workout: Workout) {
+        if let workout = RealmService.shared.read(type: .workout, primaryKey: workout.id) as? RMWorkout {
+            RealmService.shared.delete(item: workout)
+        }
+    }
+    
     func updateWorkout(uid: String, workout: Workout) {
         if let workout = RealmService.shared.read(type: .workout, primaryKey: workout.id) as? RMWorkout {
             RealmService.shared.update(item: workout) { savedWorkout in

--- a/HowManySet/Data/Repositories/WorkoutRepositoryImpl.swift
+++ b/HowManySet/Data/Repositories/WorkoutRepositoryImpl.swift
@@ -9,13 +9,13 @@ import Foundation
 
 final class WorkoutRepositoryImpl: WorkoutRepository {
     
-    func deleteWorkout(workout: Workout) {
+    func deleteWorkout(uid: String, workout: Workout) {
         if let workout = RealmService.shared.read(type: .workout, primaryKey: workout.id) as? RMWorkout {
             RealmService.shared.delete(item: workout)
         }
     }
     
-    func updateWorkout(workout: Workout) {
+    func updateWorkout(uid: String, workout: Workout) {
         if let workout = RealmService.shared.read(type: .workout, primaryKey: workout.id) as? RMWorkout {
             RealmService.shared.update(item: workout) { (savedWorkout: RMWorkout) in
                 savedWorkout.name = workout.name

--- a/HowManySet/Domain/Entity/Workout.swift
+++ b/HowManySet/Domain/Entity/Workout.swift
@@ -11,7 +11,7 @@ import Foundation
 ///
 /// 이 구조체는 특정 운동의 이름, 세트 목록, 세트 간 휴식 시간, 그리고 선택적인 코멘트를 포함합니다.
 struct Workout: Hashable {
-    
+    var id: String
     /// 운동 이름입니다.
     ///
     /// 예: `"벤치프레스"`, `"스쿼트"` 등
@@ -32,6 +32,7 @@ struct Workout: Hashable {
 extension Workout {
     static let mockData: [Workout] = [
         Workout(
+            id: UUID().uuidString,
             name: "벤치프레스",
             sets: [
                 WorkoutSet(weight: 60, unit: "kg", reps: 10),
@@ -41,6 +42,7 @@ extension Workout {
             comment: "폼에 집중하기"
         ),
         Workout(
+            id: UUID().uuidString,
             name: "스쿼트",
             sets: [
                 WorkoutSet(weight: 80, unit: "kg", reps: 10),
@@ -50,6 +52,7 @@ extension Workout {
             comment: "무릎 조심"
         ),
         Workout(
+            id: UUID().uuidString,
             name: "데드리프트",
             sets: [
                 WorkoutSet(weight: 90, unit: "kg", reps: 8),
@@ -58,6 +61,7 @@ extension Workout {
             comment: "허리 고정"
         ),
         Workout(
+            id: UUID().uuidString,
             name: "체스트 프레스",
             sets: [
                 WorkoutSet(weight: 40, unit: "kg", reps: 12),
@@ -66,6 +70,7 @@ extension Workout {
             comment: nil
         ),
         Workout(
+            id: UUID().uuidString,
             name: "랫풀 다운",
             sets: [
                 WorkoutSet(weight: 40, unit: "kg", reps: 12),

--- a/HowManySet/Domain/Repositories/RecordRepository.swift
+++ b/HowManySet/Domain/Repositories/RecordRepository.swift
@@ -33,5 +33,7 @@ protocol RecordRepository {
     /// 사용자의 모든 운동 기록을 삭제합니다.
     /// - Parameter uid: 사용자 식별자
     func deleteAllRecord(uid: String)
+    
+    func updateRecord(uid: String, item: WorkoutRecord)
 }
 

--- a/HowManySet/Domain/Repositories/RecordRepository.swift
+++ b/HowManySet/Domain/Repositories/RecordRepository.swift
@@ -37,3 +37,27 @@ protocol RecordRepository {
     func updateRecord(uid: String, item: WorkoutRecord)
 }
 
+// MARK: Realm Repository
+extension RecordRepository {
+    
+    func saveRecord(uid: String = "", item: WorkoutRecord) {
+        saveRecord(uid: uid, item: item)
+    }
+    
+    func fetchRecord(uid: String = "") -> Single<[WorkoutRecord]> {
+        return fetchRecord(uid: uid)
+    }
+    
+    func deleteRecord(uid: String = "", item: WorkoutRecord) {
+        return deleteRecord(uid: uid, item: item)
+    }
+    
+    func deleteAllRecord(uid: String = "") {
+        deleteAllRecord(uid: uid)
+    }
+    
+    func updateRecord(uid: String = "", item: WorkoutRecord) {
+        updateRecord(uid: uid, item: item)
+    }
+}
+

--- a/HowManySet/Domain/Repositories/RecordRepository.swift
+++ b/HowManySet/Domain/Repositories/RecordRepository.swift
@@ -40,24 +40,24 @@ protocol RecordRepository {
 // MARK: Realm Repository
 extension RecordRepository {
     
-    func saveRecord(uid: String = "", item: WorkoutRecord) {
-        saveRecord(uid: uid, item: item)
+    func saveRecord(item: WorkoutRecord) {
+        saveRecord(uid: "", item: item)
     }
     
-    func fetchRecord(uid: String = "") -> Single<[WorkoutRecord]> {
-        return fetchRecord(uid: uid)
+    func fetchRecord() -> Single<[WorkoutRecord]> {
+        return fetchRecord(uid: "")
     }
     
-    func deleteRecord(uid: String = "", item: WorkoutRecord) {
-        return deleteRecord(uid: uid, item: item)
+    func deleteRecord(item: WorkoutRecord) {
+        deleteRecord(uid: "", item: item)
     }
     
-    func deleteAllRecord(uid: String = "") {
-        deleteAllRecord(uid: uid)
+    func deleteAllRecord() {
+        deleteAllRecord(uid: "")
     }
     
-    func updateRecord(uid: String = "", item: WorkoutRecord) {
-        updateRecord(uid: uid, item: item)
+    func updateRecord(item: WorkoutRecord) {
+        updateRecord(uid: "", item: item)
     }
 }
 

--- a/HowManySet/Domain/Repositories/RoutineRepository.swift
+++ b/HowManySet/Domain/Repositories/RoutineRepository.swift
@@ -40,3 +40,23 @@ protocol RoutineRepository {
     ///   - item: 수정할 `WorkoutRoutine` 객체
     func updateRoutine(uid: String, item: WorkoutRoutine)
 }
+
+// MARK: Realm Repository
+extension RoutineRepository {
+    
+    func fetchRoutine(uid: String = "") -> Single<[WorkoutRoutine]> {
+        return fetchRoutine(uid: uid)
+    }
+    
+    func deleteRoutine(uid: String = "", item: WorkoutRoutine) {
+        deleteRoutine(uid: uid, item: item)
+    }
+    
+    func saveRoutine(uid: String = "", item: WorkoutRoutine) {
+        saveRoutine(uid: uid, item: item)
+    }
+    
+    func updateRoutine(uid: String = "", item: WorkoutRoutine) {
+        updateRoutine(uid: uid, item: item)
+    }
+}

--- a/HowManySet/Domain/Repositories/RoutineRepository.swift
+++ b/HowManySet/Domain/Repositories/RoutineRepository.swift
@@ -44,19 +44,19 @@ protocol RoutineRepository {
 // MARK: Realm Repository
 extension RoutineRepository {
     
-    func fetchRoutine(uid: String = "") -> Single<[WorkoutRoutine]> {
-        return fetchRoutine(uid: uid)
+    func fetchRoutine() -> Single<[WorkoutRoutine]> {
+        return fetchRoutine(uid: "")
     }
     
-    func deleteRoutine(uid: String = "", item: WorkoutRoutine) {
-        deleteRoutine(uid: uid, item: item)
+    func deleteRoutine(item: WorkoutRoutine) {
+        deleteRoutine(uid: "", item: item)
     }
     
-    func saveRoutine(uid: String = "", item: WorkoutRoutine) {
-        saveRoutine(uid: uid, item: item)
+    func saveRoutine(item: WorkoutRoutine) {
+        saveRoutine(uid: "", item: item)
     }
     
-    func updateRoutine(uid: String = "", item: WorkoutRoutine) {
-        updateRoutine(uid: uid, item: item)
+    func updateRoutine(item: WorkoutRoutine) {
+        updateRoutine(uid: "", item: item)
     }
 }

--- a/HowManySet/Domain/Repositories/UserSettingRepository.swift
+++ b/HowManySet/Domain/Repositories/UserSettingRepository.swift
@@ -27,3 +27,13 @@ protocol UserSettingRepository {
     func saveUserSetting(uid: String, settings: UserSetting)
 }
 
+// MARK: Realm Repository
+extension UserSettingRepository {
+    func fetchUserSetting(uid: String = "") -> Single<UserSetting> {
+        return fetchUserSetting(uid: uid)
+    }
+    
+    func saveUserSetting(uid: String = "", settings: UserSetting) {
+        saveUserSetting(uid: uid, settings: settings)
+    }
+}

--- a/HowManySet/Domain/Repositories/UserSettingRepository.swift
+++ b/HowManySet/Domain/Repositories/UserSettingRepository.swift
@@ -29,11 +29,11 @@ protocol UserSettingRepository {
 
 // MARK: Realm Repository
 extension UserSettingRepository {
-    func fetchUserSetting(uid: String = "") -> Single<UserSetting> {
-        return fetchUserSetting(uid: uid)
+    func fetchUserSetting() -> Single<UserSetting> {
+        return fetchUserSetting(uid: "")
     }
     
-    func saveUserSetting(uid: String = "", settings: UserSetting) {
-        saveUserSetting(uid: uid, settings: settings)
+    func saveUserSetting(settings: UserSetting) {
+        saveUserSetting(uid: "", settings: settings)
     }
 }

--- a/HowManySet/Domain/Repositories/WorkoutRepository.swift
+++ b/HowManySet/Domain/Repositories/WorkoutRepository.swift
@@ -15,10 +15,10 @@ protocol WorkoutRepository {
 // MARK: Realm Repository
 
 extension  WorkoutRepository {
-    func updateWorkout(uid: String = "", workout: Workout) {
-        updateWorkout(uid: uid, workout: workout)
+    func updateWorkout(workout: Workout) {
+        updateWorkout(uid: "", workout: workout)
     }
-    func deleteWorkout(uid: String = "", workout: Workout) {
-        deleteWorkout(uid: uid, workout: workout)
+    func deleteWorkout(workout: Workout) {
+        deleteWorkout(uid: "", workout: workout)
     }
 }

--- a/HowManySet/Domain/Repositories/WorkoutRepository.swift
+++ b/HowManySet/Domain/Repositories/WorkoutRepository.swift
@@ -9,4 +9,5 @@ import Foundation
 
 protocol WorkoutRepository {
     func updateWorkout(uid: String, workout: Workout)
+    func deleteWorkout(uid: String, workout: Workout)
 }

--- a/HowManySet/Domain/Repositories/WorkoutRepository.swift
+++ b/HowManySet/Domain/Repositories/WorkoutRepository.swift
@@ -1,0 +1,12 @@
+//
+//  WorkoutRepository.swift
+//  HowManySet
+//
+//  Created by MJ Dev on 6/23/25.
+//
+
+import Foundation
+
+protocol WorkoutRepository {
+    func updateWorkout(uid: String, workout: Workout)
+}

--- a/HowManySet/Domain/Repositories/WorkoutRepository.swift
+++ b/HowManySet/Domain/Repositories/WorkoutRepository.swift
@@ -11,3 +11,14 @@ protocol WorkoutRepository {
     func updateWorkout(uid: String, workout: Workout)
     func deleteWorkout(uid: String, workout: Workout)
 }
+
+// MARK: Realm Repository
+
+extension  WorkoutRepository {
+    func updateWorkout(uid: String = "", workout: Workout) {
+        updateWorkout(uid: uid, workout: workout)
+    }
+    func deleteWorkout(uid: String = "", workout: Workout) {
+        deleteWorkout(uid: uid, workout: workout)
+    }
+}

--- a/HowManySet/Domain/UseCase/Protocols/Record/DeleteAllRecordUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/Record/DeleteAllRecordUseCaseProtocol.swift
@@ -12,7 +12,11 @@ import Foundation
 protocol DeleteAllRecordUseCaseProtocol {
     
     /// 사용자의 모든 운동 기록을 삭제합니다.
-    /// - Parameter uid: 사용자 식별자
     func execute(uid: String)
 }
 
+extension DeleteAllRecordUseCaseProtocol {
+    func execute(uid: String = "") {
+        execute(uid: uid)
+    }
+}

--- a/HowManySet/Domain/UseCase/Protocols/Record/DeleteRecordUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/Record/DeleteRecordUseCaseProtocol.swift
@@ -13,7 +13,12 @@ protocol DeleteRecordUseCaseProtocol {
     
     /// 특정 운동 기록을 삭제합니다.
     /// - Parameters:
-    ///   - uid: 사용자 식별자
     ///   - item: 삭제할 운동 기록
     func execute(uid: String, item: WorkoutRecord)
+}
+
+extension DeleteRecordUseCaseProtocol {
+    func execute(uid: String = "", item: WorkoutRecord) {
+        execute(uid: uid, item: item)
+    }
 }

--- a/HowManySet/Domain/UseCase/Protocols/Record/FetchRecordUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/Record/FetchRecordUseCaseProtocol.swift
@@ -15,7 +15,12 @@ protocol FetchRecordUseCaseProtocol {
     
     /// 주어진 사용자 ID에 해당하는 운동 기록 리스트를 비동기적으로 가져옵니다.
     ///
-    /// - Parameter uid: 운동 기록을 조회할 사용자의 고유 식별자
     /// - Returns: `Single`로 감싸진 `WorkoutRecord` 배열, 조회 성공 시 배열을 방출하고 실패 시 에러를 방출합니다.
     func execute(uid: String) -> Single<[WorkoutRecord]>
+}
+
+extension FetchRecordUseCaseProtocol {
+    func execute(uid: String = "") -> Single<[WorkoutRecord]> {
+        return execute(uid: uid)
+    }
 }

--- a/HowManySet/Domain/UseCase/Protocols/Record/SaveRecordUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/Record/SaveRecordUseCaseProtocol.swift
@@ -19,3 +19,9 @@ protocol SaveRecordUseCaseProtocol {
     ///   - item: 저장할 `WorkoutRecord` 객체
     func execute(uid: String, item: WorkoutRecord)
 }
+
+extension SaveRecordUseCaseProtocol {
+    func execute(uid: String = "", item: WorkoutRecord) {
+        execute(uid: uid, item: item)
+    }
+}

--- a/HowManySet/Domain/UseCase/Protocols/Record/UpdateRecordUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/Record/UpdateRecordUseCaseProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  UpdateRecordUseCaseProtocol.swift
+//  HowManySet
+//
+//  Created by MJ Dev on 6/23/25.
+//
+
+import Foundation
+
+protocol UpdateRecordUseCaseProtocol {
+    func execute(uid: String, item: WorkoutRecord)
+}

--- a/HowManySet/Domain/UseCase/Protocols/Record/UpdateRecordUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/Record/UpdateRecordUseCaseProtocol.swift
@@ -10,3 +10,9 @@ import Foundation
 protocol UpdateRecordUseCaseProtocol {
     func execute(uid: String, item: WorkoutRecord)
 }
+
+extension UpdateRecordUseCaseProtocol {
+    func execute(uid: String = "", item: WorkoutRecord) {
+        execute(uid: uid, item: item)
+    }
+}

--- a/HowManySet/Domain/UseCase/Protocols/Routine/DeleteRoutineUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/Routine/DeleteRoutineUseCaseProtocol.swift
@@ -15,7 +15,12 @@ protocol DeleteRoutineUseCaseProtocol {
     /// 주어진 사용자 ID에 해당하는 운동 루틴을 삭제합니다.
     ///
     /// - Parameters:
-    ///   - uid: 운동 루틴을 삭제할 사용자의 고유 식별자
     ///   - item: 삭제할 `WorkoutRoutine` 객체
     func execute(uid: String, item: WorkoutRoutine)
+}
+
+extension DeleteRoutineUseCaseProtocol {
+    func execute(uid: String = "", item: WorkoutRoutine) {
+        execute(uid: uid, item: item)
+    }
 }

--- a/HowManySet/Domain/UseCase/Protocols/Routine/FetchRoutineUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/Routine/FetchRoutineUseCaseProtocol.swift
@@ -15,7 +15,12 @@ protocol FetchRoutineUseCaseProtocol {
     
     /// 주어진 사용자 ID에 해당하는 운동 루틴 리스트를 비동기적으로 가져옵니다.
     ///
-    /// - Parameter uid: 운동 루틴을 조회할 사용자의 고유 식별자
     /// - Returns: `Single`로 감싸진 `WorkoutRoutine` 배열, 조회 성공 시 배열을 방출하고 실패 시 에러를 방출합니다.
     func execute(uid: String) -> Single<[WorkoutRoutine]>
+}
+
+extension FetchRoutineUseCaseProtocol {
+    func execute(uid: String = "") -> Single<[WorkoutRoutine]> {
+        return execute(uid: uid)
+    }
 }

--- a/HowManySet/Domain/UseCase/Protocols/Routine/SaveRoutineUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/Routine/SaveRoutineUseCaseProtocol.swift
@@ -15,7 +15,12 @@ protocol SaveRoutineUseCaseProtocol {
     /// 주어진 사용자 ID에 해당하는 운동 루틴을 저장합니다.
     ///
     /// - Parameters:
-    ///   - uid: 운동 루틴을 저장할 사용자의 고유 식별자
     ///   - item: 저장할 `WorkoutRoutine` 객체
     func execute(uid: String, item: WorkoutRoutine)
+}
+
+extension SaveRoutineUseCaseProtocol {
+    func execute(uid: String = "", item: WorkoutRoutine) {
+        execute(uid: uid, item: item)
+    }
 }

--- a/HowManySet/Domain/UseCase/Protocols/Routine/UpdateRoutineUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/Routine/UpdateRoutineUseCaseProtocol.swift
@@ -13,7 +13,12 @@ protocol UpdateRoutineUseCaseProtocol {
     
     /// 특정 사용자의 운동 루틴을 업데이트합니다.
     /// - Parameters:
-    ///   - uid: 사용자 식별자
     ///   - item: 업데이트할 운동 루틴
     func execute(uid: String, item: WorkoutRoutine)
+}
+
+extension UpdateRoutineUseCaseProtocol {
+    func execute(uid: String = "", item: WorkoutRoutine) {
+        execute(uid: uid, item: item)
+    }
 }

--- a/HowManySet/Domain/UseCase/Protocols/UserPage/FetchUserSettingUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/UserPage/FetchUserSettingUseCaseProtocol.swift
@@ -20,3 +20,8 @@ protocol FetchUserSettingUseCaseProtocol {
     func execute(uid: String) -> Single<UserSetting>
 }
 
+extension FetchUserSettingUseCaseProtocol {
+    func execute(uid: String = "") -> Single<UserSetting> {
+        return execute(uid: uid)
+    }
+}

--- a/HowManySet/Domain/UseCase/Protocols/UserPage/SaveUserSettingUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/UserPage/SaveUserSettingUseCaseProtocol.swift
@@ -15,7 +15,12 @@ protocol SaveUserSettingUseCaseProtocol {
     /// 주어진 사용자 ID에 해당하는 사용자 설정 정보를 저장합니다.
     ///
     /// - Parameters:
-    ///   - uid: 설정 정보를 저장할 사용자의 고유 식별자
     ///   - settings: 저장할 `UserSetting` 객체
     func execute(uid: String, settings: UserSetting)
+}
+
+extension SaveUserSettingUseCaseProtocol {
+    func execute(uid: String = "", settings: UserSetting) {
+        execute(uid: uid, settings: settings)
+    }
 }

--- a/HowManySet/Domain/UseCase/Protocols/Workout/DeleteWorkoutUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/Workout/DeleteWorkoutUseCaseProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  DeleteWorkoutUseCaseProtocol.swift
+//  HowManySet
+//
+//  Created by MJ Dev on 6/23/25.
+//
+
+import Foundation
+
+protocol DeleteWorkoutUseCaseProtocol {
+    func excute(uid: String, item: Workout)
+}

--- a/HowManySet/Domain/UseCase/Protocols/Workout/DeleteWorkoutUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/Workout/DeleteWorkoutUseCaseProtocol.swift
@@ -10,3 +10,9 @@ import Foundation
 protocol DeleteWorkoutUseCaseProtocol {
     func execute(uid: String, item: Workout)
 }
+
+extension DeleteWorkoutUseCaseProtocol {
+    func execute(uid: String = "", item: Workout) {
+        execute(uid: uid, item: item)
+    }
+}

--- a/HowManySet/Domain/UseCase/Protocols/Workout/DeleteWorkoutUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/Workout/DeleteWorkoutUseCaseProtocol.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 protocol DeleteWorkoutUseCaseProtocol {
-    func excute(uid: String, item: Workout)
+    func execute(uid: String, item: Workout)
 }

--- a/HowManySet/Domain/UseCase/Protocols/Workout/UpdateWorkoutUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/Workout/UpdateWorkoutUseCaseProtocol.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 protocol UpdateWorkoutUseCaseProtocol {
-    func excute(uid: String, item: Workout)
+    func execute(uid: String, item: Workout)
 }

--- a/HowManySet/Domain/UseCase/Protocols/Workout/UpdateWorkoutUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/Workout/UpdateWorkoutUseCaseProtocol.swift
@@ -10,3 +10,9 @@ import Foundation
 protocol UpdateWorkoutUseCaseProtocol {
     func execute(uid: String, item: Workout)
 }
+
+extension UpdateWorkoutUseCaseProtocol {
+    func execute(uid: String = "", item: Workout) {
+        execute(uid: uid, item: item)
+    }
+}

--- a/HowManySet/Domain/UseCase/Protocols/Workout/UpdateWorkoutUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/Workout/UpdateWorkoutUseCaseProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  UpdateWorkoutUseCaseProtocol.swift
+//  HowManySet
+//
+//  Created by MJ Dev on 6/23/25.
+//
+
+import Foundation
+
+protocol UpdateWorkoutUseCaseProtocol {
+    func excute(uid: String, item: Workout)
+}

--- a/HowManySet/Domain/UseCase/Record/DeleteAllRecordUseCase.swift
+++ b/HowManySet/Domain/UseCase/Record/DeleteAllRecordUseCase.swift
@@ -21,9 +21,8 @@ final class DeleteAllRecordUseCase: DeleteAllRecordUseCaseProtocol {
     }
 
     /// 사용자의 모든 운동 기록을 삭제합니다.
-    /// - Parameter uid: 사용자 식별자
-    func execute(uid: String) {
-        repository.deleteAllRecord(uid: uid)
+    func execute() {
+        repository.deleteAllRecord()
     }
 }
 

--- a/HowManySet/Domain/UseCase/Record/DeleteRecordUseCase.swift
+++ b/HowManySet/Domain/UseCase/Record/DeleteRecordUseCase.swift
@@ -22,9 +22,8 @@ final class DeleteRecordUseCase: DeleteRecordUseCaseProtocol {
 
     /// 특정 운동 기록을 삭제합니다.
     /// - Parameters:
-    ///   - uid: 사용자 식별자
     ///   - item: 삭제할 운동 기록
-    func execute(uid: String, item: WorkoutRecord) {
-        repository.deleteRecord(uid: uid, item: item)
+    func execute(item: WorkoutRecord) {
+        repository.deleteRecord(item: item)
     }
 }

--- a/HowManySet/Domain/UseCase/Record/FetchRecordUseCase.swift
+++ b/HowManySet/Domain/UseCase/Record/FetchRecordUseCase.swift
@@ -24,10 +24,8 @@ final class FetchRecordUseCase: FetchRecordUseCaseProtocol {
     }
     
     /// 주어진 사용자 ID에 해당하는 운동 기록 리스트를 비동기적으로 조회합니다.
-    ///
-    /// - Parameter uid: 운동 기록을 조회할 사용자의 고유 식별자
     /// - Returns: `Single`로 감싸진 `WorkoutRecord` 배열, 조회 성공 시 배열을 방출하고 실패 시 에러를 방출합니다.
-    func execute(uid: String) -> Single<[WorkoutRecord]> {
-        return repository.fetchRecord(uid: uid)
+    func execute() -> Single<[WorkoutRecord]> {
+        return repository.fetchRecord()
     }
 }

--- a/HowManySet/Domain/UseCase/Record/SaveRecordUseCase.swift
+++ b/HowManySet/Domain/UseCase/Record/SaveRecordUseCase.swift
@@ -25,9 +25,8 @@ final class SaveRecordUseCase: SaveRecordUseCaseProtocol {
     /// 주어진 사용자 ID에 해당하는 운동 기록을 저장합니다.
     ///
     /// - Parameters:
-    ///   - uid: 운동 기록을 저장할 사용자의 고유 식별자
     ///   - item: 저장할 `WorkoutRecord` 객체
-    func execute(uid: String, item: WorkoutRecord) {
-        repository.saveRecord(uid: uid, item: item)
+    func execute(item: WorkoutRecord) {
+        repository.saveRecord(item: item)
     }
 }

--- a/HowManySet/Domain/UseCase/Record/UpdateRecordUseCase.swift
+++ b/HowManySet/Domain/UseCase/Record/UpdateRecordUseCase.swift
@@ -14,7 +14,7 @@ final class UpdateRecordUseCase: UpdateRecordUseCaseProtocol {
         self.repository = repository
     }
     
-    func execute(uid: String, item: WorkoutRecord) {
-        repository.updateRecord(uid: uid, item: item)
+    func execute(item: WorkoutRecord) {
+        repository.updateRecord(item: item)
     }
 }

--- a/HowManySet/Domain/UseCase/Record/UpdateRecordUseCase.swift
+++ b/HowManySet/Domain/UseCase/Record/UpdateRecordUseCase.swift
@@ -1,0 +1,20 @@
+//
+//  UpdateRecordUseCase.swift
+//  HowManySet
+//
+//  Created by MJ Dev on 6/23/25.
+//
+
+import Foundation
+
+final class UpdateRecordUseCase: UpdateRecordUseCaseProtocol {
+    private let repository: RecordRepository
+    
+    init(repository: RecordRepository) {
+        self.repository = repository
+    }
+    
+    func execute(uid: String, item: WorkoutRecord) {
+        repository.updateRecord(uid: uid, item: item)
+    }
+}

--- a/HowManySet/Domain/UseCase/Routine/DeleteRoutineUseCase.swift
+++ b/HowManySet/Domain/UseCase/Routine/DeleteRoutineUseCase.swift
@@ -25,10 +25,9 @@ final class DeleteRoutineUseCase: DeleteRoutineUseCaseProtocol {
     /// 주어진 사용자 ID에 해당하는 운동 루틴을 삭제합니다.
     ///
     /// - Parameters:
-    ///   - uid: 운동 루틴을 삭제할 사용자의 고유 식별자
     ///   - item: 삭제할 `WorkoutRoutine` 객체
-    func execute(uid: String, item: WorkoutRoutine) {
-        repository.deleteRoutine(uid: uid, item: item)
+    func execute(item: WorkoutRoutine) {
+        repository.deleteRoutine(item: item)
     }
 }
 

--- a/HowManySet/Domain/UseCase/Routine/FetchRoutineUseCase.swift
+++ b/HowManySet/Domain/UseCase/Routine/FetchRoutineUseCase.swift
@@ -25,10 +25,9 @@ final class FetchRoutineUseCase: FetchRoutineUseCaseProtocol {
     
     /// 주어진 사용자 ID에 해당하는 운동 루틴 리스트를 비동기적으로 조회합니다.
     ///
-    /// - Parameter uid: 운동 루틴을 조회할 사용자의 고유 식별자
     /// - Returns: `Single`로 감싸진 `WorkoutRoutine` 배열, 조회 성공 시 배열을 방출하고 실패 시 에러를 방출합니다.
-    func execute(uid: String) -> Single<[WorkoutRoutine]> {
-        return repository.fetchRoutine(uid: uid)
+    func execute() -> Single<[WorkoutRoutine]> {
+        return repository.fetchRoutine()
     }
 }
 

--- a/HowManySet/Domain/UseCase/Routine/SaveRoutineUseCase.swift
+++ b/HowManySet/Domain/UseCase/Routine/SaveRoutineUseCase.swift
@@ -25,10 +25,9 @@ final class SaveRoutineUseCase: SaveRoutineUseCaseProtocol {
     /// 주어진 사용자 ID에 해당하는 운동 루틴을 저장합니다.
     ///
     /// - Parameters:
-    ///   - uid: 운동 루틴을 저장할 사용자의 고유 식별자
     ///   - item: 저장할 `WorkoutRoutine` 객체
-    func execute(uid: String, item: WorkoutRoutine) {
-        repository.saveRoutine(uid: uid, item: item)
+    func execute(item: WorkoutRoutine) {
+        repository.saveRoutine(item: item)
     }
 }
 

--- a/HowManySet/Domain/UseCase/Routine/UpdateRoutineUseCase.swift
+++ b/HowManySet/Domain/UseCase/Routine/UpdateRoutineUseCase.swift
@@ -22,10 +22,9 @@ final class UpdateRoutineUseCase: UpdateRoutineUseCaseProtocol {
 
     /// 특정 사용자의 운동 루틴을 업데이트합니다.
     /// - Parameters:
-    ///   - uid: 사용자 식별자
     ///   - item: 업데이트할 운동 루틴
-    func execute(uid: String, item: WorkoutRoutine) {
-        repository.updateRoutine(uid: uid, item: item)
+    func execute(item: WorkoutRoutine) {
+        repository.updateRoutine(item: item)
     }
 }
 

--- a/HowManySet/Domain/UseCase/Workout/DeleteWorkoutUseCase.swift
+++ b/HowManySet/Domain/UseCase/Workout/DeleteWorkoutUseCase.swift
@@ -15,7 +15,7 @@ final class DeleteWorkoutUseCase: DeleteWorkoutUseCaseProtocol {
         self.repository = repository
     }
     
-    func excute(uid: String, item: Workout) {
+    func execute(uid: String, item: Workout) {
         repository.deleteWorkout(uid: uid, workout: item)
     }
 }

--- a/HowManySet/Domain/UseCase/Workout/DeleteWorkoutUseCase.swift
+++ b/HowManySet/Domain/UseCase/Workout/DeleteWorkoutUseCase.swift
@@ -1,0 +1,21 @@
+//
+//  DeleteWorkoutUseCase.swift
+//  HowManySet
+//
+//  Created by MJ Dev on 6/23/25.
+//
+
+import Foundation
+
+final class DeleteWorkoutUseCase: DeleteWorkoutUseCaseProtocol {
+    
+    private let repository: WorkoutRepository
+    
+    init(repository: WorkoutRepository) {
+        self.repository = repository
+    }
+    
+    func excute(uid: String, item: Workout) {
+        repository.deleteWorkout(uid: uid, workout: item)
+    }
+}

--- a/HowManySet/Domain/UseCase/Workout/DeleteWorkoutUseCase.swift
+++ b/HowManySet/Domain/UseCase/Workout/DeleteWorkoutUseCase.swift
@@ -15,7 +15,7 @@ final class DeleteWorkoutUseCase: DeleteWorkoutUseCaseProtocol {
         self.repository = repository
     }
     
-    func execute(uid: String, item: Workout) {
-        repository.deleteWorkout(uid: uid, workout: item)
+    func execute(item: Workout) {
+        repository.deleteWorkout(workout: item)
     }
 }

--- a/HowManySet/Domain/UseCase/Workout/UpdateWorkoutUseCase.swift
+++ b/HowManySet/Domain/UseCase/Workout/UpdateWorkoutUseCase.swift
@@ -15,7 +15,7 @@ final class UpdateWorkoutUseCase: UpdateWorkoutUseCaseProtocol {
         self.repository = repository
     }
     
-    func excute(uid: String, item: Workout) {
+    func execute(uid: String, item: Workout) {
         repository.updateWorkout(uid: uid, workout: item)
     }
 }

--- a/HowManySet/Domain/UseCase/Workout/UpdateWorkoutUseCase.swift
+++ b/HowManySet/Domain/UseCase/Workout/UpdateWorkoutUseCase.swift
@@ -1,0 +1,21 @@
+//
+//  UpdateWorkoutUseCase.swift
+//  HowManySet
+//
+//  Created by MJ Dev on 6/23/25.
+//
+
+import Foundation
+
+final class UpdateWorkoutUseCase: UpdateWorkoutUseCaseProtocol {
+    
+    private let repository: WorkoutRepository
+    
+    init(repository: WorkoutRepository) {
+        self.repository = repository
+    }
+    
+    func excute(uid: String, item: Workout) {
+        repository.updateWorkout(uid: uid, workout: item)
+    }
+}

--- a/HowManySet/Domain/UseCase/Workout/UpdateWorkoutUseCase.swift
+++ b/HowManySet/Domain/UseCase/Workout/UpdateWorkoutUseCase.swift
@@ -15,7 +15,7 @@ final class UpdateWorkoutUseCase: UpdateWorkoutUseCaseProtocol {
         self.repository = repository
     }
     
-    func execute(uid: String, item: Workout) {
-        repository.updateWorkout(uid: uid, workout: item)
+    func execute(item: Workout) {
+        repository.updateWorkout(workout: item)
     }
 }

--- a/HowManySet/Presentation/Feature/EditExcercise/Reactor/EditExcerciseViewReactor.swift
+++ b/HowManySet/Presentation/Feature/EditExcercise/Reactor/EditExcerciseViewReactor.swift
@@ -167,7 +167,7 @@ final class EditExcerciseViewReactor: Reactor {
             
         case .saveRoutine:
             // TODO: 실제 저장 시 UID 입력 필요
-            saveRoutineUseCase.execute(uid: "", item: newState.currentRoutine)
+            saveRoutineUseCase.execute(item: newState.currentRoutine)
             
         case .changeExcerciseName(let newName):
             newState.currentExcerciseName = newName

--- a/HowManySet/Presentation/Feature/EditExcercise/Reactor/EditExcerciseViewReactor.swift
+++ b/HowManySet/Presentation/Feature/EditExcercise/Reactor/EditExcerciseViewReactor.swift
@@ -116,6 +116,7 @@ final class EditExcerciseViewReactor: Reactor {
                 }
                 
                 let newWorkout = Workout(
+                    id: UUID().uuidString,
                     name: self.currentState.currentExcerciseName,
                     sets: sets,
                     comment: nil

--- a/HowManySet/Presentation/Feature/EditRoutine/Reactor/EditRoutineViewReactor.swift
+++ b/HowManySet/Presentation/Feature/EditRoutine/Reactor/EditRoutineViewReactor.swift
@@ -71,7 +71,7 @@ final class EditRoutineViewReactor: Reactor {
         case .reorderWorkout(source: let source, destination: let destination):
             var new = currentState.routine
             new.workouts.swapAt(source.item, destination.item)
-            deleteRoutineUseCase.execute(uid: "", item: currentState.routine)
+            deleteRoutineUseCase.execute(item: currentState.routine)
             return .just(.reorderRoutine(new))
         }
     }
@@ -90,10 +90,10 @@ final class EditRoutineViewReactor: Reactor {
         case .removeSelectedWorkout:
             var newRoutine = newState.routine
             guard let workout = currentState.currentSeclectedWorkout else { return newState }
-            deleteRoutineUseCase.execute(uid: "", item: currentState.routine)
+            deleteRoutineUseCase.execute(item: currentState.routine)
             guard let indexPath = currentState.currentSeclectedIndexPath else { return newState }
             newRoutine.workouts.remove(at: indexPath.row)
-            saveRoutineUseCase.execute(uid: "", item: newRoutine)
+            saveRoutineUseCase.execute(item: newRoutine)
             newState.routine = newRoutine
         case .changeListOrder:
             break
@@ -101,7 +101,7 @@ final class EditRoutineViewReactor: Reactor {
             break
         case .reorderRoutine(let routine):
             var newRoutine = routine
-            saveRoutineUseCase.execute(uid: "", item: routine)
+            saveRoutineUseCase.execute(item: routine)
         }
         return newState
     }

--- a/HowManySet/Presentation/Feature/Home/Reactor/HomeViewReactor.swift
+++ b/HowManySet/Presentation/Feature/Home/Reactor/HomeViewReactor.swift
@@ -752,6 +752,7 @@ private extension HomeViewReactor {
     func convertWorkoutCardStatesToWorkouts(cardStates: [WorkoutCardState]) -> [Workout] {
         return cardStates.map { card in
             Workout(
+                id: UUID().uuidString,
                 name: card.currentExerciseName,
                 sets: card.setInfo,
                 comment: card.memoInExercise

--- a/HowManySet/Presentation/Feature/RoutineList/Reactor/RoutineListViewReactor.swift
+++ b/HowManySet/Presentation/Feature/RoutineList/Reactor/RoutineListViewReactor.swift
@@ -40,7 +40,7 @@ final class RoutineListViewReactor: Reactor {
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case .viewWillAppear:
-            return fetchRoutineUseCase.execute(uid: "")
+            return fetchRoutineUseCase.execute()
                 .map{ Mutation.updatedRoutine($0) }
                 .asObservable()
         }
@@ -56,7 +56,7 @@ final class RoutineListViewReactor: Reactor {
                 if !routines[i].workouts.isEmpty {
                     newRoutines.append(routines[i])
                 } else {
-                    deleteRoutineUseCase.execute(uid: "", item: routines[i])
+                    deleteRoutineUseCase.execute(item: routines[i])
                 }
             }
             


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  closed: #99 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- Workout Update,Delete UseCase와 Repository 구현
- Routine Update Repository 수정
- Record Update UseCase, Repository 구현
- Workout Fetch, Save UseCase를 구현하지 않은 이유: Workout은 Routine단위로 저장하므로 Routine에 추가하여 Routine을 업데이트
- Workout에 PrimaryKey를 추가하여 해당 키를 바탕으로 조회할 수 있음
- 전체적으로 사용방식은 해당 데이터에 접근하여 데이터의 속성을 변경하는 것이 아닌, 변경한 데이터를 덮어쓰는 방식
- 덮어씌울 수 있는 데이터 단위 (WorkoutRecord, WorkoutRoutine, Workout)
- Realm UseCase uid 인자까지 모두 제거하고, FireBase도 같은 Repository 사용하도록 protocol 확장
## Usage
```swift
let updateRecordUseCase = UpdateRecordUseCase(repository: RecordRepositoryImpl())
let updateRoutineUseCase = UpdateRoutineUseCase(repository: RoutineRepositoryImpl())
let updateWorkoutUseCase = UpdateWorkoutUseCase(repository: WorkoutRepositoryImpl())
let deleteWorkoutUseCase = DeleteWorkoutUseCase(repository: WorkoutRepositoryImpl())

//
// 기록 수정 코드작성 (ex: comment 변경)
//
updateRecordUseCase.execute(item: 변경할 기록 데이터)

//
// 운동루틴 수정 코드 작성 (ex: name 변경, 운동항목 변경, 메모 작성)
//
updateRoutineUseCase.execute(item: 변경할 운동루틴 데이터)

//
// 운동 수정 코드 작성 (ex: 세트, 개수 변경, 이름변경)
//
updateWorkoutUseCase.execute(item: 변경할 운동 데이터)

//
// 삭제할 운동 데이터를 구하기 (model: Workout)
//
deleteWorkoutUseCase.execute(item: 삭제할 운동 데이터)

``` 
