### PR TITLE
Fix/#103 - protocol extension으로 인한 무한루프 현상 해결

### DIFF
--- a/HowManySet/Domain/Repositories/WorkoutRepository.swift
+++ b/HowManySet/Domain/Repositories/WorkoutRepository.swift
@@ -14,7 +14,7 @@ protocol WorkoutRepository {
 
 // MARK: Realm Repository
 
-extension  WorkoutRepository {
+extension WorkoutRepository {
     func updateWorkout(workout: Workout) {
         updateWorkout(uid: "", workout: workout)
     }

--- a/HowManySet/Domain/UseCase/Protocols/Record/DeleteAllRecordUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/Record/DeleteAllRecordUseCaseProtocol.swift
@@ -16,7 +16,7 @@ protocol DeleteAllRecordUseCaseProtocol {
 }
 
 extension DeleteAllRecordUseCaseProtocol {
-    func execute(uid: String = "") {
-        execute(uid: uid)
+    func execute() {
+        execute(uid: "")
     }
 }

--- a/HowManySet/Domain/UseCase/Protocols/Record/DeleteRecordUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/Record/DeleteRecordUseCaseProtocol.swift
@@ -18,7 +18,7 @@ protocol DeleteRecordUseCaseProtocol {
 }
 
 extension DeleteRecordUseCaseProtocol {
-    func execute(uid: String = "", item: WorkoutRecord) {
-        execute(uid: uid, item: item)
+    func execute(item: WorkoutRecord) {
+        execute(uid: "", item: item)
     }
 }

--- a/HowManySet/Domain/UseCase/Protocols/Record/FetchRecordUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/Record/FetchRecordUseCaseProtocol.swift
@@ -20,7 +20,7 @@ protocol FetchRecordUseCaseProtocol {
 }
 
 extension FetchRecordUseCaseProtocol {
-    func execute(uid: String = "") -> Single<[WorkoutRecord]> {
-        return execute(uid: uid)
+    func execute() -> Single<[WorkoutRecord]> {
+        return execute(uid: "")
     }
 }

--- a/HowManySet/Domain/UseCase/Protocols/Record/SaveRecordUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/Record/SaveRecordUseCaseProtocol.swift
@@ -21,7 +21,7 @@ protocol SaveRecordUseCaseProtocol {
 }
 
 extension SaveRecordUseCaseProtocol {
-    func execute(uid: String = "", item: WorkoutRecord) {
-        execute(uid: uid, item: item)
+    func execute(item: WorkoutRecord) {
+        execute(uid: "", item: item)
     }
 }

--- a/HowManySet/Domain/UseCase/Protocols/Record/UpdateRecordUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/Record/UpdateRecordUseCaseProtocol.swift
@@ -12,7 +12,7 @@ protocol UpdateRecordUseCaseProtocol {
 }
 
 extension UpdateRecordUseCaseProtocol {
-    func execute(uid: String = "", item: WorkoutRecord) {
-        execute(uid: uid, item: item)
+    func execute(item: WorkoutRecord) {
+        execute(uid: "", item: item)
     }
 }

--- a/HowManySet/Domain/UseCase/Protocols/Routine/DeleteRoutineUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/Routine/DeleteRoutineUseCaseProtocol.swift
@@ -20,7 +20,7 @@ protocol DeleteRoutineUseCaseProtocol {
 }
 
 extension DeleteRoutineUseCaseProtocol {
-    func execute(uid: String = "", item: WorkoutRoutine) {
-        execute(uid: uid, item: item)
+    func execute(item: WorkoutRoutine) {
+        execute(uid: "", item: item)
     }
 }

--- a/HowManySet/Domain/UseCase/Protocols/Routine/FetchRoutineUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/Routine/FetchRoutineUseCaseProtocol.swift
@@ -20,7 +20,7 @@ protocol FetchRoutineUseCaseProtocol {
 }
 
 extension FetchRoutineUseCaseProtocol {
-    func execute(uid: String = "") -> Single<[WorkoutRoutine]> {
-        return execute(uid: uid)
+    func execute() -> Single<[WorkoutRoutine]> {
+        return execute(uid: "")
     }
 }

--- a/HowManySet/Domain/UseCase/Protocols/Routine/SaveRoutineUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/Routine/SaveRoutineUseCaseProtocol.swift
@@ -20,7 +20,7 @@ protocol SaveRoutineUseCaseProtocol {
 }
 
 extension SaveRoutineUseCaseProtocol {
-    func execute(uid: String = "", item: WorkoutRoutine) {
-        execute(uid: uid, item: item)
+    func execute(item: WorkoutRoutine) {
+        execute(uid: "", item: item)
     }
 }

--- a/HowManySet/Domain/UseCase/Protocols/Routine/UpdateRoutineUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/Routine/UpdateRoutineUseCaseProtocol.swift
@@ -18,7 +18,7 @@ protocol UpdateRoutineUseCaseProtocol {
 }
 
 extension UpdateRoutineUseCaseProtocol {
-    func execute(uid: String = "", item: WorkoutRoutine) {
-        execute(uid: uid, item: item)
+    func execute(item: WorkoutRoutine) {
+        execute(uid: "", item: item)
     }
 }

--- a/HowManySet/Domain/UseCase/Protocols/UserPage/FetchUserSettingUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/UserPage/FetchUserSettingUseCaseProtocol.swift
@@ -21,7 +21,7 @@ protocol FetchUserSettingUseCaseProtocol {
 }
 
 extension FetchUserSettingUseCaseProtocol {
-    func execute(uid: String = "") -> Single<UserSetting> {
-        return execute(uid: uid)
+    func execute() -> Single<UserSetting> {
+        return execute(uid: "")
     }
 }

--- a/HowManySet/Domain/UseCase/Protocols/UserPage/SaveUserSettingUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/UserPage/SaveUserSettingUseCaseProtocol.swift
@@ -20,7 +20,7 @@ protocol SaveUserSettingUseCaseProtocol {
 }
 
 extension SaveUserSettingUseCaseProtocol {
-    func execute(uid: String = "", settings: UserSetting) {
-        execute(uid: uid, settings: settings)
+    func execute(settings: UserSetting) {
+        execute(uid: "", settings: settings)
     }
 }

--- a/HowManySet/Domain/UseCase/Protocols/Workout/DeleteWorkoutUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/Workout/DeleteWorkoutUseCaseProtocol.swift
@@ -12,7 +12,7 @@ protocol DeleteWorkoutUseCaseProtocol {
 }
 
 extension DeleteWorkoutUseCaseProtocol {
-    func execute(uid: String = "", item: Workout) {
-        execute(uid: uid, item: item)
+    func execute(item: Workout) {
+        execute(uid: "", item: item)
     }
 }

--- a/HowManySet/Domain/UseCase/Protocols/Workout/UpdateWorkoutUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/Workout/UpdateWorkoutUseCaseProtocol.swift
@@ -12,7 +12,7 @@ protocol UpdateWorkoutUseCaseProtocol {
 }
 
 extension UpdateWorkoutUseCaseProtocol {
-    func execute(uid: String = "", item: Workout) {
-        execute(uid: uid, item: item)
+    func execute(item: Workout) {
+        execute(uid: "", item: item)
     }
 }

--- a/HowManySet/Domain/UseCase/Record/DeleteAllRecordUseCase.swift
+++ b/HowManySet/Domain/UseCase/Record/DeleteAllRecordUseCase.swift
@@ -21,7 +21,7 @@ final class DeleteAllRecordUseCase: DeleteAllRecordUseCaseProtocol {
     }
 
     /// 사용자의 모든 운동 기록을 삭제합니다.
-    func execute() {
+    func execute(uid: String = "") {
         repository.deleteAllRecord()
     }
 }

--- a/HowManySet/Domain/UseCase/Record/DeleteRecordUseCase.swift
+++ b/HowManySet/Domain/UseCase/Record/DeleteRecordUseCase.swift
@@ -23,7 +23,7 @@ final class DeleteRecordUseCase: DeleteRecordUseCaseProtocol {
     /// 특정 운동 기록을 삭제합니다.
     /// - Parameters:
     ///   - item: 삭제할 운동 기록
-    func execute(item: WorkoutRecord) {
+    func execute(uid: String = "", item: WorkoutRecord) {
         repository.deleteRecord(item: item)
     }
 }

--- a/HowManySet/Domain/UseCase/Record/FetchRecordUseCase.swift
+++ b/HowManySet/Domain/UseCase/Record/FetchRecordUseCase.swift
@@ -25,7 +25,7 @@ final class FetchRecordUseCase: FetchRecordUseCaseProtocol {
     
     /// 주어진 사용자 ID에 해당하는 운동 기록 리스트를 비동기적으로 조회합니다.
     /// - Returns: `Single`로 감싸진 `WorkoutRecord` 배열, 조회 성공 시 배열을 방출하고 실패 시 에러를 방출합니다.
-    func execute() -> Single<[WorkoutRecord]> {
+    func execute(uid: String = "") -> Single<[WorkoutRecord]> {
         return repository.fetchRecord()
     }
 }

--- a/HowManySet/Domain/UseCase/Record/SaveRecordUseCase.swift
+++ b/HowManySet/Domain/UseCase/Record/SaveRecordUseCase.swift
@@ -26,7 +26,7 @@ final class SaveRecordUseCase: SaveRecordUseCaseProtocol {
     ///
     /// - Parameters:
     ///   - item: 저장할 `WorkoutRecord` 객체
-    func execute(item: WorkoutRecord) {
+    func execute(uid: String = "", item: WorkoutRecord) {
         repository.saveRecord(item: item)
     }
 }

--- a/HowManySet/Domain/UseCase/Record/UpdateRecordUseCase.swift
+++ b/HowManySet/Domain/UseCase/Record/UpdateRecordUseCase.swift
@@ -14,7 +14,7 @@ final class UpdateRecordUseCase: UpdateRecordUseCaseProtocol {
         self.repository = repository
     }
     
-    func execute(item: WorkoutRecord) {
+    func execute(uid: String = "", item: WorkoutRecord) {
         repository.updateRecord(item: item)
     }
 }

--- a/HowManySet/Domain/UseCase/Routine/DeleteRoutineUseCase.swift
+++ b/HowManySet/Domain/UseCase/Routine/DeleteRoutineUseCase.swift
@@ -26,7 +26,7 @@ final class DeleteRoutineUseCase: DeleteRoutineUseCaseProtocol {
     ///
     /// - Parameters:
     ///   - item: 삭제할 `WorkoutRoutine` 객체
-    func execute(item: WorkoutRoutine) {
+    func execute(uid: String = "", item: WorkoutRoutine) {
         repository.deleteRoutine(item: item)
     }
 }

--- a/HowManySet/Domain/UseCase/Routine/FetchRoutineUseCase.swift
+++ b/HowManySet/Domain/UseCase/Routine/FetchRoutineUseCase.swift
@@ -26,7 +26,7 @@ final class FetchRoutineUseCase: FetchRoutineUseCaseProtocol {
     /// 주어진 사용자 ID에 해당하는 운동 루틴 리스트를 비동기적으로 조회합니다.
     ///
     /// - Returns: `Single`로 감싸진 `WorkoutRoutine` 배열, 조회 성공 시 배열을 방출하고 실패 시 에러를 방출합니다.
-    func execute() -> Single<[WorkoutRoutine]> {
+    func execute(uid: String = "") -> Single<[WorkoutRoutine]> {
         return repository.fetchRoutine()
     }
 }

--- a/HowManySet/Domain/UseCase/Routine/SaveRoutineUseCase.swift
+++ b/HowManySet/Domain/UseCase/Routine/SaveRoutineUseCase.swift
@@ -11,10 +11,6 @@ import Foundation
 ///
 /// `RoutineRepository`를 통해 특정 사용자의 운동 루틴을 저장하는 기능을 제공합니다.
 final class SaveRoutineUseCase: SaveRoutineUseCaseProtocol {
-    func execute(uid: String = "", item: WorkoutRoutine) {
-        repository.saveRoutine(item: item)
-    }
-    
     
     /// 운동 루틴 데이터를 관리하는 리포지토리 객체
     private let repository: RoutineRepository
@@ -30,7 +26,7 @@ final class SaveRoutineUseCase: SaveRoutineUseCaseProtocol {
     ///
     /// - Parameters:
     ///   - item: 저장할 `WorkoutRoutine` 객체
-    func execute(item: WorkoutRoutine) {
+    func execute(uid: String = "", item: WorkoutRoutine) {
         repository.saveRoutine(item: item)
     }
 }

--- a/HowManySet/Domain/UseCase/Routine/SaveRoutineUseCase.swift
+++ b/HowManySet/Domain/UseCase/Routine/SaveRoutineUseCase.swift
@@ -11,6 +11,10 @@ import Foundation
 ///
 /// `RoutineRepository`를 통해 특정 사용자의 운동 루틴을 저장하는 기능을 제공합니다.
 final class SaveRoutineUseCase: SaveRoutineUseCaseProtocol {
+    func execute(uid: String = "", item: WorkoutRoutine) {
+        repository.saveRoutine(item: item)
+    }
+    
     
     /// 운동 루틴 데이터를 관리하는 리포지토리 객체
     private let repository: RoutineRepository

--- a/HowManySet/Domain/UseCase/Routine/UpdateRoutineUseCase.swift
+++ b/HowManySet/Domain/UseCase/Routine/UpdateRoutineUseCase.swift
@@ -26,5 +26,9 @@ final class UpdateRoutineUseCase: UpdateRoutineUseCaseProtocol {
     func execute(item: WorkoutRoutine) {
         repository.updateRoutine(item: item)
     }
+    
+    func execute(uid: String = "", item: WorkoutRoutine) {
+        repository.updateRoutine(uid: uid, item: item)
+    }
 }
 

--- a/HowManySet/Domain/UseCase/UserPage/FetchUserSettingUseCase.swift
+++ b/HowManySet/Domain/UseCase/UserPage/FetchUserSettingUseCase.swift
@@ -27,8 +27,8 @@ final class FetchUserSettingUseCase: FetchUserSettingUseCaseProtocol {
     ///
     /// - Parameter uid: 설정 정보를 조회할 사용자의 고유 식별자
     /// - Returns: `Single`로 감싸진 `UserSetting` 객체, 조회 성공 시 설정 정보를 방출하고 실패 시 에러를 방출합니다.
-    func execute(uid: String) -> Single<UserSetting> {
-        return repository.fetchUserSetting(uid: uid)
+    func execute(uid: String = "") -> Single<UserSetting> {
+        return repository.fetchUserSetting()
     }
 }
 

--- a/HowManySet/Domain/UseCase/UserPage/SaveUserSettingUseCase.swift
+++ b/HowManySet/Domain/UseCase/UserPage/SaveUserSettingUseCase.swift
@@ -27,8 +27,8 @@ final class SaveUserSettingUseCase: SaveUserSettingUseCaseProtocol {
     /// - Parameters:
     ///   - uid: 설정 정보를 저장할 사용자의 고유 식별자
     ///   - settings: 저장할 `UserSetting` 객체
-    func execute(uid: String, settings: UserSetting) {
-        repository.saveUserSetting(uid: uid, settings: settings)
+    func execute(uid: String = "", settings: UserSetting) {
+        repository.saveUserSetting(settings: settings)
     }
 }
 

--- a/HowManySet/Domain/UseCase/Workout/DeleteWorkoutUseCase.swift
+++ b/HowManySet/Domain/UseCase/Workout/DeleteWorkoutUseCase.swift
@@ -15,7 +15,7 @@ final class DeleteWorkoutUseCase: DeleteWorkoutUseCaseProtocol {
         self.repository = repository
     }
     
-    func execute(item: Workout) {
+    func execute(uid: String = "", item: Workout) {
         repository.deleteWorkout(workout: item)
     }
 }

--- a/HowManySet/Domain/UseCase/Workout/UpdateWorkoutUseCase.swift
+++ b/HowManySet/Domain/UseCase/Workout/UpdateWorkoutUseCase.swift
@@ -15,7 +15,7 @@ final class UpdateWorkoutUseCase: UpdateWorkoutUseCaseProtocol {
         self.repository = repository
     }
     
-    func execute(item: Workout) {
+    func execute(uid: String = "", item: Workout) {
         repository.updateWorkout(workout: item)
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  closed: #103 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- Realm, Firebase를 같은 Repository를 사용하기 위해 protocol extension을 사용
- protocol extension에 정의된 메서드가 무한실행되는 버그 발생
- protocol extension에 정의된 메서드와 protocol에 정의된 메서드의 각 파라미터를 다르게 구현
- Realm UseCase는 uid가 필요없으므로 구현부분의 uid를 기본값을 넣어줌
