### PR TITLE
로그인 to 온보딩 플로우 수정 및 리팩토링 / 카카오 이슈 해결 / 비회원 로직 수정

### DIFF
--- a/HowManySet/App/Coordinator/AppCoordinator.swift
+++ b/HowManySet/App/Coordinator/AppCoordinator.swift
@@ -11,6 +11,7 @@ import RxSwift
 
 /// 앱의 전체 흐름을 관리하는 Coordinator
 /// - 로그인 여부, 온보딩 여부를 체크하고 적절한 흐름으로 분기
+/// - 출시 수준의 완전한 플로우 구현
 final class AppCoordinator: Coordinator {
     
     /// 앱의 최상위 UIWindow
@@ -25,57 +26,71 @@ final class AppCoordinator: Coordinator {
     /// RxSwift DisposeBag
     private let disposeBag = DisposeBag()
     
+    /// 흐름 완료 시 호출될 클로저
+    var finishFlow: (() -> Void)?
+    
     /// 생성자 - 의존성 주입 및 윈도우 연결
     init(window: UIWindow, container: DIContainer) {
         self.window = window
         self.container = container
     }
     
-    /// 앱 시작 시 호출됨 - 사용자별 상태 확인하여 적절한 플로우로 분기
+    /// 앱 시작 시 호출됨 - 출시 수준의 완전한 플로우
     func start() {
-        let isLoggedIn = checkLoginStatus()
+        print("🚀 앱 시작 - 사용자 상태 확인")
         
-        if !isLoggedIn {
-            showAuthFlow()
+        // Firebase Auth 상태 변화 감지
+        Auth.auth().addStateDidChangeListener { [weak self] auth, user in
+            DispatchQueue.main.async {
+                if let user = user {
+                    print("🟢 Firebase Auth 사용자 발견: \(user.uid)")
+                    self?.checkUserStatusWithFirestore(uid: user.uid)
+                } else {
+                    print("🔴 Firebase Auth 사용자 없음")
+                    self?.checkLocalUserStatus()
+                }
+            }
+        }
+    }
+    
+    /// 로컬 사용자 상태 확인 (Firebase Auth 없을 때)
+    private func checkLocalUserStatus() {
+        let hasCompletedOnboarding = UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
+        
+        if hasCompletedOnboarding {
+            print("🟡 로컬 온보딩 완료 상태 - 메인 화면으로 (Firebase Auth 재연결 필요)")
+            showTabBarFlow()
         } else {
-            // 로그인된 사용자의 상태를 UseCase를 통해 확인
-            checkUserStatus()
-        }
-    }
-    
-    /// 로그인 상태 확인
-    private func checkLoginStatus() -> Bool {
-        let isLoggedIn = Auth.auth().currentUser != nil
-        print("✅ 로그인 상태: \(isLoggedIn)")
-        return isLoggedIn
-    }
-    
-    /// 사용자 상태 확인 (UseCase를 통해)
-    private func checkUserStatus() {
-        guard let currentUser = Auth.auth().currentUser else {
+            print("🔴 로컬 온보딩 미완료 - 로그인 화면으로")
             showAuthFlow()
-            return
         }
-
+    }
+    
+    /// Firestore 기반 사용자 상태 확인
+    private func checkUserStatusWithFirestore(uid: String) {
         let firebaseAuthService = FirebaseAuthService()
         let authRepository = AuthRepositoryImpl(firebaseAuthService: firebaseAuthService)
         let authUseCase = AuthUseCase(repository: authRepository)
         
-        authUseCase.getUserStatus(uid: currentUser.uid)
+        authUseCase.getUserStatus(uid: uid)
             .observe(on: MainScheduler.instance)
             .subscribe(
                 onNext: { [weak self] userStatus in
                     switch userStatus {
                     case .needsOnboarding:
+                        print("🔴 Firestore: 온보딩 필요 - 온보딩 화면으로")
                         self?.showOnboardingFlow()
                     case .complete:
+                        print("🟢 Firestore: 온보딩 완료 - 메인 화면으로")
+                        // UserDefaults 동기화
+                        UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
                         self?.showTabBarFlow()
                     }
                 },
                 onError: { [weak self] error in
-                    print("사용자 상태 조회 실패: \(error)")
-                    // 에러 시 온보딩부터 시작
-                    self?.showOnboardingFlow()
+                    print("🔴 Firestore 사용자 상태 조회 실패: \(error)")
+                    // 에러 시 로컬 상태 확인
+                    self?.checkLocalUserStatus()
                 }
             )
             .disposed(by: disposeBag)
@@ -83,6 +98,7 @@ final class AppCoordinator: Coordinator {
     
     /// 로그인/회원가입 흐름 시작
     private func showAuthFlow() {
+        print("🔑 로그인 화면 표시")
         let authCoordinator = AuthCoordinator(navigationController: UINavigationController(), container: container)
         childCoordinators.append(authCoordinator)
         
@@ -90,8 +106,14 @@ final class AppCoordinator: Coordinator {
             guard let self, let authCoordinator else { return }
             self.childDidFinish(authCoordinator)
             
+            print("🟢 로그인 완료 - 사용자 상태 재확인")
             // 로그인 완료 후 사용자 상태 확인
-            self.checkUserStatus()
+            if let currentUser = Auth.auth().currentUser {
+                self.checkUserStatusWithFirestore(uid: currentUser.uid)
+            } else {
+                print("🔴 로그인 완료 후 사용자 정보 없음")
+                self.showAuthFlow()
+            }
         }
         
         authCoordinator.start()
@@ -101,11 +123,16 @@ final class AppCoordinator: Coordinator {
     
     /// 온보딩 흐름 시작 (닉네임 입력 + 온보딩)
     private func showOnboardingFlow() {
+        print("👋 온보딩 화면 표시")
         let onboardingCoordinator = OnBoardingCoordinator(navigationController: UINavigationController(), container: container)
         childCoordinators.append(onboardingCoordinator)
         
         onboardingCoordinator.finishFlow = { [weak self, weak onboardingCoordinator] in
             guard let self, let onboardingCoordinator else { return }
+            
+            print("🟢 온보딩 완료 - 메인 화면으로 이동")
+            // UserDefaults에 온보딩 완료 저장
+            UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
             self.showTabBarFlow()
             self.childDidFinish(onboardingCoordinator)
         }
@@ -117,11 +144,13 @@ final class AppCoordinator: Coordinator {
     
     /// 메인 탭바 흐름 시작
     private func showTabBarFlow() {
+        print("🏠 메인 화면 표시")
         let tabBarCoordinator = TabBarCoordinator(tabBarController: UITabBarController(), container: container)
         
         tabBarCoordinator.finishFlow = { [weak self, weak tabBarCoordinator] in
             guard let self, let tabBarCoordinator else { return }
             self.childDidFinish(tabBarCoordinator)
+            print("🔑 메인 화면 종료 - 로그인 화면으로")
             // 로그아웃/계정삭제 후 인증 화면으로 이동
             self.showAuthFlow()
         }

--- a/HowManySet/App/Coordinator/AuthCoordinator.swift
+++ b/HowManySet/App/Coordinator/AuthCoordinator.swift
@@ -39,8 +39,7 @@ final class AuthCoordinator: AuthCoordinatorProtocol {
     /// 로그인 완료 시 호출
     /// 후처리 로직 추가 후 finishFlow 호출
     func completeAuth() {
-        // 비즈니스 로직 추가
-        print(#function)
+        print("🟢 AuthCoordinator: 로그인 완료")
         finishFlow?()
     }
 }

--- a/HowManySet/App/Coordinator/NicknameInputCoordinator.swift
+++ b/HowManySet/App/Coordinator/NicknameInputCoordinator.swift
@@ -1,0 +1,8 @@
+//
+//  NicknameInputCoordinator.swift
+//  HowManySet
+//
+//  Created by GO on 6/23/25.
+//
+
+import Foundation

--- a/HowManySet/App/Coordinator/NicknameInputCoordinator.swift
+++ b/HowManySet/App/Coordinator/NicknameInputCoordinator.swift
@@ -1,8 +1,0 @@
-//
-//  NicknameInputCoordinator.swift
-//  HowManySet
-//
-//  Created by GO on 6/23/25.
-//
-
-import Foundation

--- a/HowManySet/App/Coordinator/OnBoardingCoordinator.swift
+++ b/HowManySet/App/Coordinator/OnBoardingCoordinator.swift
@@ -6,13 +6,15 @@
 //
 
 import UIKit
+import FirebaseAuth
+import RxSwift
 
 protocol OnBoardingCoordinatorProtocol: Coordinator {
     func completeOnBoarding()
+    func completeNicknameSetting(nickname: String)
 }
 
-/// 온보딩 흐름 담당 coordinator
-/// 온보딩 뷰 진입 및 완료 시 finishFlow 호출
+/// 온보딩 흐름 담당 coordinator (닉네임 입력 + 온보딩)
 final class OnBoardingCoordinator: OnBoardingCoordinatorProtocol {
     
     /// 온보딩 완료 시 호출될 클로저
@@ -23,11 +25,11 @@ final class OnBoardingCoordinator: OnBoardingCoordinatorProtocol {
     
     /// DI 컨테이너
     private let container: DIContainer
+    
+    /// RxSwift DisposeBag
+    private let disposeBag = DisposeBag()
 
-    /// coordinator 생성자
-    /// - Parameters:
-    ///   - navigationController: 온보딩 흐름용 navigation
-    ///   - container: DI 컨테이너
+    /// 생성자 - 의존성 주입 및 윈도우 연결
     init(navigationController: UINavigationController, container: DIContainer) {
         self.navigationController = navigationController
         self.container = container
@@ -39,12 +41,60 @@ final class OnBoardingCoordinator: OnBoardingCoordinatorProtocol {
         navigationController.pushViewController(onboardingVC, animated: true)
     }
 
+    /// 닉네임 설정 완료 시 호출
+    func completeNicknameSetting(nickname: String) {
+        guard let currentUser = Auth.auth().currentUser else {
+            print("현재 사용자가 없음")
+            return
+        }
+
+        let firebaseAuthService = FirebaseAuthService()
+        let authRepository = AuthRepositoryImpl(firebaseAuthService: firebaseAuthService)
+        let authUseCase = AuthUseCase(repository: authRepository)
+        
+        authUseCase.completeNicknameSetting(uid: currentUser.uid, nickname: nickname)
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onNext: { _ in
+                    print("닉네임 설정 완료")
+                },
+                onError: { error in
+                    print("닉네임 설정 실패: \(error)")
+                }
+            )
+            .disposed(by: disposeBag)
+    }
+
     /// 온보딩 완료 시 호출
     func completeOnBoarding() {
-        // TODO: 필요한 비즈니스 로직들 추가
-        // UserDefaults에 온보딩 완료 상태 저장
-        UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
-        print(#function)
-        finishFlow?()
+        guard let currentUser = Auth.auth().currentUser else {
+            print("현재 사용자가 없음")
+            // 로컬 저장만 진행
+            UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
+            finishFlow?()
+            return
+        }
+        
+        let firebaseAuthService = FirebaseAuthService()
+        let authRepository = AuthRepositoryImpl(firebaseAuthService: firebaseAuthService)
+        let authUseCase = AuthUseCase(repository: authRepository)
+        
+        authUseCase.completeOnboarding(uid: currentUser.uid)
+            .observe(on: MainScheduler.instance)
+            .subscribe(
+                onNext: { [weak self] in
+                    print("온보딩 완료")
+                    // 로컬 저장도 함께 진행 (백업용)
+                    UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
+                    self?.finishFlow?()
+                },
+                onError: { [weak self] error in
+                    print("온보딩 완료 처리 실패: \(error)")
+                    // 에러가 발생해도 로컬 저장 후 다음 단계로 진행
+                    UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
+                    self?.finishFlow?()
+                }
+            )
+            .disposed(by: disposeBag)
     }
 }

--- a/HowManySet/App/Coordinator/OnBoardingCoordinator.swift
+++ b/HowManySet/App/Coordinator/OnBoardingCoordinator.swift
@@ -15,6 +15,7 @@ protocol OnBoardingCoordinatorProtocol: Coordinator {
 }
 
 /// 온보딩 흐름 담당 coordinator (닉네임 입력 + 온보딩)
+/// - Clean Architecture 원칙에 따라 Repository를 통해서만 사용자 정보 접근
 final class OnBoardingCoordinator: OnBoardingCoordinatorProtocol {
     
     /// 온보딩 완료 시 호출될 클로저
@@ -43,23 +44,25 @@ final class OnBoardingCoordinator: OnBoardingCoordinatorProtocol {
 
     /// 닉네임 설정 완료 시 호출
     func completeNicknameSetting(nickname: String) {
-        guard let currentUser = Auth.auth().currentUser else {
-            print("현재 사용자가 없음")
-            return
-        }
-
         let firebaseAuthService = FirebaseAuthService()
         let authRepository = AuthRepositoryImpl(firebaseAuthService: firebaseAuthService)
         let authUseCase = AuthUseCase(repository: authRepository)
         
-        authUseCase.completeNicknameSetting(uid: currentUser.uid, nickname: nickname)
+        // Repository를 통해 현재 사용자 정보 가져오기
+        authRepository.getCurrentUser()
+            .flatMap { user -> Observable<Void> in
+                guard let user = user else {
+                    return Observable.error(NSError(domain: "NoCurrentUser", code: -1))
+                }
+                return authUseCase.completeNicknameSetting(uid: user.uid, nickname: nickname)
+            }
             .observe(on: MainScheduler.instance)
             .subscribe(
-                onNext: { _ in
-                    print("닉네임 설정 완료")
+                onNext: { (_: Void) in
+                    print("🟢 OnBoardingCoordinator: 닉네임 설정 완료")
                 },
-                onError: { error in
-                    print("닉네임 설정 실패: \(error)")
+                onError: { (error: Error) in
+                    print("🔴 OnBoardingCoordinator: 닉네임 설정 실패 - \(error)")
                 }
             )
             .disposed(by: disposeBag)
@@ -67,29 +70,32 @@ final class OnBoardingCoordinator: OnBoardingCoordinatorProtocol {
 
     /// 온보딩 완료 시 호출
     func completeOnBoarding() {
-        guard let currentUser = Auth.auth().currentUser else {
-            print("현재 사용자가 없음")
-            // 로컬 저장만 진행
-            UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
-            finishFlow?()
-            return
-        }
-        
         let firebaseAuthService = FirebaseAuthService()
         let authRepository = AuthRepositoryImpl(firebaseAuthService: firebaseAuthService)
         let authUseCase = AuthUseCase(repository: authRepository)
         
-        authUseCase.completeOnboarding(uid: currentUser.uid)
+        // Repository를 통해 현재 사용자 정보 가져오기
+        authRepository.getCurrentUser()
+            .flatMap { [weak self] user -> Observable<Void> in
+                guard let user = user else {
+                    // 사용자가 없으면 로컬 저장만 하고 완료
+                    print("🟡 OnBoardingCoordinator: 현재 사용자가 없음 - 로컬 저장만 진행")
+                    UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
+                    self?.finishFlow?()
+                    return Observable.empty()
+                }
+                return authUseCase.completeOnboarding(uid: user.uid)
+            }
             .observe(on: MainScheduler.instance)
             .subscribe(
-                onNext: { [weak self] in
-                    print("온보딩 완료")
+                onNext: { [weak self] (_: Void) in
+                    print("🟢 OnBoardingCoordinator: 온보딩 완료")
                     // 로컬 저장도 함께 진행 (백업용)
                     UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
                     self?.finishFlow?()
                 },
-                onError: { [weak self] error in
-                    print("온보딩 완료 처리 실패: \(error)")
+                onError: { [weak self] (error: Error) in
+                    print("🔴 OnBoardingCoordinator: 온보딩 완료 처리 실패 - \(error)")
                     // 에러가 발생해도 로컬 저장 후 다음 단계로 진행
                     UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
                     self?.finishFlow?()

--- a/HowManySet/App/DIContainer.swift
+++ b/HowManySet/App/DIContainer.swift
@@ -10,17 +10,14 @@ import FirebaseFirestore
 
 final class DIContainer {
     
-    /// 온보딩 화면을 생성하여 반환
-    func makeOnBoardingViewController(coordinator: OnBoardingCoordinator) -> UIViewController {
-        //        let repository
-        //        let useCase
+    /// 온보딩 화면을 생성하여 반환 (닉네임 입력 + 온보딩 통합)
+    func makeOnBoardingViewController(coordinator: OnBoardingCoordinatorProtocol) -> UIViewController {
         let reactor = OnBoardingViewReactor()
-        
         return OnBoardingViewController(reactor: reactor, coordinator: coordinator)
     }
     
     /// 인증 화면을 생성하여 반환
-    func makeAuthViewController(coordinator: AuthCoordinator) -> UIViewController {
+    func makeAuthViewController(coordinator: AuthCoordinatorProtocol) -> UIViewController {
         let firebaseAuthService = FirebaseAuthService()
         let repository = AuthRepositoryImpl(firebaseAuthService: firebaseAuthService)
         let useCase = AuthUseCase(repository: repository)
@@ -81,11 +78,6 @@ final class DIContainer {
             deleteRoutineUseCase: deleteRoutineUseCase,
             fetchRoutineUseCase: fetchRoutineUseCase,
             saveRoutineUseCase: saveRoutineUseCase
-//            ,
-//            // Firestore UseCase들 추가
-//            fsFetchRoutineUseCase: fsFetchRoutineUseCase,
-//            fsSaveRoutineUseCase: fsSaveRoutineUseCase,
-//            fsDeleteRoutineUseCase: fsDeleteRoutineUseCase
         )
         
         return RoutineListViewController(reactor: reactor, coordinator: coordinator)
@@ -107,10 +99,6 @@ final class DIContainer {
         let reactor = CalendarViewReactor(
             saveRecordUseCase: saveRecordUseCase,
             fetchRecordUseCase: fetchRecordUseCase
-//            ,
-//            // Firestore UseCase들 추가
-//            fsSaveRecordUseCase: fsSaveRecordUseCase,
-//            fsFetchRecordUseCase: fsFetchRecordUseCase
         )
         
         return CalendarViewController(reactor: reactor, coordinator: coordinator)
@@ -134,7 +122,7 @@ final class DIContainer {
             repository: fsUserSettingRespository
         )
         
-        // AuthUseCase 추가
+        // AuthUseCase 추가 (기존 패턴 유지)
         let firebaseAuthService = FirebaseAuthService()
         let authRepository = AuthRepositoryImpl(firebaseAuthService: firebaseAuthService)
         let authUseCase = AuthUseCase(repository: authRepository)
@@ -143,10 +131,6 @@ final class DIContainer {
             fetchUserSettingUseCase: fetchUserSettingUseCase,
             saveUserSettingUseCase: saveUserSettingUseCase,
             authUseCase: authUseCase
-//            ,
-//            // Firestore UseCase들 추가
-//            fsFetchUserSettingUseCase: fsFetchUserSettingUseCase,
-//            fsSaveUserSettingUseCase: fsSaveUserSettingUseCase
         )
         
         return MyPageViewController(reactor: reactor, coordinator: coordinator)
@@ -154,6 +138,16 @@ final class DIContainer {
     
     /// 루틴 완료 화면을 생성하여 반환
     func makeRoutineCompleteViewController(coordinator: RoutineCompleteCoordinator, workoutSummary: WorkoutSummary, homeViewReactor: HomeViewReactor) -> UIViewController {
+        
+        let recordRepository = RecordRepositoryImpl()
+        let saveRecordUseCase = SaveRecordUseCase(repository: recordRepository)
+        
+        // Firestore 로직 추가
+        let firestoreService = FirestoreService()
+        let fsRecordRepository = FSRecordRepositoryImpl(firestoreService: firestoreService)
+        let fsSaveRecordUseCase = FSSaveRecordUseCase(repository: fsRecordRepository)
+
+        let reactor = RoutineCompleteViewReactor(saveRecordUseCase: saveRecordUseCase)
         
         return RoutineCompleteViewController(coordinator: coordinator, workoutSummary: workoutSummary, homeViewReactor: homeViewReactor)
     }

--- a/HowManySet/App/DIContainer.swift
+++ b/HowManySet/App/DIContainer.swift
@@ -8,6 +8,8 @@
 import UIKit
 import FirebaseFirestore
 
+/// 의존성 주입 컨테이너
+/// - 출시 수준의 완전한 DI 구현
 final class DIContainer {
     
     /// 온보딩 화면을 생성하여 반환 (닉네임 입력 + 온보딩 통합)
@@ -122,7 +124,6 @@ final class DIContainer {
             repository: fsUserSettingRespository
         )
         
-        // AuthUseCase 추가 (기존 패턴 유지)
         let firebaseAuthService = FirebaseAuthService()
         let authRepository = AuthRepositoryImpl(firebaseAuthService: firebaseAuthService)
         let authUseCase = AuthUseCase(repository: authRepository)

--- a/HowManySet/Data/DTO/UserDTO.swift
+++ b/HowManySet/Data/DTO/UserDTO.swift
@@ -8,50 +8,141 @@
 import Foundation
 import FirebaseFirestore
 
-struct UserDTO {
-    let uid: String
-    let name: String
-    let provider: String
-    let email: String?
-    let hasSetNickname: Bool
-    let hasCompletedOnboarding: Bool
+/// 사용자 정보 데이터 전송 객체
+///
+/// Firestore와 Domain Layer 간의 데이터 변환을 담당하며,
+/// 다양한 소셜 로그인 제공자의 고유 식별자를 포함합니다.
+public struct UserDTO {
+    /// Firebase Auth 사용자 고유 식별자
+    public let uid: String
+    
+    /// 사용자 닉네임
+    public let name: String
+    
+    /// 로그인 제공자 식별자
+    public let provider: String
+    
+    /// 사용자 이메일 주소 (선택적)
+    public let email: String?
+    
+    /// 닉네임 설정 완료 여부
+    public let hasSetNickname: Bool
+    
+    /// 온보딩 프로세스 완료 여부
+    public let hasCompletedOnboarding: Bool
+    
+    /// 카카오 사용자 고유 식별자 (선택적)
+    public let kakaoId: Int64?
+    
+    /// 구글 사용자 고유 식별자 (선택적)
+    public let googleId: String?
+    
+    /// Apple 사용자 고유 식별자 (선택적)
+    public let appleId: String?
 
-    init(uid: String, name: String, provider: String, email: String? = nil, hasSetNickname: Bool = false, hasCompletedOnboarding: Bool = false) {
+    /// UserDTO 인스턴스를 생성합니다
+    /// - Parameters:
+    ///   - uid: Firebase Auth 사용자 ID
+    ///   - name: 사용자 닉네임
+    ///   - provider: 로그인 제공자 식별자
+    ///   - email: 사용자 이메일 (선택적)
+    ///   - hasSetNickname: 닉네임 설정 완료 여부 (기본값: false)
+    ///   - hasCompletedOnboarding: 온보딩 완료 여부 (기본값: false)
+    ///   - kakaoId: 카카오 사용자 ID (선택적)
+    ///   - googleId: 구글 사용자 ID (선택적)
+    ///   - appleId: Apple 사용자 ID (선택적)
+    public init(
+        uid: String,
+        name: String,
+        provider: String,
+        email: String? = nil,
+        hasSetNickname: Bool = false,
+        hasCompletedOnboarding: Bool = false,
+        kakaoId: Int64? = nil,
+        googleId: String? = nil,
+        appleId: String? = nil
+    ) {
         self.uid = uid
         self.name = name
         self.provider = provider
         self.email = email
         self.hasSetNickname = hasSetNickname
         self.hasCompletedOnboarding = hasCompletedOnboarding
+        self.kakaoId = kakaoId
+        self.googleId = googleId
+        self.appleId = appleId
     }
 
-    func toEntity() -> User {
-        return User(uid: uid, name: name, provider: provider, email: email, hasSetNickname: hasSetNickname, hasCompletedOnboarding: hasCompletedOnboarding)
+    /// UserDTO를 User 도메인 모델로 변환합니다
+    /// - Returns: User 도메인 모델 인스턴스
+    public func toEntity() -> User {
+        return User(
+            uid: uid,
+            name: name,
+            provider: provider,
+            email: email,
+            hasSetNickname: hasSetNickname,
+            hasCompletedOnboarding: hasCompletedOnboarding
+        )
     }
 
-    static func from(uid: String, data: [String: Any]) -> UserDTO? {
+    /// Firestore 문서 데이터로부터 UserDTO를 생성합니다
+    /// - Parameters:
+    ///   - uid: Firebase Auth 사용자 ID
+    ///   - data: Firestore 문서 데이터
+    /// - Returns: 생성된 UserDTO 인스턴스 또는 nil (필수 필드 누락 시)
+    public static func from(uid: String, data: [String: Any]) -> UserDTO? {
         guard let name = data["name"] as? String,
               let provider = data["provider"] as? String else {
             return nil
         }
+        
         let email = data["email"] as? String
         let hasSetNickname = data["hasSetNickname"] as? Bool ?? false
         let hasCompletedOnboarding = data["hasCompletedOnboarding"] as? Bool ?? false
-        return UserDTO(uid: uid, name: name, provider: provider, email: email, hasSetNickname: hasSetNickname, hasCompletedOnboarding: hasCompletedOnboarding)
+        let kakaoId = data["kakaoId"] as? Int64
+        let googleId = data["googleId"] as? String
+        let appleId = data["appleId"] as? String
+        
+        return UserDTO(
+            uid: uid,
+            name: name,
+            provider: provider,
+            email: email,
+            hasSetNickname: hasSetNickname,
+            hasCompletedOnboarding: hasCompletedOnboarding,
+            kakaoId: kakaoId,
+            googleId: googleId,
+            appleId: appleId
+        )
     }
 
-    func toFirestoreData() -> [String: Any] {
+    /// UserDTO를 Firestore 저장용 데이터로 변환합니다
+    /// - Returns: Firestore에 저장할 수 있는 딕셔너리 형태의 데이터
+    public func toFirestoreData() -> [String: Any] {
         var data: [String: Any] = [
             "uid": uid,
             "name": name,
             "provider": provider,
             "hasSetNickname": hasSetNickname,
             "hasCompletedOnboarding": hasCompletedOnboarding,
-            "createdAt": FieldValue.serverTimestamp()
+            "createdAt": FieldValue.serverTimestamp(),
+            "lastLoginAt": FieldValue.serverTimestamp()
         ]
+        
         if let email = email {
             data["email"] = email
         }
+        if let kakaoId = kakaoId {
+            data["kakaoId"] = kakaoId
+        }
+        if let googleId = googleId {
+            data["googleId"] = googleId
+        }
+        if let appleId = appleId {
+            data["appleId"] = appleId
+        }
+        
         return data
     }
 }

--- a/HowManySet/Data/DTO/UserDTO.swift
+++ b/HowManySet/Data/DTO/UserDTO.swift
@@ -13,9 +13,20 @@ struct UserDTO {
     let name: String
     let provider: String
     let email: String?
+    let hasSetNickname: Bool
+    let hasCompletedOnboarding: Bool
+
+    init(uid: String, name: String, provider: String, email: String? = nil, hasSetNickname: Bool = false, hasCompletedOnboarding: Bool = false) {
+        self.uid = uid
+        self.name = name
+        self.provider = provider
+        self.email = email
+        self.hasSetNickname = hasSetNickname
+        self.hasCompletedOnboarding = hasCompletedOnboarding
+    }
 
     func toEntity() -> User {
-        return User(uid: uid, name: name, provider: provider, email: email)
+        return User(uid: uid, name: name, provider: provider, email: email, hasSetNickname: hasSetNickname, hasCompletedOnboarding: hasCompletedOnboarding)
     }
 
     static func from(uid: String, data: [String: Any]) -> UserDTO? {
@@ -23,15 +34,19 @@ struct UserDTO {
               let provider = data["provider"] as? String else {
             return nil
         }
-        let email = data["email"] as? String  // 선택적 필드
-        return UserDTO(uid: uid, name: name, provider: provider, email: email)
+        let email = data["email"] as? String
+        let hasSetNickname = data["hasSetNickname"] as? Bool ?? false
+        let hasCompletedOnboarding = data["hasCompletedOnboarding"] as? Bool ?? false
+        return UserDTO(uid: uid, name: name, provider: provider, email: email, hasSetNickname: hasSetNickname, hasCompletedOnboarding: hasCompletedOnboarding)
     }
 
     func toFirestoreData() -> [String: Any] {
         var data: [String: Any] = [
-            "uid": uid,  // 🔥 추가
+            "uid": uid,
             "name": name,
             "provider": provider,
+            "hasSetNickname": hasSetNickname,
+            "hasCompletedOnboarding": hasCompletedOnboarding,
             "createdAt": FieldValue.serverTimestamp()
         ]
         if let email = email {

--- a/HowManySet/Data/Firebase/FirebaseAuthService.swift
+++ b/HowManySet/Data/Firebase/FirebaseAuthService.swift
@@ -8,17 +8,46 @@
 import Foundation
 import FirebaseAuth
 import FirebaseFirestore
+import KakaoSDKUser
+import GoogleSignIn
 
 /// Firebase Auth 서비스 구현체
-/// - Firebase Auth의 기본 기능들을 구현
+///
+/// Firebase Auth의 기본 기능들을 구현하며, 계정 삭제 시 모든 소셜 로그인 연결 끊기를 포함한
+/// 완전한 데이터 삭제를 보장합니다.
 public final class FirebaseAuthService: FirebaseAuthServiceProtocol {
     /// Firestore 데이터베이스 인스턴스
     private let db = Firestore.firestore()
 
     public init() {}
 
-    /// 익명 로그인 처리
-    /// - Parameter completion: 로그인 결과 콜백
+    /// 커스텀 토큰으로 Firebase Auth 로그인을 수행합니다
+    /// - Parameters:
+    ///   - customToken: Firebase 커스텀 토큰
+    ///   - completion: 로그인 결과를 반환하는 콜백
+    public func signInWithCustomToken(_ customToken: String, completion: @escaping (Result<User, Error>) -> Void) {
+        Auth.auth().signIn(withCustomToken: customToken) { authResult, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+            guard let user = authResult?.user else {
+                completion(.failure(NSError(domain: "NoUser", code: -1)))
+                return
+            }
+            
+            let userModel = User(
+                uid: user.uid,
+                name: user.displayName ?? "사용자",
+                provider: "custom",
+                email: user.email
+            )
+            completion(.success(userModel))
+        }
+    }
+
+    /// 익명 로그인을 수행하고 기본 Firestore 데이터를 설정합니다
+    /// - Parameter completion: 로그인 결과를 반환하는 콜백
     public func signInAnonymously(completion: @escaping (Result<User, Error>) -> Void) {
         Auth.auth().signInAnonymously { authResult, error in
             if let error = error {
@@ -40,8 +69,8 @@ public final class FirebaseAuthService: FirebaseAuthServiceProtocol {
         }
     }
 
-    /// 현재 로그인된 사용자 정보 가져오기
-    /// - Returns: 현재 사용자 (없으면 nil)
+    /// 현재 로그인된 사용자 정보를 가져옵니다
+    /// - Returns: 현재 사용자 정보 또는 nil (로그인되지 않은 경우)
     public func fetchCurrentUser() -> User? {
         guard let user = Auth.auth().currentUser else { return nil }
         return User(
@@ -52,8 +81,8 @@ public final class FirebaseAuthService: FirebaseAuthServiceProtocol {
         )
     }
 
-    /// 로그아웃 처리
-    /// - Returns: 로그아웃 결과
+    /// Firebase Auth에서 로그아웃을 수행합니다
+    /// - Returns: 로그아웃 성공 여부
     public func signOut() -> Result<Void, Error> {
         do {
             try Auth.auth().signOut()
@@ -63,8 +92,11 @@ public final class FirebaseAuthService: FirebaseAuthServiceProtocol {
         }
     }
 
-    /// 계정 삭제 처리
-    /// - Parameter completion: 삭제 결과 콜백
+    /// 계정을 완전히 삭제합니다
+    ///
+    /// 모든 소셜 로그인 연결을 끊고, UserDefaults를 초기화하며,
+    /// Firestore 데이터와 Firebase Auth 계정을 삭제합니다.
+    /// - Parameter completion: 삭제 결과를 반환하는 콜백
     public func deleteAccount(completion: @escaping (Result<Void, Error>) -> Void) {
         guard let user = Auth.auth().currentUser else {
             completion(.failure(NSError(domain: "NoUser", code: -1)))
@@ -72,24 +104,154 @@ public final class FirebaseAuthService: FirebaseAuthServiceProtocol {
         }
         let uid = user.uid
 
-        // 🔥 Firestore 데이터 먼저 삭제
-        let userRef = db.collection("users").document(uid)
-        let defaultsRef = db.collection("defaults").document(uid)
+        print("🔥 계정 삭제 시작: \(uid)")
         
-        // 병렬로 데이터 삭제
+        unlinkAllSocialConnections { [weak self] unlinkResult in
+            switch unlinkResult {
+            case .success:
+                print("🟢 모든 소셜 연결 끊기 성공")
+            case .failure(let error):
+                print("🔴 소셜 연결 끊기 실패: \(error)")
+            }
+            
+            self?.clearAllUserDefaults()
+            self?.deleteFirestoreData(uid: uid, completion: completion)
+        }
+    }
+
+    /// 사용자의 로그인 제공자에 따라 적절한 소셜 로그인 연결을 끊습니다
+    /// - Parameter completion: 연결 끊기 결과를 반환하는 콜백
+    private func unlinkAllSocialConnections(completion: @escaping (Result<Void, Error>) -> Void) {
+        let userProvider = UserDefaults.standard.string(forKey: "userProvider") ?? ""
+        
+        switch userProvider {
+        case "kakao":
+            unlinkKakaoConnection(completion: completion)
+        case "google":
+            unlinkGoogleConnection(completion: completion)
+        case "apple":
+            unlinkAppleConnection(completion: completion)
+        case "anonymous":
+            print("🟡 익명 사용자 - 소셜 연결 끊기 스킵")
+            completion(.success(()))
+        default:
+            print("🟡 알 수 없는 제공자: \(userProvider) - 연결 끊기 스킵")
+            completion(.success(()))
+        }
+    }
+
+    /// 카카오 플랫폼과의 연결을 끊습니다
+    /// - Parameter completion: 연결 끊기 결과를 반환하는 콜백
+    private func unlinkKakaoConnection(completion: @escaping (Result<Void, Error>) -> Void) {
+        print("🟢 카카오 연결 끊기 시작")
+        
+        UserApi.shared.unlink { error in
+            if let error = error {
+                print("🔴 카카오 연결 끊기 실패: \(error)")
+                completion(.failure(error))
+            } else {
+                print("🟢 카카오 연결 끊기 성공 - 앱과 카카오 간 연결 완전 해제")
+                completion(.success(()))
+            }
+        }
+    }
+
+    /// 구글 플랫폼과의 연결을 끊습니다
+    /// - Parameter completion: 연결 끊기 결과를 반환하는 콜백
+    private func unlinkGoogleConnection(completion: @escaping (Result<Void, Error>) -> Void) {
+        print("🟢 구글 연결 끊기 시작")
+        
+        guard let user = Auth.auth().currentUser else {
+            completion(.failure(NSError(domain: "NoUser", code: -1)))
+            return
+        }
+        
+        user.unlink(fromProvider: "google.com") { authResult, error in
+            if let error = error {
+                print("🔴 구글 연결 끊기 실패: \(error)")
+                completion(.failure(error))
+            } else {
+                print("🟢 구글 연결 끊기 성공")
+                GIDSignIn.sharedInstance.signOut()
+                completion(.success(()))
+            }
+        }
+    }
+
+    /// Apple 플랫폼과의 연결을 끊습니다
+    /// - Parameter completion: 연결 끊기 결과를 반환하는 콜백
+    private func unlinkAppleConnection(completion: @escaping (Result<Void, Error>) -> Void) {
+        print("🟢 Apple 연결 끊기 시작")
+        
+        guard let user = Auth.auth().currentUser else {
+            completion(.failure(NSError(domain: "NoUser", code: -1)))
+            return
+        }
+        
+        user.unlink(fromProvider: "apple.com") { authResult, error in
+            if let error = error {
+                print("🔴 Apple 연결 끊기 실패: \(error)")
+                completion(.failure(error))
+            } else {
+                print("🟢 Apple 연결 끊기 성공")
+                completion(.success(()))
+            }
+        }
+    }
+
+    /// 사용자 관련 모든 UserDefaults 데이터를 초기화합니다
+    private func clearAllUserDefaults() {
+        print("🟢 UserDefaults 완전 초기화 시작")
+        
+        let keysToRemove = [
+            "hasCompletedOnboarding",
+            "hasSkippedOnboarding",
+            "userNickname",
+            "userProvider",
+            "userUID",
+            "hasSetNickname"
+        ]
+        
+        for key in keysToRemove {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+        
+        UserDefaults.standard.synchronize()
+        print("🟢 UserDefaults 완전 초기화 완료")
+    }
+
+    /// 사용자와 관련된 모든 Firestore 데이터를 삭제합니다
+    /// - Parameters:
+    ///   - uid: 삭제할 사용자 ID
+    ///   - completion: 삭제 결과를 반환하는 콜백
+    private func deleteFirestoreData(uid: String, completion: @escaping (Result<Void, Error>) -> Void) {
         let group = DispatchGroup()
         var deletionError: Error?
         
         group.enter()
-        userRef.delete { error in
+        db.collection("users").document(uid).delete { error in
             if let error = error {
+                print("🔴 users 문서 삭제 실패: \(error)")
                 deletionError = error
+            } else {
+                print("🟢 users 문서 삭제 성공")
             }
             group.leave()
         }
         
         group.enter()
-        defaultsRef.delete { error in
+        db.collection("defaults").document(uid).delete { error in
+            if let error = error {
+                print("🔴 defaults 문서 삭제 실패: \(error)")
+                deletionError = error
+            } else {
+                print("🟢 defaults 문서 삭제 성공")
+            }
+            group.leave()
+        }
+        
+        group.enter()
+        deleteAllSocialConnectionData(uid: uid) { error in
             if let error = error {
                 deletionError = error
             }
@@ -98,25 +260,76 @@ public final class FirebaseAuthService: FirebaseAuthServiceProtocol {
         
         group.notify(queue: .main) {
             if let error = deletionError {
+                print("🔴 Firestore 데이터 삭제 중 오류 발생: \(error)")
                 completion(.failure(error))
                 return
             }
             
-            // 🔥 Firebase Auth 계정 삭제
-            user.delete { error in
+            Auth.auth().currentUser?.delete { error in
                 if let error = error {
-                    print("Firebase Auth 계정 삭제 실패: \(error.localizedDescription)")
+                    print("🔴 Firebase Auth 계정 삭제 실패: \(error.localizedDescription)")
                     completion(.failure(error))
                     return
                 }
-                print("🔥 Firebase Auth 계정 삭제 성공")
+                print("🟢 Firebase Auth 계정 삭제 성공 - 모든 데이터 완전 삭제")
                 completion(.success(()))
             }
         }
     }
 
+    /// 모든 소셜 로그인 제공자별 연결 데이터를 Firestore에서 삭제합니다
+    /// - Parameters:
+    ///   - uid: 사용자 ID
+    ///   - completion: 삭제 완료를 알리는 콜백
+    private func deleteAllSocialConnectionData(uid: String, completion: @escaping (Error?) -> Void) {
+        let group = DispatchGroup()
+        var deletionError: Error?
+        
+        group.enter()
+        db.collection("users").whereField("kakaoId", isGreaterThan: 0).getDocuments { snapshot, error in
+            if let error = error {
+                deletionError = error
+            } else if let documents = snapshot?.documents {
+                for document in documents.filter({ $0.data()["uid"] as? String == uid }) {
+                    document.reference.delete()
+                    print("🟢 kakaoId 기반 문서 삭제: \(document.documentID)")
+                }
+            }
+            group.leave()
+        }
+        
+        group.enter()
+        db.collection("users").whereField("googleId", isGreaterThan: "").getDocuments { snapshot, error in
+            if let error = error {
+                deletionError = error
+            } else if let documents = snapshot?.documents {
+                for document in documents.filter({ $0.data()["uid"] as? String == uid }) {
+                    document.reference.delete()
+                    print("🟢 googleId 기반 문서 삭제: \(document.documentID)")
+                }
+            }
+            group.leave()
+        }
+        
+        group.enter()
+        db.collection("users").whereField("appleId", isGreaterThan: "").getDocuments { snapshot, error in
+            if let error = error {
+                deletionError = error
+            } else if let documents = snapshot?.documents {
+                for document in documents.filter({ $0.data()["uid"] as? String == uid }) {
+                    document.reference.delete()
+                    print("🟢 appleId 기반 문서 삭제: \(document.documentID)")
+                }
+            }
+            group.leave()
+        }
+        
+        group.notify(queue: .main) {
+            completion(deletionError)
+        }
+    }
 
-    /// 기본 Firestore 데이터 설정
+    /// 익명 사용자를 위한 기본 Firestore 데이터를 설정합니다
     /// - Parameter uid: 사용자 ID
     private func setupDefaultFirestoreData(uid: String) {
         let userRef = db.collection("defaults").document(uid)

--- a/HowManySet/Data/Firebase/FirebaseAuthServiceProtocol.swift
+++ b/HowManySet/Data/Firebase/FirebaseAuthServiceProtocol.swift
@@ -10,6 +10,12 @@ import Foundation
 /// Firebase Auth 서비스를 정의하는 프로토콜
 /// - Firebase Auth의 기본 기능들을 추상화
 public protocol FirebaseAuthServiceProtocol {
+    /// 커스텀 토큰으로 로그인
+    /// - Parameters:
+    ///   - customToken: Firebase 커스텀 토큰
+    ///   - completion: 로그인 결과 콜백
+    func signInWithCustomToken(_ customToken: String, completion: @escaping (Result<User, Error>) -> Void)
+    
     /// 익명 로그인 처리
     /// - Parameter completion: 로그인 결과 콜백
     func signInAnonymously(completion: @escaping (Result<User, Error>) -> Void)

--- a/HowManySet/Data/Firebase/Repositories/AuthRepositoryImpl.swift
+++ b/HowManySet/Data/Firebase/Repositories/AuthRepositoryImpl.swift
@@ -15,20 +15,25 @@ import KakaoSDKAuth
 import KakaoSDKUser
 
 /// 인증 관련 데이터 처리를 담당하는 Repository 구현체
-/// - Firebase Auth와 각종 소셜 로그인을 통합하여 처리
-/// - Realm과 Firestore 데이터 동기화를 고려한 최소한의 코드 변경 구조
+///
+/// Firebase Auth와 각종 소셜 로그인을 통합하여 처리하며,
+/// 출시 수준의 완전한 로그인 플로우를 구현합니다.
+/// 로그아웃 후 재로그인 문제를 해결하여 온보딩 상태를 올바르게 유지합니다.
 public final class AuthRepositoryImpl: AuthRepositoryProtocol {
     
     private let firebaseAuthService: FirebaseAuthServiceProtocol
 
-    /// AuthRepositoryImpl 생성자
-    /// - Parameter firebaseAuthService: Firebase 인증 서비스
+    /// AuthRepositoryImpl 인스턴스를 생성합니다
+    /// - Parameter firebaseAuthService: Firebase 인증 서비스 프로토콜 구현체
     public init(firebaseAuthService: FirebaseAuthServiceProtocol) {
         self.firebaseAuthService = firebaseAuthService
     }
 
-    /// 카카오 로그인 처리 (익명 로그인 방식으로 Firebase 연동)
-    /// - Returns: 로그인된 사용자 정보 Observable
+    /// 카카오 계정으로 로그인을 수행합니다
+    ///
+    /// 로그아웃 후 재로그인 시 기존 온보딩 상태를 유지하도록 개선되었습니다.
+    /// Firebase Auth 상태와 무관하게 Firestore에서 기존 사용자를 조회합니다.
+    /// - Returns: 로그인된 사용자 정보를 방출하는 Observable
     public func signInWithKakao() -> Observable<User> {
         return Observable.create { observer in
             let loginHandler: ((OAuthToken?, Error?) -> Void) = { token, error in
@@ -55,78 +60,40 @@ public final class AuthRepositoryImpl: AuthRepositoryProtocol {
                     
                     print("카카오 사용자 정보 성공: \(nickname) / \(kakaoId)")
                     
-                    // 기존 카카오 사용자 확인
-                    let db = Firestore.firestore()
-                    db.collection("users").whereField("kakaoId", isEqualTo: kakaoId).getDocuments { snapshot, error in
-                        if let error = error {
-                            print("Firestore 조회 실패: \(error)")
-                            observer.onError(error)
-                            return
-                        }
-                        
-                        if let documents = snapshot?.documents, !documents.isEmpty {
-                            // 기존 사용자 발견
-                            let existingUserData = documents.first!.data()
-                            if let uid = existingUserData["uid"] as? String {
-                                print("기존 카카오 사용자 발견: \(uid)")
-                                
-                                // 기존 사용자로 Firebase 인증
-                                let userDTO = UserDTO(
-                                    uid: uid,
-                                    name: nickname,
-                                    provider: "kakao",
-                                    email: user.kakaoAccount?.email,
-                                    hasSetNickname: existingUserData["hasSetNickname"] as? Bool ?? false,
-                                    hasCompletedOnboarding: existingUserData["hasCompletedOnboarding"] as? Bool ?? false
-                                )
-                                observer.onNext(userDTO.toEntity())
-                                observer.onCompleted()
-                                return
-                            }
-                        }
-                        
-                        // 새 사용자 - 익명 로그인 후 카카오 정보 연결
-                        Auth.auth().signInAnonymously { authResult, error in
-                            if let error = error {
-                                print("익명 로그인 실패: \(error)")
-                                observer.onError(error)
-                                return
-                            }
-                            
-                            guard let authResult = authResult else {
-                                observer.onError(NSError(domain: "AnonymousSignIn", code: -1))
-                                return
-                            }
-                            
-                            print("익명 로그인 성공: \(authResult.user.uid)")
-                            
-                            // Firestore에 카카오 사용자 정보 저장
-                            let userDTO = UserDTO(
-                                uid: authResult.user.uid,
-                                name: nickname,
-                                provider: "kakao",
-                                email: user.kakaoAccount?.email,
-                                hasSetNickname: false,
-                                hasCompletedOnboarding: false
-                            )
-                            
-                            // 카카오 ID를 별도로 저장하여 중복 로그인 방지
-                            var firestoreData = userDTO.toFirestoreData()
-                            firestoreData["kakaoId"] = kakaoId
-                            
-                            db.collection("users").document(authResult.user.uid).setData(firestoreData, merge: true) { error in
-                                if let error = error {
-                                    print("Firestore 저장 실패: \(error)")
-                                    observer.onError(error)
-                                    return
+                    self.findExistingKakaoUser(kakaoId: kakaoId)
+                        .subscribe(
+                            onNext: { existingUser in
+                                if let existingUser = existingUser {
+                                    print("🟢 기존 카카오 사용자 발견: \(existingUser.uid)")
+                                    print("🔍 기존 사용자 온보딩 상태: hasSetNickname=\(existingUser.hasSetNickname), hasCompletedOnboarding=\(existingUser.hasCompletedOnboarding)")
+                                    
+                                    self.reconnectExistingKakaoUser(existingUser, kakaoId: kakaoId, nickname: nickname, email: user.kakaoAccount?.email) { result in
+                                        switch result {
+                                        case .success(let user):
+                                            observer.onNext(user)
+                                            observer.onCompleted()
+                                        case .failure(let error):
+                                            observer.onError(error)
+                                        }
+                                    }
+                                } else {
+                                    print("🔴 새로운 카카오 사용자 - 계정 생성")
+                                    self.createNewKakaoUser(kakaoId: kakaoId, nickname: nickname, email: user.kakaoAccount?.email) { result in
+                                        switch result {
+                                        case .success(let user):
+                                            observer.onNext(user)
+                                            observer.onCompleted()
+                                        case .failure(let error):
+                                            observer.onError(error)
+                                        }
+                                    }
                                 }
-                                
-                                print("카카오 로그인 완료: \(authResult.user.uid)")
-                                observer.onNext(userDTO.toEntity())
-                                observer.onCompleted()
+                            },
+                            onError: { error in
+                                print("기존 사용자 조회 실패: \(error)")
+                                observer.onError(error)
                             }
-                        }
-                    }
+                        )
                 }
             }
 
@@ -142,13 +109,14 @@ public final class AuthRepositoryImpl: AuthRepositoryProtocol {
         }
     }
 
-    /// 구글 로그인 처리
-    /// - Returns: 로그인된 사용자 정보 Observable
+    /// 구글 계정으로 로그인을 수행합니다
+    ///
+    /// Firebase Auth와 직접 연결하여 안정적인 로그인을 제공합니다.
+    /// - Returns: 로그인된 사용자 정보를 방출하는 Observable
     public func signInWithGoogle() -> Observable<User> {
         return Observable.create { observer in
             print("구글 로그인 시작")
             
-            // Google Sign-In 설정 확인
             guard GIDSignIn.sharedInstance.configuration != nil else {
                 print("Google Sign-In 설정 없음")
                 observer.onError(NSError(domain: "GoogleSignIn", code: -1, userInfo: [NSLocalizedDescriptionKey: "Google Sign-In not configured"]))
@@ -196,19 +164,47 @@ public final class AuthRepositoryImpl: AuthRepositoryProtocol {
                         return
                     }
 
-                    print("구글 로그인 성공: \(authResult.user.uid)")
-                    let userDTO = UserDTO(
-                        uid: authResult.user.uid,
-                        name: user.profile?.name ?? "구글 사용자",
-                        provider: "google",
-                        email: user.profile?.email,
-                        hasSetNickname: false,
-                        hasCompletedOnboarding: false
-                    )
+                    print("🟢 구글 로그인 성공: \(authResult.user.uid)")
                     
-                    self.saveUserToFirestore(userDTO)
-                    observer.onNext(userDTO.toEntity())
-                    observer.onCompleted()
+                    self.fetchUserInfo(uid: authResult.user.uid)
+                        .subscribe(
+                            onNext: { firestoreUser in
+                                if let firestoreUser = firestoreUser {
+                                    print("🟢 기존 구글 사용자 Firestore 정보 발견")
+                                    observer.onNext(firestoreUser)
+                                } else {
+                                    print("🔴 새로운 구글 사용자 - Firestore 정보 생성")
+                                    let newUserDTO = UserDTO(
+                                        uid: authResult.user.uid,
+                                        name: user.profile?.name ?? "구글 사용자",
+                                        provider: "google",
+                                        email: user.profile?.email,
+                                        hasSetNickname: false,
+                                        hasCompletedOnboarding: false,
+                                        googleId: user.userID
+                                    )
+                                    
+                                    self.saveUserToFirestore(newUserDTO)
+                                    observer.onNext(newUserDTO.toEntity())
+                                }
+                                observer.onCompleted()
+                            },
+                            onError: { error in
+                                print("Firestore 사용자 정보 조회 실패: \(error)")
+                                let userDTO = UserDTO(
+                                    uid: authResult.user.uid,
+                                    name: user.profile?.name ?? "구글 사용자",
+                                    provider: "google",
+                                    email: user.profile?.email,
+                                    hasSetNickname: false,
+                                    hasCompletedOnboarding: false,
+                                    googleId: user.userID
+                                )
+                                self.saveUserToFirestore(userDTO)
+                                observer.onNext(userDTO.toEntity())
+                                observer.onCompleted()
+                            }
+                        )
                 }
             }
 
@@ -216,25 +212,22 @@ public final class AuthRepositoryImpl: AuthRepositoryProtocol {
         }
     }
 
-    /// Apple 로그인 처리
+    /// Apple ID로 로그인을 수행합니다
+    ///
+    /// Firebase Auth와 직접 연결하여 안정적인 로그인을 제공합니다.
     /// - Parameters:
     ///   - token: Apple ID 토큰
     ///   - nonce: 보안을 위한 nonce 값
-    /// - Returns: 로그인된 사용자 정보 Observable
+    /// - Returns: 로그인된 사용자 정보를 방출하는 Observable
     public func signInWithApple(token: String, nonce: String) -> Observable<User> {
         return Observable.create { observer in
             print("Apple 로그인 시작")
-            print("Token: \(token.prefix(50))...")
-            print("Nonce: \(nonce)")
             
             let credential = OAuthProvider.credential(withProviderID: "apple.com", idToken: token, rawNonce: nonce)
-            print("Firebase Credential 생성 완료")
 
             Auth.auth().signIn(with: credential) { authResult, error in
                 if let error = error {
                     print("Firebase Apple 로그인 실패: \(error)")
-                    print("Error Code: \((error as NSError).code)")
-                    print("Error Domain: \((error as NSError).domain)")
                     observer.onError(error)
                     return
                 }
@@ -245,31 +238,55 @@ public final class AuthRepositoryImpl: AuthRepositoryProtocol {
                     return
                 }
                 
-                print("Apple 로그인 성공")
-                print("UID: \(authResult.user.uid)")
-                print("Email: \(authResult.user.email ?? "nil")")
-                print("DisplayName: \(authResult.user.displayName ?? "nil")")
+                print("🟢 Apple 로그인 성공: \(authResult.user.uid)")
 
-                let userDTO = UserDTO(
-                    uid: authResult.user.uid,
-                    name: authResult.user.displayName ?? "Apple 사용자",
-                    provider: "apple",
-                    email: authResult.user.email,
-                    hasSetNickname: false,
-                    hasCompletedOnboarding: false
-                )
-                
-                self.saveUserToFirestore(userDTO)
-                observer.onNext(userDTO.toEntity())
-                observer.onCompleted()
+                self.fetchUserInfo(uid: authResult.user.uid)
+                    .subscribe(
+                        onNext: { firestoreUser in
+                            if let firestoreUser = firestoreUser {
+                                print("🟢 기존 Apple 사용자 Firestore 정보 발견")
+                                observer.onNext(firestoreUser)
+                            } else {
+                                print("🔴 새로운 Apple 사용자 - Firestore 정보 생성")
+                                let newUserDTO = UserDTO(
+                                    uid: authResult.user.uid,
+                                    name: authResult.user.displayName ?? "Apple 사용자",
+                                    provider: "apple",
+                                    email: authResult.user.email,
+                                    hasSetNickname: false,
+                                    hasCompletedOnboarding: false,
+                                    appleId: authResult.user.uid
+                                )
+                                
+                                self.saveUserToFirestore(newUserDTO)
+                                observer.onNext(newUserDTO.toEntity())
+                            }
+                            observer.onCompleted()
+                        },
+                        onError: { error in
+                            print("Firestore 사용자 정보 조회 실패: \(error)")
+                            let userDTO = UserDTO(
+                                uid: authResult.user.uid,
+                                name: authResult.user.displayName ?? "Apple 사용자",
+                                provider: "apple",
+                                email: authResult.user.email,
+                                hasSetNickname: false,
+                                hasCompletedOnboarding: false,
+                                appleId: authResult.user.uid
+                            )
+                            self.saveUserToFirestore(userDTO)
+                            observer.onNext(userDTO.toEntity())
+                            observer.onCompleted()
+                        }
+                    )
             }
 
             return Disposables.create()
         }
     }
 
-    /// 익명 로그인 처리
-    /// - Returns: 로그인된 사용자 정보 Observable
+    /// 익명 로그인을 수행합니다
+    /// - Returns: 익명 사용자 정보를 방출하는 Observable
     public func signInAnonymously() -> Observable<User> {
         return Observable.create { observer in
             print("익명 로그인 시작")
@@ -288,8 +305,8 @@ public final class AuthRepositoryImpl: AuthRepositoryProtocol {
         }
     }
 
-    /// 로그아웃 처리
-    /// - Returns: 로그아웃 결과 Observable
+    /// 현재 사용자를 로그아웃시킵니다
+    /// - Returns: 로그아웃 완료를 알리는 Observable
     public func signOut() -> Observable<Void> {
         return Observable.create { observer in
             print("로그아웃 시작")
@@ -307,8 +324,8 @@ public final class AuthRepositoryImpl: AuthRepositoryProtocol {
         }
     }
 
-    /// 계정 삭제 처리
-    /// - Returns: 계정 삭제 결과 Observable
+    /// 현재 사용자의 계정을 완전히 삭제합니다
+    /// - Returns: 계정 삭제 완료를 알리는 Observable
     public func deleteAccount() -> Observable<Void> {
         return Observable.create { observer in
             print("계정 삭제 시작")
@@ -327,9 +344,9 @@ public final class AuthRepositoryImpl: AuthRepositoryProtocol {
         }
     }
 
-    /// 사용자 정보 조회
-    /// - Parameter uid: 사용자 ID
-    /// - Returns: 사용자 정보 Observable
+    /// 특정 사용자의 정보를 Firestore에서 조회합니다
+    /// - Parameter uid: 조회할 사용자의 고유 식별자
+    /// - Returns: 사용자 정보를 방출하는 Observable (사용자가 없으면 nil)
     public func fetchUserInfo(uid: String) -> Observable<User?> {
         return Observable.create { observer in
             let db = Firestore.firestore()
@@ -354,22 +371,28 @@ public final class AuthRepositoryImpl: AuthRepositoryProtocol {
         }
     }
 
-    /// 사용자 닉네임 업데이트
+    /// 사용자의 닉네임을 업데이트합니다
+    ///
+    /// setData with merge를 사용하여 문서가 없으면 생성하고 있으면 업데이트합니다.
     /// - Parameters:
-    ///   - uid: 사용자 ID
-    ///   - nickname: 새 닉네임
-    /// - Returns: 업데이트 결과 Observable
+    ///   - uid: 사용자 고유 식별자
+    ///   - nickname: 새로운 닉네임
+    /// - Returns: 업데이트 완료를 알리는 Observable
     public func updateUserNickname(uid: String, nickname: String) -> Observable<Void> {
         return Observable.create { observer in
             let db = Firestore.firestore()
-            db.collection("users").document(uid).updateData([
+            db.collection("users").document(uid).setData([
+                "uid": uid,
                 "name": nickname,
-                "hasSetNickname": true
-            ]) { error in
+                "hasSetNickname": true,
+                "lastUpdatedAt": FieldValue.serverTimestamp()
+            ], merge: true) { error in
                 if let error = error {
+                    print("🔴 닉네임 업데이트 실패: \(error)")
                     observer.onError(error)
                     return
                 }
+                print("🟢 닉네임 Firestore 업데이트 성공: \(nickname)")
                 observer.onNext(())
                 observer.onCompleted()
             }
@@ -377,21 +400,33 @@ public final class AuthRepositoryImpl: AuthRepositoryProtocol {
         }
     }
 
-    /// 온보딩 상태 업데이트
+    /// 사용자의 온보딩 완료 상태를 업데이트합니다
+    ///
+    /// setData with merge를 사용하여 문서가 없으면 생성하고 있으면 업데이트합니다.
     /// - Parameters:
-    ///   - uid: 사용자 ID
+    ///   - uid: 사용자 고유 식별자
     ///   - completed: 온보딩 완료 여부
-    /// - Returns: 업데이트 결과 Observable
+    /// - Returns: 업데이트 완료를 알리는 Observable
     public func updateOnboardingStatus(uid: String, completed: Bool) -> Observable<Void> {
         return Observable.create { observer in
             let db = Firestore.firestore()
-            db.collection("users").document(uid).updateData([
-                "hasCompletedOnboarding": completed
-            ]) { error in
+            var updateData: [String: Any] = [
+                "uid": uid,
+                "hasCompletedOnboarding": completed,
+                "lastUpdatedAt": FieldValue.serverTimestamp()
+            ]
+            
+            if completed {
+                updateData["onboardingCompletedAt"] = FieldValue.serverTimestamp()
+            }
+            
+            db.collection("users").document(uid).setData(updateData, merge: true) { error in
                 if let error = error {
+                    print("🔴 온보딩 상태 업데이트 실패: \(error)")
                     observer.onError(error)
                     return
                 }
+                print("🟢 온보딩 상태 Firestore 업데이트 성공: \(completed)")
                 observer.onNext(())
                 observer.onCompleted()
             }
@@ -399,16 +434,280 @@ public final class AuthRepositoryImpl: AuthRepositoryProtocol {
         }
     }
 
-    /// 사용자 정보를 Firestore에 저장
+    /// 사용자의 온보딩 상태를 초기화합니다
+    /// - Parameter uid: 사용자 고유 식별자
+    /// - Returns: 초기화 완료를 알리는 Observable
+    public func resetUserOnboardingStatus(uid: String) -> Observable<Void> {
+        return Observable.create { observer in
+            let db = Firestore.firestore()
+            db.collection("users").document(uid).setData([
+                "uid": uid,
+                "hasSetNickname": false,
+                "hasCompletedOnboarding": false,
+                "lastUpdatedAt": FieldValue.serverTimestamp()
+            ], merge: true) { error in
+                if let error = error {
+                    print("Firestore 온보딩 상태 초기화 실패: \(error)")
+                    observer.onError(error)
+                    return
+                }
+                print("Firestore 온보딩 상태 초기화 성공")
+                observer.onNext(())
+                observer.onCompleted()
+            }
+            return Disposables.create()
+        }
+    }
+
+    /// 현재 로그인된 사용자의 정보를 가져옵니다
+    ///
+    /// Firebase Auth 사용자가 있으면 Firestore에서 상세 정보를 조회하고,
+    /// 없으면 Firebase Auth 기본 정보를 사용합니다.
+    /// - Returns: 현재 사용자 정보를 방출하는 Observable (로그인되지 않은 경우 nil)
+    public func getCurrentUser() -> Observable<User?> {
+        return Observable.create { observer in
+            if let currentUser = Auth.auth().currentUser {
+                self.fetchUserInfo(uid: currentUser.uid)
+                    .subscribe(
+                        onNext: { firestoreUser in
+                            if let firestoreUser = firestoreUser {
+                                observer.onNext(firestoreUser)
+                            } else {
+                                let user = User(
+                                    uid: currentUser.uid,
+                                    name: currentUser.displayName ?? "사용자",
+                                    provider: "firebase",
+                                    email: currentUser.email
+                                )
+                                observer.onNext(user)
+                            }
+                            observer.onCompleted()
+                        },
+                        onError: { error in
+                            print("Firestore 사용자 정보 조회 실패: \(error)")
+                            let user = User(
+                                uid: currentUser.uid,
+                                name: currentUser.displayName ?? "사용자",
+                                provider: "firebase",
+                                email: currentUser.email
+                            )
+                            observer.onNext(user)
+                            observer.onCompleted()
+                        }
+                    )
+            } else {
+                observer.onNext(nil)
+                observer.onCompleted()
+            }
+            return Disposables.create()
+        }
+    }
+
+    /// 소셜 로그인 제공자별 고유 식별자로 기존 사용자를 찾습니다
+    ///
+    /// 계정 삭제 후 재로그인 시 새 사용자로 처리하도록 개선되었습니다.
+    /// Firebase Auth에서 해당 사용자가 실제로 존재하는지 확인합니다.
+    /// - Parameters:
+    ///   - kakaoId: 카카오 사용자 고유 식별자 (선택적)
+    ///   - googleId: 구글 사용자 고유 식별자 (선택적)
+    ///   - appleId: Apple 사용자 고유 식별자 (선택적)
+    /// - Returns: 기존 사용자 정보를 방출하는 Observable (없으면 nil)
+    public func findExistingUser(kakaoId: Int64?, googleId: String?, appleId: String?) -> Observable<User?> {
+        return Observable.create { observer in
+            let db = Firestore.firestore()
+            var query: Query?
+            
+            if let kakaoId = kakaoId {
+                query = db.collection("users").whereField("kakaoId", isEqualTo: kakaoId)
+            } else if let googleId = googleId {
+                query = db.collection("users").whereField("googleId", isEqualTo: googleId)
+            } else if let appleId = appleId {
+                query = db.collection("users").whereField("appleId", isEqualTo: appleId)
+            }
+            
+            guard let query = query else {
+                observer.onNext(nil)
+                observer.onCompleted()
+                return Disposables.create()
+            }
+            
+            query.getDocuments { snapshot, error in
+                if let error = error {
+                    observer.onError(error)
+                    return
+                }
+                
+                guard let documents = snapshot?.documents, !documents.isEmpty else {
+                    print("🔴 기존 사용자 없음 - 새 사용자로 처리")
+                    observer.onNext(nil)
+                    observer.onCompleted()
+                    return
+                }
+                
+                let firstDoc = documents.first!
+                let uid = firstDoc.documentID
+                
+                if let currentUser = Auth.auth().currentUser, currentUser.uid == uid {
+                    if let userDTO = UserDTO.from(uid: uid, data: firstDoc.data()) {
+                        print("🟢 유효한 기존 사용자 발견: \(uid)")
+                        observer.onNext(userDTO.toEntity())
+                    } else {
+                        print("🔴 잘못된 사용자 데이터 - 새 사용자로 처리")
+                        observer.onNext(nil)
+                    }
+                    observer.onCompleted()
+                } else {
+                    print("🔴 Firebase Auth에 없는 사용자 또는 계정 삭제 후 재로그인 - Firestore 문서 삭제")
+                    firstDoc.reference.delete { _ in
+                        print("🟢 기존 Firestore 문서 삭제 완료 - 새 사용자로 처리")
+                        observer.onNext(nil)
+                        observer.onCompleted()
+                    }
+                }
+            }
+            return Disposables.create()
+        }
+    }
+
+    // MARK: - Private Methods
+
+    /// Firebase Auth 상태와 무관하게 카카오 사용자를 직접 조회합니다
+    ///
+    /// 로그아웃 후 재로그인 문제를 해결하기 위해 추가된 메서드입니다.
+    /// - Parameter kakaoId: 카카오 사용자 고유 식별자
+    /// - Returns: 기존 사용자 정보를 방출하는 Observable (없으면 nil)
+    private func findExistingKakaoUser(kakaoId: Int64) -> Observable<User?> {
+        return Observable.create { observer in
+            let db = Firestore.firestore()
+            
+            db.collection("users").whereField("kakaoId", isEqualTo: kakaoId).getDocuments { snapshot, error in
+                if let error = error {
+                    print("🔴 카카오 기존 사용자 조회 실패: \(error)")
+                    observer.onError(error)
+                    return
+                }
+                
+                guard let documents = snapshot?.documents, !documents.isEmpty else {
+                    print("🔴 카카오 기존 사용자 없음")
+                    observer.onNext(nil)
+                    observer.onCompleted()
+                    return
+                }
+                
+                let firstDoc = documents.first!
+                let uid = firstDoc.documentID
+                
+                if let userDTO = UserDTO.from(uid: uid, data: firstDoc.data()) {
+                    print("🟢 카카오 기존 사용자 발견: \(uid)")
+                    print("🔍 온보딩 상태: hasSetNickname=\(userDTO.hasSetNickname), hasCompletedOnboarding=\(userDTO.hasCompletedOnboarding)")
+                    observer.onNext(userDTO.toEntity())
+                } else {
+                    print("🔴 카카오 사용자 데이터 파싱 실패")
+                    observer.onNext(nil)
+                }
+                observer.onCompleted()
+            }
+            
+            return Disposables.create()
+        }
+    }
+
+    /// 기존 카카오 사용자의 Firebase Auth를 재연결합니다
+    ///
+    /// 기존 온보딩 상태를 유지하면서 새로운 Firebase Auth UID로 업데이트합니다.
+    /// - Parameters:
+    ///   - user: 기존 사용자 정보
+    ///   - kakaoId: 카카오 사용자 고유 식별자
+    ///   - nickname: 사용자 닉네임
+    ///   - email: 사용자 이메일 (선택적)
+    ///   - completion: 재연결 결과를 반환하는 콜백
+    private func reconnectExistingKakaoUser(_ user: User, kakaoId: Int64, nickname: String, email: String?, completion: @escaping (Result<User, Error>) -> Void) {
+        print("🔄 기존 카카오 사용자 Firebase Auth 재연결 시작")
+        
+        Auth.auth().signInAnonymously { authResult, error in
+            if let error = error {
+                print("🔴 Firebase Auth 재연결 실패: \(error)")
+                completion(.failure(error))
+                return
+            }
+            
+            guard let authResult = authResult else {
+                completion(.failure(NSError(domain: "AnonymousSignIn", code: -1)))
+                return
+            }
+            
+            print("🟢 Firebase Auth 재연결 성공: \(authResult.user.uid)")
+            
+            let updatedUserDTO = UserDTO(
+                uid: authResult.user.uid,
+                name: user.name,
+                provider: "kakao",
+                email: email,
+                hasSetNickname: user.hasSetNickname,
+                hasCompletedOnboarding: user.hasCompletedOnboarding,
+                kakaoId: kakaoId
+            )
+            
+            let db = Firestore.firestore()
+            db.collection("users").document(user.uid).delete { deleteError in
+                if let deleteError = deleteError {
+                    print("🔴 기존 문서 삭제 실패: \(deleteError)")
+                }
+                
+                self.saveUserToFirestore(updatedUserDTO)
+                
+                print("🟢 기존 카카오 사용자 재연결 완료 - 온보딩 상태 유지")
+                completion(.success(updatedUserDTO.toEntity()))
+            }
+        }
+    }
+
+    /// 새로운 카카오 사용자를 생성합니다
+    /// - Parameters:
+    ///   - kakaoId: 카카오 사용자 고유 식별자
+    ///   - nickname: 사용자 닉네임
+    ///   - email: 사용자 이메일 (선택적)
+    ///   - completion: 생성 결과를 반환하는 콜백
+    private func createNewKakaoUser(kakaoId: Int64, nickname: String, email: String?, completion: @escaping (Result<User, Error>) -> Void) {
+        Auth.auth().signInAnonymously { authResult, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+            
+            guard let authResult = authResult else {
+                completion(.failure(NSError(domain: "AnonymousSignIn", code: -1)))
+                return
+            }
+            
+            print("🟢 새 카카오 사용자 생성: \(authResult.user.uid)")
+            
+            let userDTO = UserDTO(
+                uid: authResult.user.uid,
+                name: nickname,
+                provider: "kakao",
+                email: email,
+                hasSetNickname: false,
+                hasCompletedOnboarding: false,
+                kakaoId: kakaoId
+            )
+            
+            self.saveUserToFirestore(userDTO)
+            completion(.success(userDTO.toEntity()))
+        }
+    }
+
+    /// 사용자 정보를 Firestore에 저장합니다
+    ///
+    /// setData with merge를 사용하여 문서가 없으면 생성하고 있으면 병합합니다.
     /// - Parameter dto: 저장할 사용자 정보 DTO
-    /// - Note: Realm과 Firestore 데이터 동기화를 위한 구조
     private func saveUserToFirestore(_ dto: UserDTO) {
         let db = Firestore.firestore()
         db.collection("users").document(dto.uid).setData(dto.toFirestoreData(), merge: true) { error in
             if let error = error {
-                print("Firestore 저장 실패: \(error.localizedDescription)")
+                print("🔴 Firestore 저장 실패: \(error.localizedDescription)")
             } else {
-                print("Firestore 저장 성공: \(dto.uid)")
+                print("🟢 Firestore 저장 성공: \(dto.uid)")
             }
         }
     }

--- a/HowManySet/Domain/Entity/User.swift
+++ b/HowManySet/Domain/Entity/User.swift
@@ -7,37 +7,57 @@
 
 import Foundation
 
-/// 사용자 상태 열거형
+/// 사용자 온보딩 상태를 나타내는 열거형
 public enum UserStatus {
-    case needsOnboarding    // 온보딩 필요 (닉네임 입력 + 온보딩)
-    case complete           // 모든 설정 완료
+    /// 온보딩이 필요한 상태 (닉네임 입력 + 온보딩 진행 필요)
+    case needsOnboarding
+    /// 모든 설정이 완료된 상태
+    case complete
 }
 
-/// 사용자 정보를 나타내는 도메인 모델
-/// - 앱 전체에서 사용되는 통합된 사용자 모델
+/// 앱 전체에서 사용되는 통합된 사용자 도메인 모델
+///
+/// Firebase Auth와 Firestore에서 관리되는 사용자 정보를 캡슐화하며,
+/// 다양한 로그인 제공자(카카오, 구글, Apple, 익명)를 지원합니다.
 public struct User {
-    /// Firebase Auth에서 제공하는 고유 사용자 ID
+    /// Firebase Auth에서 제공하는 고유 사용자 식별자
     public let uid: String
-    /// 사용자 이름 (닉네임)
+    
+    /// 사용자 닉네임
     public let name: String
-    /// 로그인 제공자 (kakao, google, apple, anonymous)
+    
+    /// 로그인 제공자 식별자
+    /// - "kakao": 카카오 로그인
+    /// - "google": 구글 로그인
+    /// - "apple": Apple 로그인
+    /// - "anonymous": 익명 로그인
     public let provider: String
-    /// 사용자 이메일 (선택적)
+    
+    /// 사용자 이메일 주소 (선택적)
     public let email: String?
+    
     /// 닉네임 설정 완료 여부
     public let hasSetNickname: Bool
-    /// 온보딩 완료 여부
+    
+    /// 온보딩 프로세스 완료 여부
     public let hasCompletedOnboarding: Bool
 
-    /// User 모델 생성자
+    /// User 인스턴스를 생성합니다
     /// - Parameters:
     ///   - uid: Firebase Auth 사용자 ID
-    ///   - name: 사용자 이름
-    ///   - provider: 로그인 제공자
+    ///   - name: 사용자 닉네임
+    ///   - provider: 로그인 제공자 식별자
     ///   - email: 사용자 이메일 (선택적)
-    ///   - hasSetNickname: 닉네임 설정 완료 여부
-    ///   - hasCompletedOnboarding: 온보딩 완료 여부
-    public init(uid: String, name: String, provider: String, email: String? = nil, hasSetNickname: Bool = false, hasCompletedOnboarding: Bool = false) {
+    ///   - hasSetNickname: 닉네임 설정 완료 여부 (기본값: false)
+    ///   - hasCompletedOnboarding: 온보딩 완료 여부 (기본값: false)
+    public init(
+        uid: String,
+        name: String,
+        provider: String,
+        email: String? = nil,
+        hasSetNickname: Bool = false,
+        hasCompletedOnboarding: Bool = false
+    ) {
         self.uid = uid
         self.name = name
         self.provider = provider

--- a/HowManySet/Domain/Entity/User.swift
+++ b/HowManySet/Domain/Entity/User.swift
@@ -9,8 +9,7 @@ import Foundation
 
 /// 사용자 상태 열거형
 public enum UserStatus {
-    case needsNickname      // 닉네임 설정 필요
-    case needsOnboarding    // 온보딩 필요
+    case needsOnboarding    // 온보딩 필요 (닉네임 입력 + 온보딩)
     case complete           // 모든 설정 완료
 }
 

--- a/HowManySet/Domain/Entity/User.swift
+++ b/HowManySet/Domain/Entity/User.swift
@@ -18,6 +18,10 @@ public struct User {
     public let provider: String
     /// 사용자 이메일 (선택적)
     public let email: String?
+    /// 닉네임 설정 완료 여부
+    public let hasSetNickname: Bool
+    /// 온보딩 완료 여부
+    public let hasCompletedOnboarding: Bool
 
     /// User 모델 생성자
     /// - Parameters:
@@ -25,10 +29,14 @@ public struct User {
     ///   - name: 사용자 이름
     ///   - provider: 로그인 제공자
     ///   - email: 사용자 이메일 (선택적)
-    public init(uid: String, name: String, provider: String, email: String? = nil) {
+    ///   - hasSetNickname: 닉네임 설정 완료 여부
+    ///   - hasCompletedOnboarding: 온보딩 완료 여부
+    public init(uid: String, name: String, provider: String, email: String? = nil, hasSetNickname: Bool = false, hasCompletedOnboarding: Bool = false) {
         self.uid = uid
         self.name = name
         self.provider = provider
         self.email = email
+        self.hasSetNickname = hasSetNickname
+        self.hasCompletedOnboarding = hasCompletedOnboarding
     }
 }

--- a/HowManySet/Domain/Entity/User.swift
+++ b/HowManySet/Domain/Entity/User.swift
@@ -7,6 +7,13 @@
 
 import Foundation
 
+/// 사용자 상태 열거형
+public enum UserStatus {
+    case needsNickname      // 닉네임 설정 필요
+    case needsOnboarding    // 온보딩 필요
+    case complete           // 모든 설정 완료
+}
+
 /// 사용자 정보를 나타내는 도메인 모델
 /// - 앱 전체에서 사용되는 통합된 사용자 모델
 public struct User {

--- a/HowManySet/Domain/Repositories/AuthRepository.swift
+++ b/HowManySet/Domain/Repositories/AuthRepository.swift
@@ -1,5 +1,5 @@
 //
-//  AuthRepository.swift
+//  AuthRepositoryProtocol.swift
 //  HowManySet
 //
 //  Created by GO on 6/19/25.
@@ -7,14 +7,74 @@
 
 import RxSwift
 
+/// 인증 관련 데이터 처리를 정의하는 프로토콜
+///
+/// 다양한 소셜 로그인 제공자(카카오, 구글, Apple, 익명)를 지원하며,
+/// Firebase Auth와 Firestore를 통한 사용자 인증 및 데이터 관리 기능을 추상화합니다.
 public protocol AuthRepositoryProtocol {
+    
+    /// 카카오 계정으로 로그인을 수행합니다
+    /// - Returns: 로그인된 사용자 정보를 방출하는 Observable
     func signInWithKakao() -> Observable<User>
+    
+    /// 구글 계정으로 로그인을 수행합니다
+    /// - Returns: 로그인된 사용자 정보를 방출하는 Observable
     func signInWithGoogle() -> Observable<User>
+    
+    /// Apple ID로 로그인을 수행합니다
+    /// - Parameters:
+    ///   - token: Apple ID 토큰
+    ///   - nonce: 보안을 위한 nonce 값
+    /// - Returns: 로그인된 사용자 정보를 방출하는 Observable
     func signInWithApple(token: String, nonce: String) -> Observable<User>
+    
+    /// 익명 로그인을 수행합니다
+    /// - Returns: 익명 사용자 정보를 방출하는 Observable
     func signInAnonymously() -> Observable<User>
+    
+    /// 현재 사용자를 로그아웃시킵니다
+    /// - Returns: 로그아웃 완료를 알리는 Observable
     func signOut() -> Observable<Void>
+    
+    /// 현재 사용자의 계정을 완전히 삭제합니다
+    ///
+    /// 소셜 로그인 연결 해제, Firestore 데이터 삭제, Firebase Auth 계정 삭제를 포함합니다.
+    /// - Returns: 계정 삭제 완료를 알리는 Observable
     func deleteAccount() -> Observable<Void>
+    
+    /// 특정 사용자의 정보를 Firestore에서 조회합니다
+    /// - Parameter uid: 조회할 사용자의 고유 식별자
+    /// - Returns: 사용자 정보를 방출하는 Observable (사용자가 없으면 nil)
     func fetchUserInfo(uid: String) -> Observable<User?>
+    
+    /// 사용자의 닉네임을 업데이트합니다
+    /// - Parameters:
+    ///   - uid: 사용자 고유 식별자
+    ///   - nickname: 새로운 닉네임
+    /// - Returns: 업데이트 완료를 알리는 Observable
     func updateUserNickname(uid: String, nickname: String) -> Observable<Void>
+    
+    /// 사용자의 온보딩 완료 상태를 업데이트합니다
+    /// - Parameters:
+    ///   - uid: 사용자 고유 식별자
+    ///   - completed: 온보딩 완료 여부
+    /// - Returns: 업데이트 완료를 알리는 Observable
     func updateOnboardingStatus(uid: String, completed: Bool) -> Observable<Void>
+    
+    /// 사용자의 온보딩 상태를 초기화합니다
+    /// - Parameter uid: 사용자 고유 식별자
+    /// - Returns: 초기화 완료를 알리는 Observable
+    func resetUserOnboardingStatus(uid: String) -> Observable<Void>
+    
+    /// 현재 로그인된 사용자의 정보를 가져옵니다
+    /// - Returns: 현재 사용자 정보를 방출하는 Observable (로그인되지 않은 경우 nil)
+    func getCurrentUser() -> Observable<User?>
+    
+    /// 소셜 로그인 제공자별 고유 식별자로 기존 사용자를 찾습니다
+    /// - Parameters:
+    ///   - kakaoId: 카카오 사용자 고유 식별자 (선택적)
+    ///   - googleId: 구글 사용자 고유 식별자 (선택적)
+    ///   - appleId: Apple 사용자 고유 식별자 (선택적)
+    /// - Returns: 기존 사용자 정보를 방출하는 Observable (없으면 nil)
+    func findExistingUser(kakaoId: Int64?, googleId: String?, appleId: String?) -> Observable<User?>
 }

--- a/HowManySet/Domain/Repositories/AuthRepository.swift
+++ b/HowManySet/Domain/Repositories/AuthRepository.swift
@@ -14,4 +14,7 @@ public protocol AuthRepositoryProtocol {
     func signInAnonymously() -> Observable<User>
     func signOut() -> Observable<Void>
     func deleteAccount() -> Observable<Void>
+    func fetchUserInfo(uid: String) -> Observable<User?>
+    func updateUserNickname(uid: String, nickname: String) -> Observable<Void>
+    func updateOnboardingStatus(uid: String, completed: Bool) -> Observable<Void>
 }

--- a/HowManySet/Domain/UseCase/Auth/AuthUseCase.swift
+++ b/HowManySet/Domain/UseCase/Auth/AuthUseCase.swift
@@ -9,129 +9,320 @@ import RxSwift
 import Foundation
 
 /// 인증 관련 비즈니스 로직을 처리하는 UseCase 구현체
-/// - Repository를 통해 데이터를 처리하고 비즈니스 규칙을 적용
+///
+/// Repository를 통해 데이터를 처리하고 비즈니스 규칙을 적용하며,
+/// Clean Architecture 원칙에 따라 Firebase에 직접 접근하지 않습니다.
+/// Firestore 기반 닉네임 관리와 익명 사용자 로컬 저장, 완전한 계정 삭제를 지원합니다.
 public final class AuthUseCase: AuthUseCaseProtocol {
     /// 인증 데이터 처리를 담당하는 Repository
     private let repository: AuthRepositoryProtocol
 
-    /// AuthUseCase 생성자
-    /// - Parameter repository: 인증 데이터 처리 Repository
+    /// AuthUseCase 인스턴스를 생성합니다
+    /// - Parameter repository: 인증 데이터 처리를 담당하는 Repository 구현체
     public init(repository: AuthRepositoryProtocol) {
         self.repository = repository
     }
 
-    /// 카카오 로그인 비즈니스 로직
-    /// - Returns: 로그인된 사용자 정보 Observable
+    /// 카카오 계정으로 로그인을 수행합니다
+    ///
+    /// 로그인 성공 시 UserDefaults에 백업 데이터를 저장하며,
+    /// 기존 온보딩 상태를 유지합니다.
+    /// - Returns: 로그인된 사용자 정보를 방출하는 Observable
     public func loginWithKakao() -> Observable<User> {
         return repository.signInWithKakao()
             .do(onNext: { user in
-                print("카카오 로그인 성공: \(user.name)")
+                print("🟢 카카오 로그인 성공: \(user.name) (\(user.uid))")
+                UserDefaults.standard.set(user.name, forKey: "userNickname")
+                UserDefaults.standard.set("kakao", forKey: "userProvider")
+                UserDefaults.standard.set(user.uid, forKey: "userUID")
+                if user.hasCompletedOnboarding {
+                    UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
+                }
+                UserDefaults.standard.synchronize()
+            })
+            .do(onError: { error in
+                print("🔴 카카오 로그인 실패: \(error)")
             })
     }
 
-    /// 구글 로그인 비즈니스 로직
-    /// - Returns: 로그인된 사용자 정보 Observable
+    /// 구글 계정으로 로그인을 수행합니다
+    ///
+    /// 로그인 성공 시 UserDefaults에 백업 데이터를 저장하며,
+    /// 기존 온보딩 상태를 유지합니다.
+    /// - Returns: 로그인된 사용자 정보를 방출하는 Observable
     public func loginWithGoogle() -> Observable<User> {
         return repository.signInWithGoogle()
             .do(onNext: { user in
-                print("구글 로그인 성공: \(user.name)")
+                print("🟢 구글 로그인 성공: \(user.name) (\(user.uid))")
+                UserDefaults.standard.set(user.name, forKey: "userNickname")
+                UserDefaults.standard.set("google", forKey: "userProvider")
+                UserDefaults.standard.set(user.uid, forKey: "userUID")
+                if user.hasCompletedOnboarding {
+                    UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
+                }
+                UserDefaults.standard.synchronize()
+            })
+            .do(onError: { error in
+                print("🔴 구글 로그인 실패: \(error)")
             })
     }
 
-    /// Apple 로그인 비즈니스 로직
+    /// Apple ID로 로그인을 수행합니다
+    ///
+    /// 로그인 성공 시 UserDefaults에 백업 데이터를 저장하며,
+    /// 기존 온보딩 상태를 유지합니다.
     /// - Parameters:
     ///   - token: Apple ID 토큰
     ///   - nonce: 보안을 위한 nonce 값
-    /// - Returns: 로그인된 사용자 정보 Observable
+    /// - Returns: 로그인된 사용자 정보를 방출하는 Observable
     public func loginWithApple(token: String, nonce: String) -> Observable<User> {
         return repository.signInWithApple(token: token, nonce: nonce)
             .do(onNext: { user in
-                print("Apple 로그인 성공: \(user.name)")
+                print("🟢 Apple 로그인 성공: \(user.name) (\(user.uid))")
+                UserDefaults.standard.set(user.name, forKey: "userNickname")
+                UserDefaults.standard.set("apple", forKey: "userProvider")
+                UserDefaults.standard.set(user.uid, forKey: "userUID")
+                if user.hasCompletedOnboarding {
+                    UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
+                }
+                UserDefaults.standard.synchronize()
+            })
+            .do(onError: { error in
+                print("🔴 Apple 로그인 실패: \(error)")
             })
     }
 
-    /// 익명 로그인 비즈니스 로직
-    /// - Returns: 로그인된 사용자 정보 Observable
+    /// 익명 로그인을 수행합니다
+    ///
+    /// 익명 사용자의 경우 모든 데이터를 로컬(UserDefaults)에만 저장합니다.
+    /// - Returns: 익명 사용자 정보를 방출하는 Observable
     public func loginAnonymously() -> Observable<User> {
         return repository.signInAnonymously()
             .do(onNext: { user in
-                print("익명 로그인 성공: \(user.name)")
+                print("🟢 익명 로그인 성공: \(user.name) (\(user.uid))")
+                UserDefaults.standard.set("비회원", forKey: "userNickname")
+                UserDefaults.standard.set("anonymous", forKey: "userProvider")
+                UserDefaults.standard.set(user.uid, forKey: "userUID")
+                UserDefaults.standard.synchronize()
+            })
+            .do(onError: { error in
+                print("🔴 익명 로그인 실패: \(error)")
             })
     }
     
-    /// 로그아웃 비즈니스 로직
-    /// - Returns: 로그아웃 결과 Observable
+    /// 현재 사용자를 로그아웃시킵니다
+    ///
+    /// Firestore의 온보딩 상태는 유지하고 UserDefaults만 초기화합니다.
+    /// 재로그인 시 기존 온보딩 상태를 복원할 수 있습니다.
+    /// - Returns: 로그아웃 완료를 알리는 Observable
     public func logout() -> Observable<Void> {
         return repository.signOut()
             .do(onNext: { _ in
-                print("로그아웃 성공")
-                // 필요시 추가 비즈니스 로직 (캐시 삭제 등)
+                print("🟢 로그아웃 성공 - Firestore 온보딩 상태는 유지됨")
+                UserDefaults.standard.removeObject(forKey: "hasCompletedOnboarding")
+                UserDefaults.standard.removeObject(forKey: "hasSkippedOnboarding")
+                UserDefaults.standard.removeObject(forKey: "userNickname")
+                UserDefaults.standard.removeObject(forKey: "userProvider")
+                UserDefaults.standard.removeObject(forKey: "userUID")
+                UserDefaults.standard.removeObject(forKey: "hasSetNickname")
+                UserDefaults.standard.synchronize()
+            })
+            .do(onError: { error in
+                print("🔴 로그아웃 실패: \(error)")
             })
     }
     
-    /// 계정 삭제 비즈니스 로직
-    /// - Returns: 계정 삭제 결과 Observable
+    /// 현재 사용자의 계정을 완전히 삭제합니다
+    ///
+    /// 소셜 로그인 연결 해제, Firestore 데이터 삭제, 로컬 데이터 초기화를
+    /// 모두 수행합니다.
+    /// - Returns: 계정 삭제 완료를 알리는 Observable
     public func deleteAccount() -> Observable<Void> {
         return repository.deleteAccount()
             .do(onNext: { _ in
-                print("계정 삭제 성공")
-                // 필요시 추가 비즈니스 로직 (로컬 데이터 삭제 등)
-            })
-    }
-
-    /// 사용자 상태 조회 비즈니스 로직
-    /// - Parameter uid: 사용자 ID
-    /// - Returns: 사용자 상태 Observable
-    public func getUserStatus(uid: String) -> Observable<UserStatus> {
-        return repository.fetchUserInfo(uid: uid)
-            .map { user in
-                guard let user = user else {
-                    return .needsOnboarding
-                }
+                print("🟢 계정 삭제 성공 - 모든 데이터 완전 초기화")
+                let keysToRemove = [
+                    "hasCompletedOnboarding",
+                    "hasSkippedOnboarding",
+                    "userNickname",
+                    "userProvider",
+                    "userUID",
+                    "hasSetNickname"
+                ]
                 
-                if !user.hasCompletedOnboarding {
-                    return .needsOnboarding
-                } else {
-                    return .complete
+                for key in keysToRemove {
+                    UserDefaults.standard.removeObject(forKey: key)
                 }
-            }
-            .do(onNext: { status in
-                print("사용자 상태 조회 결과: \(status)")
+                UserDefaults.standard.synchronize()
+            })
+            .do(onError: { error in
+                print("🔴 계정 삭제 실패: \(error)")
             })
     }
 
-    /// 닉네임 설정 완료 비즈니스 로직
+    /// 사용자의 온보딩 상태를 조회합니다
+    ///
+    /// 익명 사용자는 로컬 상태를, 일반 사용자는 Firestore 상태를 확인하여
+    /// 온보딩 필요 여부를 판단합니다.
+    /// - Parameter uid: 사용자 고유 식별자
+    /// - Returns: 사용자 온보딩 상태를 방출하는 Observable
+    public func getUserStatus(uid: String) -> Observable<UserStatus> {
+        let userProvider = UserDefaults.standard.string(forKey: "userProvider") ?? ""
+        
+        if userProvider == "anonymous" {
+            let hasCompletedOnboarding = UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
+            let hasSetNickname = UserDefaults.standard.bool(forKey: "hasSetNickname")
+            
+            if !hasSetNickname || !hasCompletedOnboarding {
+                print("🔴 익명 사용자 온보딩 미완료 - 로컬 확인")
+                return Observable.just(.needsOnboarding)
+            } else {
+                print("🟢 익명 사용자 온보딩 완료 - 로컬 확인")
+                return Observable.just(.complete)
+            }
+        } else {
+            return repository.fetchUserInfo(uid: uid)
+                .map { user in
+                    guard let user = user else {
+                        print("🔴 사용자 정보 없음 - 온보딩 필요")
+                        return .needsOnboarding
+                    }
+                    
+                    if !user.hasSetNickname || !user.hasCompletedOnboarding {
+                        print("🔴 온보딩 미완료 - 닉네임: \(user.hasSetNickname), 온보딩: \(user.hasCompletedOnboarding)")
+                        return .needsOnboarding
+                    } else {
+                        print("🟢 온보딩 완료 - 메인 화면으로")
+                        UserDefaults.standard.set(user.name, forKey: "userNickname")
+                        UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
+                        UserDefaults.standard.set(true, forKey: "hasSetNickname")
+                        UserDefaults.standard.synchronize()
+                        return .complete
+                    }
+                }
+                .do(onNext: { status in
+                    print("🔍 사용자 상태 조회 결과: \(status)")
+                })
+                .do(onError: { error in
+                    print("🔴 사용자 상태 조회 실패: \(error)")
+                })
+        }
+    }
+
+    /// 사용자의 닉네임 설정을 완료합니다
+    ///
+    /// 닉네임 유효성 검사를 수행하며, 익명 사용자는 로컬에,
+    /// 일반 사용자는 Firestore에 저장합니다.
     /// - Parameters:
-    ///   - uid: 사용자 ID
-    ///   - nickname: 설정할 닉네임
-    /// - Returns: 완료 결과 Observable
+    ///   - uid: 사용자 고유 식별자
+    ///   - nickname: 설정할 닉네임 (한글/영문/숫자 2~8자)
+    /// - Returns: 닉네임 설정 완료를 알리는 Observable
     public func completeNicknameSetting(uid: String, nickname: String) -> Observable<Void> {
-        // 닉네임 유효성 검사
         guard isValidNickname(nickname) else {
-            return Observable.error(NSError(domain: "InvalidNickname", code: -1, userInfo: [NSLocalizedDescriptionKey: "유효하지 않은 닉네임입니다."]))
+            return Observable.error(NSError(domain: "InvalidNickname", code: -1, userInfo: [NSLocalizedDescriptionKey: "유효하지 않은 닉네임입니다. (한글/영문 2~8자)"]))
         }
         
-        return repository.updateUserNickname(uid: uid, nickname: nickname)
-            .do(onNext: { _ in
-                print("닉네임 설정 완료: \(nickname)")
-            })
+        let userProvider = UserDefaults.standard.string(forKey: "userProvider") ?? ""
+        
+        if userProvider == "anonymous" {
+            return Observable.create { observer in
+                UserDefaults.standard.set(nickname, forKey: "userNickname")
+                UserDefaults.standard.set(true, forKey: "hasSetNickname")
+                UserDefaults.standard.synchronize()
+                
+                print("🟢 익명 사용자 닉네임 로컬 저장: \(nickname)")
+                observer.onNext(())
+                observer.onCompleted()
+                return Disposables.create()
+            }
+        } else {
+            return repository.updateUserNickname(uid: uid, nickname: nickname)
+                .do(onNext: { _ in
+                    print("🟢 닉네임 Firestore 저장 완료: \(nickname)")
+                    UserDefaults.standard.set(nickname, forKey: "userNickname")
+                    UserDefaults.standard.set(true, forKey: "hasSetNickname")
+                    UserDefaults.standard.synchronize()
+                })
+                .do(onError: { error in
+                    print("🔴 닉네임 Firestore 저장 실패: \(error)")
+                })
+        }
     }
 
-    /// 온보딩 완료 비즈니스 로직
-    /// - Parameter uid: 사용자 ID
-    /// - Returns: 완료 결과 Observable
+    /// 사용자의 온보딩 프로세스를 완료합니다
+    ///
+    /// 익명 사용자는 로컬에, 일반 사용자는 Firestore에 완료 상태를 저장합니다.
+    /// - Parameter uid: 사용자 고유 식별자
+    /// - Returns: 온보딩 완료를 알리는 Observable
     public func completeOnboarding(uid: String) -> Observable<Void> {
-        return repository.updateOnboardingStatus(uid: uid, completed: true)
-            .do(onNext: { _ in
-                print("온보딩 완료")
-            })
+        let userProvider = UserDefaults.standard.string(forKey: "userProvider") ?? ""
+        
+        if userProvider == "anonymous" {
+            return Observable.create { observer in
+                UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
+                UserDefaults.standard.synchronize()
+                
+                print("🟢 익명 사용자 온보딩 로컬 저장 완료")
+                observer.onNext(())
+                observer.onCompleted()
+                return Disposables.create()
+            }
+        } else {
+            return repository.updateOnboardingStatus(uid: uid, completed: true)
+                .do(onNext: { _ in
+                    print("🟢 온보딩 Firestore 저장 완료")
+                    UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
+                    UserDefaults.standard.synchronize()
+                })
+                .do(onError: { error in
+                    print("🔴 온보딩 Firestore 저장 실패: \(error)")
+                })
+        }
     }
 
-    /// 닉네임 유효성 검사 (한글/영문 2~8자)
+    /// 사용자의 온보딩 상태를 초기화합니다
+    ///
+    /// 개발 및 테스트 목적으로 사용되며, 온보딩을 처음부터 다시 진행할 수 있도록 합니다.
+    /// - Parameter uid: 사용자 고유 식별자
+    /// - Returns: 온보딩 상태 초기화 완료를 알리는 Observable
+    public func resetUserOnboardingStatus(uid: String) -> Observable<Void> {
+        let userProvider = UserDefaults.standard.string(forKey: "userProvider") ?? ""
+        
+        if userProvider == "anonymous" {
+            return Observable.create { observer in
+                UserDefaults.standard.removeObject(forKey: "hasCompletedOnboarding")
+                UserDefaults.standard.removeObject(forKey: "hasSetNickname")
+                UserDefaults.standard.set("비회원", forKey: "userNickname")
+                UserDefaults.standard.synchronize()
+                
+                print("🟢 익명 사용자 온보딩 상태 로컬 초기화 완료")
+                observer.onNext(())
+                observer.onCompleted()
+                return Disposables.create()
+            }
+        } else {
+            return repository.resetUserOnboardingStatus(uid: uid)
+                .do(onNext: { _ in
+                    print("🟢 사용자 온보딩 상태 초기화 완료")
+                    UserDefaults.standard.removeObject(forKey: "hasCompletedOnboarding")
+                    UserDefaults.standard.removeObject(forKey: "hasSkippedOnboarding")
+                    UserDefaults.standard.removeObject(forKey: "hasSetNickname")
+                    UserDefaults.standard.synchronize()
+                })
+                .do(onError: { error in
+                    print("🔴 온보딩 상태 초기화 실패: \(error)")
+                })
+        }
+    }
+
+    /// 닉네임의 유효성을 검사합니다
+    ///
+    /// 한글, 영문, 숫자 조합으로 2~8자 길이의 닉네임만 허용합니다.
     /// - Parameter nickname: 검사할 닉네임
-    /// - Returns: 유효하면 true, 아니면 false
+    /// - Returns: 유효한 닉네임이면 true, 그렇지 않으면 false
     private func isValidNickname(_ nickname: String) -> Bool {
-        let regex = "^[가-힣a-zA-Z]{2,8}$"
-        return NSPredicate(format: "SELF MATCHES %@", regex).evaluate(with: nickname)
+        let trimmed = nickname.trimmingCharacters(in: .whitespacesAndNewlines)
+        let regex = "^[가-힣a-zA-Z0-9]{2,8}$"
+        return NSPredicate(format: "SELF MATCHES %@", regex).evaluate(with: trimmed)
     }
 }

--- a/HowManySet/Domain/UseCase/Protocols/Auth/AuthUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/Auth/AuthUseCaseProtocol.swift
@@ -5,53 +5,88 @@
 //  Created by GO on 6/19/25.
 //
 
-import Foundation
 import RxSwift
 
 /// 인증 관련 비즈니스 로직을 정의하는 프로토콜
-/// - 다양한 로그인 방식의 비즈니스 로직을 추상화
+///
+/// 다양한 소셜 로그인 제공자를 지원하며, 사용자 인증과 온보딩 프로세스의
+/// 비즈니스 규칙을 추상화합니다. Repository 계층과 Presentation 계층 사이의
+/// 중간 역할을 담당합니다.
 public protocol AuthUseCaseProtocol {
-    /// 카카오 로그인 비즈니스 로직
-    /// - Returns: 로그인된 사용자 정보 Observable
+    
+    /// 카카오 계정으로 로그인을 수행합니다
+    ///
+    /// 로그인 성공 시 UserDefaults에 백업 데이터를 저장하며,
+    /// 기존 온보딩 상태를 유지합니다.
+    /// - Returns: 로그인된 사용자 정보를 방출하는 Observable
     func loginWithKakao() -> Observable<User>
     
-    /// 구글 로그인 비즈니스 로직
-    /// - Returns: 로그인된 사용자 정보 Observable
+    /// 구글 계정으로 로그인을 수행합니다
+    ///
+    /// 로그인 성공 시 UserDefaults에 백업 데이터를 저장하며,
+    /// 기존 온보딩 상태를 유지합니다.
+    /// - Returns: 로그인된 사용자 정보를 방출하는 Observable
     func loginWithGoogle() -> Observable<User>
     
-    /// Apple 로그인 비즈니스 로직
+    /// Apple ID로 로그인을 수행합니다
+    ///
+    /// 로그인 성공 시 UserDefaults에 백업 데이터를 저장하며,
+    /// 기존 온보딩 상태를 유지합니다.
     /// - Parameters:
     ///   - token: Apple ID 토큰
     ///   - nonce: 보안을 위한 nonce 값
-    /// - Returns: 로그인된 사용자 정보 Observable
+    /// - Returns: 로그인된 사용자 정보를 방출하는 Observable
     func loginWithApple(token: String, nonce: String) -> Observable<User>
     
-    /// 익명 로그인 비즈니스 로직
-    /// - Returns: 로그인된 사용자 정보 Observable
+    /// 익명 로그인을 수행합니다
+    ///
+    /// 익명 사용자의 경우 모든 데이터를 로컬(UserDefaults)에만 저장합니다.
+    /// - Returns: 익명 사용자 정보를 방출하는 Observable
     func loginAnonymously() -> Observable<User>
     
-    /// 로그아웃 비즈니스 로직
-    /// - Returns: 로그아웃 결과 Observable
+    /// 현재 사용자를 로그아웃시킵니다
+    ///
+    /// Firestore의 온보딩 상태는 유지하고 UserDefaults만 초기화합니다.
+    /// 재로그인 시 기존 온보딩 상태를 복원할 수 있습니다.
+    /// - Returns: 로그아웃 완료를 알리는 Observable
     func logout() -> Observable<Void>
     
-    /// 계정 삭제 비즈니스 로직
-    /// - Returns: 계정 삭제 결과 Observable
+    /// 현재 사용자의 계정을 완전히 삭제합니다
+    ///
+    /// 소셜 로그인 연결 해제, Firestore 데이터 삭제, 로컬 데이터 초기화를
+    /// 모두 수행합니다.
+    /// - Returns: 계정 삭제 완료를 알리는 Observable
     func deleteAccount() -> Observable<Void>
     
-    /// 사용자 상태 조회 비즈니스 로직
-    /// - Parameter uid: 사용자 ID
-    /// - Returns: 사용자 상태 Observable
+    /// 사용자의 온보딩 상태를 조회합니다
+    ///
+    /// 익명 사용자는 로컬 상태를, 일반 사용자는 Firestore 상태를 확인하여
+    /// 온보딩 필요 여부를 판단합니다.
+    /// - Parameter uid: 사용자 고유 식별자
+    /// - Returns: 사용자 온보딩 상태를 방출하는 Observable
     func getUserStatus(uid: String) -> Observable<UserStatus>
     
-    /// 닉네임 설정 완료 비즈니스 로직
+    /// 사용자의 닉네임 설정을 완료합니다
+    ///
+    /// 닉네임 유효성 검사를 수행하며, 익명 사용자는 로컬에,
+    /// 일반 사용자는 Firestore에 저장합니다.
     /// - Parameters:
-    ///   - uid: 사용자 ID
-    ///   - nickname: 설정할 닉네임
-    /// - Returns: 완료 결과 Observable
+    ///   - uid: 사용자 고유 식별자
+    ///   - nickname: 설정할 닉네임 (한글/영문/숫자 2~8자)
+    /// - Returns: 닉네임 설정 완료를 알리는 Observable
     func completeNicknameSetting(uid: String, nickname: String) -> Observable<Void>
     
-    /// 온보딩 완료 비즈니스 로직
-    /// - Parameter uid: 사용자 ID
-    /// - Returns: 완료 결과 Observable
+    /// 사용자의 온보딩 프로세스를 완료합니다
+    ///
+    /// 익명 사용자는 로컬에, 일반 사용자는 Firestore에 완료 상태를 저장합니다.
+    /// - Parameter uid: 사용자 고유 식별자
+    /// - Returns: 온보딩 완료를 알리는 Observable
     func completeOnboarding(uid: String) -> Observable<Void>
+    
+    /// 사용자의 온보딩 상태를 초기화합니다
+    ///
+    /// 개발 및 테스트 목적으로 사용되며, 온보딩을 처음부터 다시 진행할 수 있도록 합니다.
+    /// - Parameter uid: 사용자 고유 식별자
+    /// - Returns: 온보딩 상태 초기화 완료를 알리는 Observable
+    func resetUserOnboardingStatus(uid: String) -> Observable<Void>
 }

--- a/HowManySet/Domain/UseCase/Protocols/Auth/AuthUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/Auth/AuthUseCaseProtocol.swift
@@ -5,6 +5,7 @@
 //  Created by GO on 6/19/25.
 //
 
+import Foundation
 import RxSwift
 
 /// 인증 관련 비즈니스 로직을 정의하는 프로토콜
@@ -36,4 +37,21 @@ public protocol AuthUseCaseProtocol {
     /// 계정 삭제 비즈니스 로직
     /// - Returns: 계정 삭제 결과 Observable
     func deleteAccount() -> Observable<Void>
+    
+    /// 사용자 상태 조회 비즈니스 로직
+    /// - Parameter uid: 사용자 ID
+    /// - Returns: 사용자 상태 Observable
+    func getUserStatus(uid: String) -> Observable<UserStatus>
+    
+    /// 닉네임 설정 완료 비즈니스 로직
+    /// - Parameters:
+    ///   - uid: 사용자 ID
+    ///   - nickname: 설정할 닉네임
+    /// - Returns: 완료 결과 Observable
+    func completeNicknameSetting(uid: String, nickname: String) -> Observable<Void>
+    
+    /// 온보딩 완료 비즈니스 로직
+    /// - Parameter uid: 사용자 ID
+    /// - Returns: 완료 결과 Observable
+    func completeOnboarding(uid: String) -> Observable<Void>
 }

--- a/HowManySet/Presentation/Feature/MyPage/MyPageViewController.swift
+++ b/HowManySet/Presentation/Feature/MyPage/MyPageViewController.swift
@@ -48,6 +48,12 @@ final class MyPageViewController: UIViewController, View {
         setupUI()
     }
     
+    /// 뷰가 나타날 때마다 사용자 이름 로드
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        reactor?.action.onNext(.loadUserName)
+    }
+    
     /// ReactorKit 바인딩
     func bind(reactor: MyPageViewReactor) {
         
@@ -76,9 +82,17 @@ final class MyPageViewController: UIViewController, View {
         /// 에러 처리
         reactor.state
             .compactMap { $0.error }
-            .subscribe(with: self) { error in
-                print(error)
+            .subscribe(with: self) { owner, error in
+                print("🔴 MyPage 에러: \(error)")
             }.disposed(by: disposeBag)
+        
+        /// 사용자 이름 바인딩 (Firestore에서 fetch한 데이터)
+        reactor.state
+            .map { $0.userName }
+            .compactMap { $0 }
+            .distinctUntilChanged()
+            .bind(to: mypageView.headerView.usernameLabel.rx.text)
+            .disposed(by: disposeBag)
     }
 
     /// 선택된 셀에 따라 코디네이터로 화면 이동 처리

--- a/HowManySet/Presentation/Feature/MyPage/View/MyPageHeaderView.swift
+++ b/HowManySet/Presentation/Feature/MyPage/View/MyPageHeaderView.swift
@@ -14,7 +14,7 @@ import Then
 final class MyPageHeaderView: UIView {
     
     /// 사용자 이름 또는 상태(예: 비회원)를 표시하는 레이블
-    private let usernameLabel = UILabel().then {
+    let usernameLabel = UILabel().then {
         $0.font = .systemFont(ofSize: 36, weight: .regular)
         $0.numberOfLines = 0
         $0.text = "비회원" // 기본값

--- a/HowManySet/Presentation/Feature/MyPage/View/MyPageView.swift
+++ b/HowManySet/Presentation/Feature/MyPage/View/MyPageView.swift
@@ -14,7 +14,7 @@ import Then
 final class MyPageView: UIView {
     
     /// 사용자 이름 또는 상태를 표시하는 헤더 뷰
-    private let headerView = MyPageHeaderView()
+    let headerView = MyPageHeaderView()
     
     /// 마이페이지 목록을 표시하는 컬렉션 뷰
     let collectionView = MyPageCollectionView()

--- a/HowManySet/Presentation/Feature/OnBoarding/OnBoardingViewController.swift
+++ b/HowManySet/Presentation/Feature/OnBoarding/OnBoardingViewController.swift
@@ -69,6 +69,7 @@ private extension OnBoardingViewController {
     /// 배경색 및 온보딩 페이지 인디케이터의 페이지 수 등 Appearance 관련 설정.
     func setAppearance() {
         view.backgroundColor = .background
+        navigationController?.setNavigationBarHidden(true, animated: false)
         onboardingView.pageIndicator.numberOfPages = onboardingPages.count
     }
     
@@ -98,6 +99,15 @@ private extension OnBoardingViewController {
 private extension OnBoardingViewController {
     /// 닉네임 입력 "다음" 버튼 클릭 시 온보딩 페이지로 전환. 첫 페이지로 초기화.
     @objc func nicknameInputViewNextButtonAction() {
+        guard let nickname = nicknameInputView.nicknameTextField.text,
+              !nickname.isEmpty else {
+            return
+        }
+        
+        // 닉네임 설정 완료 처리
+        coordinator?.completeNicknameSetting(nickname: nickname)
+        
+        // 온보딩 화면으로 전환
         nicknameInputView.isHidden = true
         onboardingView.isHidden = false
         currentPageIndex = 0
@@ -125,9 +135,6 @@ private extension OnBoardingViewController {
     
     /// 온보딩 닫기(X) 버튼 클릭 시 온보딩을 건너뛰고 바로 완료 처리.
     @objc func onboardingViewCloseButtonAction() {
-        // 온보딩 완료 상태를 UserDefaults에 저장
-        UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
-        
         // 온보딩 건너뛰었음을 별도로 저장 (향후 재안내 등에 활용 가능)
         UserDefaults.standard.set(true, forKey: "hasSkippedOnboarding")
         
@@ -199,7 +206,7 @@ private extension OnBoardingViewController {
         onboardingView.titleLabel.text = page.title
         onboardingView.subTitleLabel.text = page.subtitle
         onboardingView.centerImageView.image = UIImage(named: page.imageName)
-
+        
         let isLastPage = index == onboardingPages.count - 1
         let buttonTitle = isLastPage ? "시작하기" : "다음"
         onboardingView.nextButton.setTitle(buttonTitle, for: .normal)
@@ -212,15 +219,13 @@ private extension OnBoardingViewController {
             currentPageIndex = nextIndex
         } else {
             print("goToNextPage() - else")
-            (coordinator as? OnBoardingCoordinator)?.completeOnBoarding()
+            coordinator?.completeOnBoarding()
         }
     }
 }
 
 private extension OnBoardingViewController {
-    
     func bindUIEvents() {
-        
         // 화면 탭하면 키보드 내리기
         let tapGesture = UITapGestureRecognizer()
         tapGesture.cancelsTouchesInView = false


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  closed: #92 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- 로그인 및 온보딩 플로우 수정
  - 최초 로그인 시 닉네임 입력과 온보딩 과정을 거치도록 구현
  - 온보딩 완료 여부를 Firestore에 저장하여 앱 재시작 시 상태를 정확히 반영
  - 로그아웃 시 Firestore 데이터는 유지하고 UserDefaults만 초기화하여 재로그인 시 온보딩 스킵 가능
  - 계정 삭제 시 Firestore 데이터와 Firebase Auth 계정을 완전 삭제

- 로컬 저장에서 Firestore 기반 로직으로 수정
  - 닉네임, 온보딩 상태 등 사용자 정보는 Firestore에 저장하고 앱에서는 UserDefaults를 백업용으로 사용
  - 앱 삭제 후 재설치 시에도 Firestore에서 데이터를 복원하여 온보딩 스킵 보장
  - 익명 로그인 사용자는 로컬에만 닉네임과 온보딩 상태를 저장
  - 로그아웃 후 재로그인 시에도 온보딩 생략이 정상적으로 작동
  
- 카카오 로그인 이슈 해결
  - 카카오 로그인 시 Firebase Auth와의 UID 불일치 문제 해결
  - 기존 사용자 조회 시 Firebase Auth 상태에 의존하지 않고 Firestore에서 직접 조회
  - 기존 사용자가 있으면 Firebase Auth 익명 로그인으로 재연결 후 기존 온보딩 상태를 유지하며 사용자 정보 업데이트
  
- 비회원 로그인 이슈 해결
  - 익명 로그인 시 닉네임과 온보딩 상태를 UserDefaults에만 저장
  - 익명 사용자는 Firestore에 데이터 저장하지 않음
  - MyPage에서 닉네임을 UserDefaults에서 읽어와 표시
  - 익명 사용자는 앱 재시작 시에도 로컬 상태를 기반으로 온보딩 스킵
  
- 계정 삭제 시 완전한 데이터 삭제 보장
  - 카카오, 구글, Apple 소셜 로그인 연결 끊기 API 호출 추가
  - Firestore의 사용자 데이터 및 소셜 연결 데이터 완전 삭제
  - Firebase Auth 계정 삭제
  - UserDefaults 초기화

- 기타 개선사항
  - Clean Architecture 원칙 준수, UseCase에서 Firebase 직접 접근 제거
  - MyPage 닉네임 표시 로직 및 ReactorKit 활용
 
## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/bcd09ff2-e867-4d81-9444-2de86eccc0c6" width ="250"> |

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
🔥 **확인 부탁드립니다 !!!** 🔥
- ✅ 비회원 로그인과 카카오, 구글, 애플 로그인 데이터 저장 방식 차이가 있습니다.
- ✅ 계정 삭제 시 Firestore 내부 데이터 완전 삭제됩니다.
- ✅ 카카오 관련 코드들은 다른 로그인들과 로직에서 차이가 있습니다.
- ✅ 닉네임 변경 UI 현재 구현 X
- ✅ 기획단계에서 비회원의 경우 UI 및 로직이 달라야할 것 같습니다.
- ✅ Onboarding쪽 Reactor 도입되지 않은 상태입니다
- ✅ 로그인 실패 Alert가 뜰 때 에러 메시지가 함께 나오는 상태(디버깅 용도)가 여전히 같이 나오고 있어 보안에 안좋은 상태입니다 (추후 수정)