### PR TITLE
NicknameInputView 버튼 가려지는 이슈

### DIFF
--- a/HowManySet/Presentation/Feature/OnBoarding/NicknameInputView.swift
+++ b/HowManySet/Presentation/Feature/OnBoarding/NicknameInputView.swift
@@ -58,6 +58,7 @@ final class NicknameInputView: UIView {
         $0.autocorrectionType = .no // 자동 수정 끔
         $0.spellCheckingType = .no // 맞춤법 검사 끔
         $0.smartInsertDeleteType = .no // 스마트 삽입/삭제 끔
+        $0.autocapitalizationType = .none // 자동 대문자 변환 끔
     }
     
     /// 하단 "다음" 버튼. 기본 비활성화 상태, 유효성 통과 시 활성화.

--- a/HowManySet/Presentation/Feature/OnBoarding/NicknameInputView.swift
+++ b/HowManySet/Presentation/Feature/OnBoarding/NicknameInputView.swift
@@ -54,6 +54,10 @@ final class NicknameInputView: UIView {
         )
         $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 16, height: 0))
         $0.leftViewMode = .always
+        
+        $0.autocorrectionType = .no // 자동 수정 끔
+        $0.spellCheckingType = .no // 맞춤법 검사 끔
+        $0.smartInsertDeleteType = .no // 스마트 삽입/삭제 끔
     }
     
     /// 하단 "다음" 버튼. 기본 비활성화 상태, 유효성 통과 시 활성화.

--- a/HowManySet/Presentation/Feature/OnBoarding/NicknameInputView.swift
+++ b/HowManySet/Presentation/Feature/OnBoarding/NicknameInputView.swift
@@ -71,6 +71,9 @@ final class NicknameInputView: UIView {
         $0.backgroundColor = .darkGray
         $0.setTitleColor(.lightGray, for: .normal)
     }
+    
+    /// nextButton 제약조건 (키보드 대응용)
+    private var nextButtonConstraint: Constraint?
 
     /**
      닉네임 입력 뷰를 초기화하고 UI 요소를 배치합니다.
@@ -79,9 +82,16 @@ final class NicknameInputView: UIView {
         super.init(frame: frame)
         setupUI()
     }
-
+    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    /// 키보드 높이에 따라 버튼 위치만 조정
+    /// - Parameter keyboardHeight: 키보드 높이 (0이면 원래 위치로 복원)
+    func adjustButtonForKeyboard(keyboardHeight: CGFloat) {
+        let bottomInset = keyboardHeight > 0 ? keyboardHeight + 20 : 28
+        nextButtonConstraint?.update(inset: bottomInset)
     }
 }
 
@@ -117,8 +127,8 @@ private extension NicknameInputView {
         }
         nextButton.snp.makeConstraints {
             $0.directionalHorizontalEdges.equalToSuperview().inset(20)
-            $0.bottom.equalTo(self.safeAreaLayoutGuide).inset(28)
             $0.height.equalTo(56)
+            nextButtonConstraint = $0.bottom.equalTo(self.safeAreaLayoutGuide).inset(28).constraint
         }
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  - closed: #130 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- TextField 클릭 시 팝업되는 키보드에 nextButton이 가려지는 이슈 발생
- `var nextButtonConstraint: Constraint?`키보드 높이에 따라 버튼 위치를 동적으로 조정하기 위해서 추가
- `adjustButtonForKeyboard ` 메서드 생성 -> 키보드 높이에 따라 버튼 위치 조정
- `nextButtonConstraint = $0.bottom.equalTo(self.safeAreaLayoutGuide).inset(28).constraint `<br> update(inset:)로 제약조건 값을 변경
- `setupKeyboardObserver `메서드 생성 -> 키보드 표시/숨김 알림을 감지하는 옵저버 등록
- `keyboardWillShow `, `keyboardWillHide ` 메서드
  - 키보드 높이 계산 → 버튼 위치 조정 → 애니메이션 적용
  - 버튼을 원래 위치로 복원 → 애니메이션 적용
- `bindUIEvents ` 메서드 -> 화면 탭 시 키보드 숨김, cancelsTouchesInView = true로 버튼 터치 허용

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/16f67bb6-826d-434f-9b14-dfdabb1c0efa" width ="250"> |


## 참고 자료
- https://velog.io/@mraz9/iOS-%ED%8A%B8%EB%9F%AC%EB%B8%94-%EC%8A%88%ED%8C%85-%ED%82%A4%EB%B3%B4%EB%93%9C%EA%B0%80-%ED%99%94%EB%A9%B4%EC%9D%84-%EC%95%88-%EA%B0%80%EB%A6%AC%EA%B2%8C-%ED%95%98%EB%A0%A4%EB%A9%B4
- https://velog.io/@jaybadass/iOSSwift-%ED%82%A4%EB%B3%B4%EB%93%9C%EA%B0%80-%ED%99%94%EB%A9%B4-%EA%B0%80%EB%A6%B4-%EB%95%8C-%ED%95%B4%EA%B2%B0-%EB%B0%A9%EB%B2%95
- https://icksw.tistory.com/87