### PR TITLE
스와이프 삭제 및 업데이트 로직 구현 및 피드백 수정

### DIFF
--- a/HowManySet/App/Coordinator/CalendarCoordinator.swift
+++ b/HowManySet/App/Coordinator/CalendarCoordinator.swift
@@ -39,7 +39,13 @@ final class CalendarCoordinator: CalendarCoordinatorProtocol {
     /// 기록 상세 화면 모달 present
     /// large sheet 스타일 + grabber 표시
     func presentRecordDetailView(record: WorkoutRecord) {
-        let reactor = RecordDetailViewReactor(record: record)
+        let realmService: RealmServiceProtocol = RealmService()
+        let recordRepository = RecordRepositoryImpl(realmService: realmService)
+        let saveRecordUseCase = SaveRecordUseCase(repository: recordRepository)
+        let fetchRecordUseCase = FetchRecordUseCase(repository: recordRepository)
+
+        let reactor = RecordDetailViewReactor(saveRecordUseCase: saveRecordUseCase, fetchRecordUseCase: fetchRecordUseCase,
+                                              record: record)
         let recordDetailVC = RecordDetailViewController(reactor: reactor)
         
         if let sheet = recordDetailVC.sheetPresentationController {

--- a/HowManySet/App/Coordinator/CalendarCoordinator.swift
+++ b/HowManySet/App/Coordinator/CalendarCoordinator.swift
@@ -39,13 +39,13 @@ final class CalendarCoordinator: CalendarCoordinatorProtocol {
     /// 기록 상세 화면 모달 present
     /// large sheet 스타일 + grabber 표시
     func presentRecordDetailView(record: WorkoutRecord) {
-        let realmService: RealmServiceProtocol = RealmService()
-        let recordRepository = RecordRepositoryImpl(realmService: realmService)
-        let saveRecordUseCase = SaveRecordUseCase(repository: recordRepository)
-        let fetchRecordUseCase = FetchRecordUseCase(repository: recordRepository)
+        let recordRepository = RecordRepositoryImpl()
+        let updateRecordUseCase = UpdateRecordUseCase(repository: recordRepository)
 
-        let reactor = RecordDetailViewReactor(saveRecordUseCase: saveRecordUseCase, fetchRecordUseCase: fetchRecordUseCase,
-                                              record: record)
+        let reactor = RecordDetailViewReactor(
+            updateRecordUseCase: updateRecordUseCase,
+            record: record
+        )
         let recordDetailVC = RecordDetailViewController(reactor: reactor)
         
         if let sheet = recordDetailVC.sheetPresentationController {

--- a/HowManySet/App/DIContainer.swift
+++ b/HowManySet/App/DIContainer.swift
@@ -93,7 +93,7 @@ final class DIContainer {
     func makeCalendarViewController(coordinator: CalendarCoordinator) -> UIViewController {
         let recordRepository = RecordRepositoryImpl()
         
-        let saveRecordUseCase = SaveRecordUseCase(repository: recordRepository)
+        let deleteRecordUseCase = DeleteRecordUseCase(repository: recordRepository)
         let fetchRecordUseCase = FetchRecordUseCase(repository: recordRepository)
 
         // Firestore 로직 추가
@@ -103,7 +103,7 @@ final class DIContainer {
         let fsFetchRecordUseCase = FSFetchRecordUseCase(repository: fsRecordRepository)
 
         let reactor = CalendarViewReactor(
-            saveRecordUseCase: saveRecordUseCase,
+            deleteRecordUseCase: deleteRecordUseCase,
             fetchRecordUseCase: fetchRecordUseCase
         )
         

--- a/HowManySet/App/DIContainer.swift
+++ b/HowManySet/App/DIContainer.swift
@@ -99,12 +99,15 @@ final class DIContainer {
         // Firestore 로직 추가
         let firestoreService: FirestoreServiceProtocol = FirestoreService()
         let fsRecordRepository = FSRecordRepositoryImpl(firestoreService: firestoreService)
-        let fsSaveRecordUseCase = FSSaveRecordUseCase(repository: fsRecordRepository)
+        let fsDeleteRecordUseCase = FSDeleteRecordUseCase(repository: fsRecordRepository)
         let fsFetchRecordUseCase = FSFetchRecordUseCase(repository: fsRecordRepository)
 
         let reactor = CalendarViewReactor(
             deleteRecordUseCase: deleteRecordUseCase,
-            fetchRecordUseCase: fetchRecordUseCase
+            fetchRecordUseCase: fetchRecordUseCase,
+//            // Firestore UseCase들 추가
+            fsDeleteRecordUseCase: fsDeleteRecordUseCase,
+            fsFetchRecordUseCase: fsFetchRecordUseCase
         )
         
         return CalendarViewController(reactor: reactor, coordinator: coordinator)

--- a/HowManySet/App/DIContainer.swift
+++ b/HowManySet/App/DIContainer.swift
@@ -83,7 +83,10 @@ final class DIContainer {
         let reactor = RoutineListViewReactor(
             deleteRoutineUseCase: deleteRoutineUseCase,
             fetchRoutineUseCase: fetchRoutineUseCase,
-            saveRoutineUseCase: saveRoutineUseCase
+            saveRoutineUseCase: saveRoutineUseCase,
+            fsDeleteRoutineUseCase: fsDeleteRoutineUseCase,
+            fsFetchRoutineUseCase: fsFetchRoutineUseCase,
+            fsSaveRoutineUseCase: fsSaveRoutineUseCase
         )
         
         return RoutineListViewController(reactor: reactor, coordinator: coordinator)

--- a/HowManySet/Domain/Entity/WorkoutRecord.swift
+++ b/HowManySet/Domain/Entity/WorkoutRecord.swift
@@ -68,3 +68,15 @@ extension WorkoutRecord {
         )
     ]
 }
+// MARK: - 커스텀 복사 메서드
+extension WorkoutRecord {
+    func withUpdatedComment(_ newComment: String?) -> WorkoutRecord {
+        return WorkoutRecord(
+            workoutRoutine: self.workoutRoutine,
+            totalTime: self.totalTime,
+            workoutTime: self.workoutTime,
+            comment: newComment,
+            date: self.date
+        )
+    }
+}

--- a/HowManySet/Domain/Entity/WorkoutRecord.swift
+++ b/HowManySet/Domain/Entity/WorkoutRecord.swift
@@ -68,15 +68,3 @@ extension WorkoutRecord {
         )
     ]
 }
-// MARK: - 커스텀 복사 메서드
-extension WorkoutRecord {
-    func withUpdatedComment(_ newComment: String?) -> WorkoutRecord {
-        return WorkoutRecord(
-            workoutRoutine: self.workoutRoutine,
-            totalTime: self.totalTime,
-            workoutTime: self.workoutTime,
-            comment: newComment,
-            date: self.date
-        )
-    }
-}

--- a/HowManySet/Presentation/Feature/Calendar/CalendarView.swift
+++ b/HowManySet/Presentation/Feature/Calendar/CalendarView.swift
@@ -80,6 +80,7 @@ private extension CalendarView {
         recordTableView.do {
             $0.backgroundColor = .clear
             $0.separatorStyle = .none
+            $0.showsVerticalScrollIndicator = false
         }
 
         previousMonthButton.do {

--- a/HowManySet/Presentation/Feature/Calendar/CalendarView.swift
+++ b/HowManySet/Presentation/Feature/Calendar/CalendarView.swift
@@ -126,7 +126,8 @@ private extension CalendarView {
 
         recordTableView.snp.makeConstraints {
             $0.top.equalTo(calendarContainerView.snp.bottom).offset(16)
-            $0.horizontalEdges.bottom.equalTo(safeAreaLayoutGuide).inset(20)
+            $0.horizontalEdges.equalTo(safeAreaLayoutGuide).inset(20)
+            $0.bottom.equalTo(safeAreaLayoutGuide)
         }
 
         previousMonthButton.snp.makeConstraints {

--- a/HowManySet/Presentation/Feature/Calendar/CalendarView.swift
+++ b/HowManySet/Presentation/Feature/Calendar/CalendarView.swift
@@ -74,7 +74,7 @@ private extension CalendarView {
             $0.appearance.selectionColor = .brand // 선택된 날짜의 배경 색상
             $0.appearance.titleSelectionColor = .black // 선택된 날짜 텍스트 색상
             $0.appearance.eventDefaultColor = .success // 이벤트 점의 기본 색상
-            $0.appearance.eventSelectionColor = .success // 선택된 날짜의 이벤트 점 색상
+            $0.appearance.eventSelectionColor = .clear // 선택된 날짜의 이벤트 점 색상
         }
 
         recordTableView.do {

--- a/HowManySet/Presentation/Feature/Calendar/CalendarView.swift
+++ b/HowManySet/Presentation/Feature/Calendar/CalendarView.swift
@@ -95,13 +95,13 @@ private extension CalendarView {
     }
 
     func setViewHierarchy() {
-        [
+        addSubviews(
             titleLabel,
             calendarContainerView,
             previousMonthButton,
             nextMonthButton,
             recordTableView
-        ].forEach { addSubviews($0) }
+        )
 
         calendarContainerView.addSubview(calendar)
     }

--- a/HowManySet/Presentation/Feature/Calendar/CalendarView.swift
+++ b/HowManySet/Presentation/Feature/Calendar/CalendarView.swift
@@ -44,7 +44,7 @@ private extension CalendarView {
         }
 
         calendarContainerView.do {
-            $0.backgroundColor = .cardContentBG // 달력의 배경 색상 /* 추후 색상 변경 예정‼️ */
+            $0.backgroundColor = .grey5 // 달력의 배경 색상
             $0.layer.cornerRadius = 20
             $0.clipsToBounds = true
         }
@@ -63,7 +63,7 @@ private extension CalendarView {
             $0.appearance.headerTitleOffset = CGPoint(x: 0, y: -3) // 캘린더 헤더 위치 조정
 
             // 달력 요일
-            $0.appearance.weekdayTextColor = .textTertiary // 달력 요일 텍스트 색상 /* 추후 색상 변경 예정‼️ */
+            $0.appearance.weekdayTextColor = .grey3 // 달력 요일 텍스트 색상
             $0.appearance.weekdayFont = .systemFont(ofSize: 16, weight: .regular) // 달력 요일 텍스트 폰트
 
             // 달력 일반 날짜
@@ -71,7 +71,7 @@ private extension CalendarView {
             $0.appearance.titleFont = .systemFont(ofSize: 16, weight: .regular) // 달력 일반 날짜 텍스트 폰트
             $0.appearance.titleTodayColor = .brand // 오늘 날짜 텍스트의 색상
             $0.appearance.todayColor = .clear // 오늘 날짜의 배경 색상
-            $0.appearance.selectionColor = .brand // 선택된 날짜의 배경 색상
+            $0.appearance.selectionColor = .green6 // 선택된 날짜의 배경 색상
             $0.appearance.titleSelectionColor = .black // 선택된 날짜 텍스트 색상
             $0.appearance.eventDefaultColor = .success // 이벤트 점의 기본 색상
             $0.appearance.eventSelectionColor = .clear // 선택된 날짜의 이벤트 점 색상

--- a/HowManySet/Presentation/Feature/Calendar/CalendarViewController.swift
+++ b/HowManySet/Presentation/Feature/Calendar/CalendarViewController.swift
@@ -149,7 +149,7 @@ private extension CalendarViewController {
 extension CalendarViewController: UITableViewDelegate {
     /// TableView Cell의 높이를 설정하는 메서드
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        136
+        120
     }
 
     /// TableView Cell이 선택되었을 때 실행하는 메서드

--- a/HowManySet/Presentation/Feature/Calendar/CalendarViewController.swift
+++ b/HowManySet/Presentation/Feature/Calendar/CalendarViewController.swift
@@ -57,7 +57,7 @@ final class CalendarViewController: UIViewController, View {
         // records를 tableView에 바인딩
         reactor.state
             .map { state in
-                state.records.map { SectionModel(model: "", items: [$0]) }  // 섹션당 1개 셀
+                state.selectedRecords.map { SectionModel(model: "", items: [$0]) }  // 섹션당 1개 셀
             }
             .bind(to: calendarView.publicRecordTableView.rx.items(dataSource: dataSource))
             .disposed(by: disposeBag)
@@ -158,7 +158,7 @@ extension CalendarViewController: UITableViewDelegate {
         calendarView.publicRecordTableView.deselectRow(at: indexPath, animated: true)
 
         // 해당 record 가져오기
-        guard let record = reactor?.currentState.records[indexPath.row] else { return }
+        guard let record = reactor?.currentState.selectedRecords[indexPath.row] else { return }
 
         coordinator?.presentRecordDetailView(record: record)
     }

--- a/HowManySet/Presentation/Feature/Calendar/CalendarViewController.swift
+++ b/HowManySet/Presentation/Feature/Calendar/CalendarViewController.swift
@@ -10,7 +10,7 @@ final class CalendarViewController: UIViewController, View {
     var disposeBag = DisposeBag()
 
     let calendarView = CalendarView()
-    private var coordinator: CalendarCoordinatorProtocol? // 이유는 모르겠지만 weak를 쓰면 인스턴스가 메모리에서 해제됨. 따라서 일단 strong으로 구현하자
+    private weak var coordinator: CalendarCoordinatorProtocol? 
 
     // 기록이 있는 날짜를 담아놓을 배열 생성
     private var recordedDates: [Date] = []

--- a/HowManySet/Presentation/Feature/Calendar/CalendarViewController.swift
+++ b/HowManySet/Presentation/Feature/Calendar/CalendarViewController.swift
@@ -163,6 +163,7 @@ extension CalendarViewController: UITableViewDelegate {
         coordinator?.presentRecordDetailView(record: record)
     }
 
+    /// trailing -> leading 방향으로 스와이프하는 메서드
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         let deleteAction = UIContextualAction(style: .destructive, title: "삭제") { [weak self] _, _, completion in
             self?.reactor?.action.onNext(.deleteItem(indexPath)) // Reactor로 이벤트 전달
@@ -173,12 +174,14 @@ extension CalendarViewController: UITableViewDelegate {
         return UISwipeActionsConfiguration(actions: [deleteAction])
     }
 
+    /// tableView의 섹션 안에 있는 footerView를 설정하는 메서드
     func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         let footer = UIView()
         footer.backgroundColor = .clear
         return footer
     }
 
+    /// tableView의 섹션 안에 있는 footerView의 높이를 정하는 메서드
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         16 // 원하는 spacing 값
     }

--- a/HowManySet/Presentation/Feature/Calendar/CalendarViewController.swift
+++ b/HowManySet/Presentation/Feature/Calendar/CalendarViewController.swift
@@ -20,7 +20,9 @@ final class CalendarViewController: UIViewController, View {
 
     let dataSource = RxTableViewSectionedReloadDataSource<RecordSection>(
         configureCell: { dataSource, tableView, indexPath, item in
-            let cell = tableView.dequeueReusableCell(withIdentifier: RecordCell.identifier) as! RecordCell
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: RecordCell.identifier, for: indexPath) as? RecordCell else {
+                return UITableViewCell()
+            }
             cell.configure(with: item)
             return cell
         }
@@ -72,7 +74,7 @@ final class CalendarViewController: UIViewController, View {
             }
             .disposed(by: disposeBag)
 
-        // tableView.delegate 설정
+        // tableView.delegate 바인딩
         calendarView.publicRecordTableView.rx.setDelegate(self)
             .disposed(by: disposeBag)
         

--- a/HowManySet/Presentation/Feature/Calendar/CalendarViewController.swift
+++ b/HowManySet/Presentation/Feature/Calendar/CalendarViewController.swift
@@ -35,6 +35,15 @@ final class CalendarViewController: UIViewController, View {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        // 캘린더 날짜 선택 해제
+        if let selectedDate = calendarView.publicCalendar.selectedDate {
+            calendarView.publicCalendar.deselect(selectedDate)
+        }
+
+        // Reactor 상태도 초기화
+        reactor?.action.onNext(.clearSelection)
+
+        // 선택된 날짜 기준 fetch
         reactor?.action.onNext(.viewWillAppear)
     }
 

--- a/HowManySet/Presentation/Feature/Calendar/CalendarViewController.swift
+++ b/HowManySet/Presentation/Feature/Calendar/CalendarViewController.swift
@@ -33,12 +33,16 @@ final class CalendarViewController: UIViewController, View {
         view = calendarView
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        reactor?.action.onNext(.viewWillAppear)
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         setDelegates()
         setRegisters()
         setButtonTargets()
-        reactor?.action.onNext(.viewDidLoad)
     }
 
     // MARK: - Init

--- a/HowManySet/Presentation/Feature/Calendar/Reactor/CalendarViewReactor.swift
+++ b/HowManySet/Presentation/Feature/Calendar/Reactor/CalendarViewReactor.swift
@@ -18,14 +18,14 @@ final class CalendarViewReactor: Reactor {
     enum Mutation {
         case setAllRecords([WorkoutRecord])
         case setSelectedDate(Date)
-        case setRecords([WorkoutRecord])
+        case setSelectedRecords([WorkoutRecord])
         case deleteRecordAt(IndexPath)
     }
 
     // MARK: - State is a current view state
     struct State {
         var selectedDate: Date = Date()
-        var records: [WorkoutRecord] = []
+        var selectedRecords: [WorkoutRecord] = []
         var allRecords: [WorkoutRecord] = []
     }
 
@@ -51,7 +51,7 @@ final class CalendarViewReactor: Reactor {
                     let filteredRecords = allRecords.filter {
                         Calendar.current.isDate($0.date, inSameDayAs: date)
                     }
-                    return Mutation.setRecords(filteredRecords)
+                    return Mutation.setSelectedRecords(filteredRecords)
                 }
                 .asObservable()
 
@@ -61,7 +61,7 @@ final class CalendarViewReactor: Reactor {
             ])
 
         case let .deleteItem(indexPath):
-            let recordToDelete = currentState.records[indexPath.row]
+            let recordToDelete = currentState.selectedRecords[indexPath.row]
             deleteRecordUseCase.execute(uid: UUID().uuidString, item: recordToDelete)
 
             return .just(.deleteRecordAt(indexPath))
@@ -77,12 +77,12 @@ final class CalendarViewReactor: Reactor {
             newState.allRecords = records
         case let .setSelectedDate(date):
             newState.selectedDate = date
-        case let .setRecords(records):
-            newState.records = records
+        case let .setSelectedRecords(records):
+            newState.selectedRecords = records
         case let .deleteRecordAt(indexPath):
-            var updatedRecords = state.records
+            var updatedRecords = state.selectedRecords
             updatedRecords.remove(at: indexPath.row)
-            newState.records = updatedRecords
+            newState.selectedRecords = updatedRecords
         }
 
         return newState

--- a/HowManySet/Presentation/Feature/Calendar/Reactor/CalendarViewReactor.swift
+++ b/HowManySet/Presentation/Feature/Calendar/Reactor/CalendarViewReactor.swift
@@ -6,6 +6,8 @@ final class CalendarViewReactor: Reactor {
 
     private let deleteRecordUseCase: DeleteRecordUseCase
     private let fetchRecordUseCase: FetchRecordUseCase
+    private let fsDeleteRecordUseCase: FSDeleteRecordUseCase
+    private let fsFetchRecordUseCase: FSFetchRecordUseCase
 
     // MARK: - Action is an user interaction
     enum Action {
@@ -31,10 +33,19 @@ final class CalendarViewReactor: Reactor {
 
     let initialState: State
 
+    private let uid = FirebaseAuthService().fetchCurrentUser()?.uid
+
     // MARK: - Init
-    init(deleteRecordUseCase: DeleteRecordUseCase, fetchRecordUseCase: FetchRecordUseCase) {
+    init(
+        deleteRecordUseCase: DeleteRecordUseCase,
+        fetchRecordUseCase: FetchRecordUseCase,
+        fsDeleteRecordUseCase: FSDeleteRecordUseCase,
+        fsFetchRecordUseCase: FSFetchRecordUseCase
+    ) {
         self.deleteRecordUseCase = deleteRecordUseCase
         self.fetchRecordUseCase = fetchRecordUseCase
+        self.fsDeleteRecordUseCase = fsDeleteRecordUseCase
+        self.fsFetchRecordUseCase = fsFetchRecordUseCase
         self.initialState = State()
     }
 
@@ -42,11 +53,22 @@ final class CalendarViewReactor: Reactor {
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case .viewDidLoad:
-            return fetchRecordUseCase.execute(uid: UUID().uuidString)
+            return fetchRecordUseCase.execute()
                 .map { Mutation.setAllRecords($0) }
                 .asObservable()
+
+//            let realmRecords = fetchRecordUseCase.execute()
+//                .map { Mutation.setAllRecords($0) }
+//                .asObservable()
+//
+//            let fsRecords = fsFetchRecordUseCase.execute(uid: uid ?? "")
+//                .map { Mutation.setAllRecords($0) }
+//                .asObservable()
+//
+//            return Observable.merge([realmRecords, fsRecords])
+
         case let .selectDate(date):
-            let fetchRecords = fetchRecordUseCase.execute(uid: UUID().uuidString)
+            let fetchRecords = fetchRecordUseCase.execute()
                 .map { allRecords in
                     let filteredRecords = allRecords.filter {
                         Calendar.current.isDate($0.date, inSameDayAs: date)
@@ -59,10 +81,32 @@ final class CalendarViewReactor: Reactor {
                 .just(.setSelectedDate(date)),
                 fetchRecords
             ])
+//
+//            let realmFetchRecords = fetchRecordUseCase.execute()
+//
+//            let fsFetchRecords = fsFetchRecordUseCase.execute(uid: uid ?? "")
+//
+//            let combinedFetch = Observable.zip(realmFetchRecords.asObservable(), fsFetchRecords.asObservable())
+//                .map { realmFetchRecords, fsFetchRecords in
+//                    let allRecords = realmFetchRecords + fsFetchRecords
+//                    let filteredRecords = allRecords.filter {
+//                        Calendar.current.isDate($0.date, inSameDayAs: date)
+//                    }
+//                    return Mutation.setSelectedRecords(filteredRecords)
+//                }
+//
+//            return Observable.concat([
+//                .just(.setSelectedDate(date)),
+//                combinedFetch
+//            ])
 
         case let .deleteItem(indexPath):
             let recordToDelete = currentState.selectedRecords[indexPath.row]
-            deleteRecordUseCase.execute(uid: UUID().uuidString, item: recordToDelete)
+            deleteRecordUseCase.execute(item: recordToDelete)
+//
+//            if let uid = uid {
+//                fsDeleteRecordUseCase.execute(uid: uid, item: recordToDelete)
+//            }
 
             return .just(.deleteRecordAt(indexPath))
         }

--- a/HowManySet/Presentation/Feature/Calendar/Reactor/CalendarViewReactor.swift
+++ b/HowManySet/Presentation/Feature/Calendar/Reactor/CalendarViewReactor.swift
@@ -39,18 +39,18 @@ final class CalendarViewReactor: Reactor {
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case let .selectDate(date):
-            let fetch = fetchRecordUseCase.execute(uid: UUID().uuidString)
-                .map { records in
-                    let filtered = records.filter {
+            let fetchRecords = fetchRecordUseCase.execute(uid: UUID().uuidString)
+                .map { allRecords in
+                    let filteredRecords = allRecords.filter {
                         Calendar.current.isDate($0.date, inSameDayAs: date)
                     }
-                    return Mutation.setRecords(filtered)
+                    return Mutation.setRecords(filteredRecords)
                 }
                 .asObservable()
 
             return Observable.concat([
                 .just(.setSelectedDate(date)),
-                fetch
+                fetchRecords
             ])
 
         case let .deleteItem(indexPath):

--- a/HowManySet/Presentation/Feature/Calendar/Reactor/CalendarViewReactor.swift
+++ b/HowManySet/Presentation/Feature/Calendar/Reactor/CalendarViewReactor.swift
@@ -11,7 +11,7 @@ final class CalendarViewReactor: Reactor {
 
     // MARK: - Action is an user interaction
     enum Action {
-        case viewDidLoad
+        case viewWillAppear
         case selectDate(Date)
         case deleteItem(IndexPath)
     }
@@ -52,7 +52,7 @@ final class CalendarViewReactor: Reactor {
     // MARK: - Action -> Mutation
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
-        case .viewDidLoad:
+        case .viewWillAppear:
             return fetchRecordUseCase.execute()
                 .map { Mutation.setAllRecords($0) }
                 .asObservable()

--- a/HowManySet/Presentation/Feature/Calendar/Reactor/CalendarViewReactor.swift
+++ b/HowManySet/Presentation/Feature/Calendar/Reactor/CalendarViewReactor.swift
@@ -14,6 +14,7 @@ final class CalendarViewReactor: Reactor {
         case viewWillAppear
         case selectDate(Date)
         case deleteItem(IndexPath)
+        case clearSelection
     }
 
     // MARK: - Mutate is a state manipulator which is not exposed to a view
@@ -22,6 +23,7 @@ final class CalendarViewReactor: Reactor {
         case setSelectedDate(Date)
         case setSelectedRecords([WorkoutRecord])
         case deleteRecordAt(IndexPath)
+        case clearSelectedDate
     }
 
     // MARK: - State is a current view state
@@ -109,6 +111,9 @@ final class CalendarViewReactor: Reactor {
 //            }
 
             return .just(.deleteRecordAt(indexPath))
+
+        case .clearSelection:
+            return .just(.clearSelectedDate)
         }
     }
 
@@ -127,6 +132,9 @@ final class CalendarViewReactor: Reactor {
             var updatedRecords = state.selectedRecords
             updatedRecords.remove(at: indexPath.row)
             newState.selectedRecords = updatedRecords
+        case .clearSelectedDate:
+            newState.selectedDate = Date()
+            newState.selectedRecords = []
         }
 
         return newState

--- a/HowManySet/Presentation/Feature/Calendar/Reactor/CalendarViewReactor.swift
+++ b/HowManySet/Presentation/Feature/Calendar/Reactor/CalendarViewReactor.swift
@@ -4,18 +4,20 @@ import ReactorKit
 
 final class CalendarViewReactor: Reactor {
 
-    private let saveRecordUseCase: SaveRecordUseCase
+    private let deleteRecordUseCase: DeleteRecordUseCase
     private let fetchRecordUseCase: FetchRecordUseCase
 
     // MARK: - Action is an user interaction
     enum Action {
         case selectDate(Date)
+        case deleteItem(IndexPath)
     }
 
     // MARK: - Mutate is a state manipulator which is not exposed to a view
     enum Mutation {
         case setSelectedDate(Date)
         case setRecords([WorkoutRecord])
+        case deleteRecordAt(IndexPath)
     }
 
     // MARK: - State is a current view state
@@ -27,8 +29,8 @@ final class CalendarViewReactor: Reactor {
     let initialState: State
 
     // MARK: - Init
-    init(saveRecordUseCase: SaveRecordUseCase, fetchRecordUseCase: FetchRecordUseCase) {
-        self.saveRecordUseCase = saveRecordUseCase
+    init(deleteRecordUseCase: DeleteRecordUseCase, fetchRecordUseCase: FetchRecordUseCase) {
+        self.deleteRecordUseCase = deleteRecordUseCase
         self.fetchRecordUseCase = fetchRecordUseCase
         self.initialState = State()
     }
@@ -47,6 +49,12 @@ final class CalendarViewReactor: Reactor {
                 Observable.just(.setSelectedDate(date)),
                 Observable.just(.setRecords(filteredRecords))
             ])
+
+        case let .deleteItem(indexPath):
+            let recordToDelete = currentState.records[indexPath.row]
+            deleteRecordUseCase.execute(uid: "", item: recordToDelete)
+
+            return .just(.deleteRecordAt(indexPath))
         }
     }
 
@@ -59,6 +67,10 @@ final class CalendarViewReactor: Reactor {
             newState.selectedDate = date
         case let .setRecords(records):
             newState.records = records
+        case let .deleteRecordAt(indexPath):
+            var updatedRecords = state.records
+            updatedRecords.remove(at: indexPath.row)
+            newState.records = updatedRecords
         }
 
         return newState

--- a/HowManySet/Presentation/Feature/Calendar/Reactor/CalendarViewReactor.swift
+++ b/HowManySet/Presentation/Feature/Calendar/Reactor/CalendarViewReactor.swift
@@ -9,12 +9,14 @@ final class CalendarViewReactor: Reactor {
 
     // MARK: - Action is an user interaction
     enum Action {
+        case viewDidLoad
         case selectDate(Date)
         case deleteItem(IndexPath)
     }
 
     // MARK: - Mutate is a state manipulator which is not exposed to a view
     enum Mutation {
+        case setAllRecords([WorkoutRecord])
         case setSelectedDate(Date)
         case setRecords([WorkoutRecord])
         case deleteRecordAt(IndexPath)
@@ -24,6 +26,7 @@ final class CalendarViewReactor: Reactor {
     struct State {
         var selectedDate: Date = Date()
         var records: [WorkoutRecord] = []
+        var allRecords: [WorkoutRecord] = []
     }
 
     let initialState: State
@@ -38,6 +41,10 @@ final class CalendarViewReactor: Reactor {
     // MARK: - Action -> Mutation
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
+        case .viewDidLoad:
+            return fetchRecordUseCase.execute(uid: UUID().uuidString)
+                .map { Mutation.setAllRecords($0) }
+                .asObservable()
         case let .selectDate(date):
             let fetchRecords = fetchRecordUseCase.execute(uid: UUID().uuidString)
                 .map { allRecords in
@@ -66,6 +73,8 @@ final class CalendarViewReactor: Reactor {
         var newState = state
 
         switch mutation {
+        case let .setAllRecords(records):
+            newState.allRecords = records
         case let .setSelectedDate(date):
             newState.selectedDate = date
         case let .setRecords(records):

--- a/HowManySet/Presentation/Feature/Calendar/RecordCell.swift
+++ b/HowManySet/Presentation/Feature/Calendar/RecordCell.swift
@@ -73,12 +73,12 @@ private extension RecordCell {
         }
 
         setsLabel.do {
-            $0.textColor = .textSecondary
+            $0.textColor = .white
             $0.font = .systemFont(ofSize: 14, weight: .regular)
         }
 
         timeLabel.do {
-            $0.textColor = .textSecondary
+            $0.textColor = .white
             $0.font = .systemFont(ofSize: 14, weight: .regular)
         }
     }

--- a/HowManySet/Presentation/Feature/Calendar/RecordCell.swift
+++ b/HowManySet/Presentation/Feature/Calendar/RecordCell.swift
@@ -94,6 +94,11 @@ private extension RecordCell {
     }
 
     func setConstraints() {
+        contentView.snp.makeConstraints {
+            $0.verticalEdges.equalToSuperview().inset(8)
+            $0.horizontalEdges.equalToSuperview()
+        }
+
         labelStackView.snp.makeConstraints {
             $0.verticalEdges.equalToSuperview().inset(16)
             $0.horizontalEdges.equalToSuperview().inset(20)

--- a/HowManySet/Presentation/Feature/Calendar/RecordCell.swift
+++ b/HowManySet/Presentation/Feature/Calendar/RecordCell.swift
@@ -95,7 +95,7 @@ private extension RecordCell {
 
     func setConstraints() {
         contentView.snp.makeConstraints {
-            $0.verticalEdges.equalToSuperview().inset(8)
+            $0.verticalEdges.equalToSuperview()
             $0.horizontalEdges.equalToSuperview()
         }
 

--- a/HowManySet/Presentation/Feature/RecordDetail/Cell/MemoInfoCell.swift
+++ b/HowManySet/Presentation/Feature/RecordDetail/Cell/MemoInfoCell.swift
@@ -24,7 +24,7 @@ final class MemoInfoCell: UICollectionViewCell {
     func configure(comment: String?) {
         let isEmpty = (comment?.isEmpty ?? true)
         memoTextView.text = isEmpty ? placeholderText : comment
-        memoTextView.textColor = isEmpty ? .systemGray3 : .white
+        memoTextView.textColor = isEmpty ? .grey3 : .white
         memoTextView.layer.borderWidth = 0
     }
 }

--- a/HowManySet/Presentation/Feature/RecordDetail/Cell/SummaryInfoCell.swift
+++ b/HowManySet/Presentation/Feature/RecordDetail/Cell/SummaryInfoCell.swift
@@ -66,6 +66,14 @@ extension SummaryInfoCell {
     var publicSaveButton: UIButton { saveButton }
 }
 
+// MARK: - 저장버튼 활성화 상태 정하는 메서드
+extension SummaryInfoCell {
+    func updateSaveButtonEnabled(_ isEnabled: Bool) {
+        publicSaveButton.isEnabled = isEnabled
+        publicSaveButton.setTitleColor(isEnabled ? .white : .systemGray, for: .normal)
+    }
+}
+
 // MARK: - SummaryInfoCell UI 관련 extension
 private extension SummaryInfoCell {
     func setupUI() {

--- a/HowManySet/Presentation/Feature/RecordDetail/Cell/SummaryInfoCell.swift
+++ b/HowManySet/Presentation/Feature/RecordDetail/Cell/SummaryInfoCell.swift
@@ -8,7 +8,7 @@ final class SummaryInfoCell: UICollectionViewCell {
 
     private let headerHStackView = UIStackView()
     private let routineNameLabel = UILabel()
-    private let editButton = UIButton()
+    private let saveButton = UIButton()
     private let confirmButton = UIButton()
     private let headerVStackView = UIStackView()
     private let startToEndLabel = UILabel()
@@ -63,6 +63,7 @@ final class SummaryInfoCell: UICollectionViewCell {
 // MARK: - Computed Properties
 extension SummaryInfoCell {
     var publicConfirmButton: UIButton { confirmButton }
+    var publicSaveButton: UIButton { saveButton }
 }
 
 // MARK: - SummaryInfoCell UI 관련 extension
@@ -86,8 +87,8 @@ private extension SummaryInfoCell {
             $0.font = .systemFont(ofSize: 18, weight: .semibold)
             $0.textAlignment = .center
         }
-        editButton.do {
-            $0.setTitle("수정", for: .normal)
+        saveButton.do {
+            $0.setTitle("저장", for: .normal)
             $0.titleLabel?.font = .systemFont(ofSize: 16, weight: .medium)
             $0.setTitleColor(.textTertiary, for: .normal)
         }
@@ -128,7 +129,7 @@ private extension SummaryInfoCell {
     }
 
     func setViewHierarchy() {
-        headerHStackView.addArrangedSubviews(editButton, routineNameLabel, confirmButton)
+        headerHStackView.addArrangedSubviews(saveButton, routineNameLabel, confirmButton)
         headerVStackView.addArrangedSubviews(headerHStackView, startToEndLabel)
 
         contentView.addSubviews(

--- a/HowManySet/Presentation/Feature/RecordDetail/Cell/SummaryInfoCell.swift
+++ b/HowManySet/Presentation/Feature/RecordDetail/Cell/SummaryInfoCell.swift
@@ -6,11 +6,6 @@ final class SummaryInfoCell: UICollectionViewCell {
     // MARK: - Properties
     static let identifier = "SummaryInfoCell"
 
-    private let headerHStackView = UIStackView()
-    private let routineNameLabel = UILabel()
-    private let saveButton = UIButton()
-    private let confirmButton = UIButton()
-    private let headerVStackView = UIStackView()
     private let startToEndLabel = UILabel()
 
     private let totalSummaryStackView = UIStackView()
@@ -32,8 +27,6 @@ final class SummaryInfoCell: UICollectionViewCell {
     // MARK: - configure
     /// WorkoutRecord의 데이터를 받아오는 메서드
     func configure(with record: WorkoutRecord) {
-        // 루틴명
-        routineNameLabel.text = record.workoutRoutine.name
 
         // 시작~종료 시간
         let endTime = record.date
@@ -60,20 +53,6 @@ final class SummaryInfoCell: UICollectionViewCell {
     }
 }
 
-// MARK: - Computed Properties
-extension SummaryInfoCell {
-    var publicConfirmButton: UIButton { confirmButton }
-    var publicSaveButton: UIButton { saveButton }
-}
-
-// MARK: - 저장버튼 활성화 상태 정하는 메서드
-extension SummaryInfoCell {
-    func updateSaveButtonEnabled(_ isEnabled: Bool) {
-        publicSaveButton.isEnabled = isEnabled
-        publicSaveButton.setTitleColor(isEnabled ? .white : .systemGray, for: .normal)
-    }
-}
-
 // MARK: - SummaryInfoCell UI 관련 extension
 private extension SummaryInfoCell {
     func setupUI() {
@@ -84,32 +63,6 @@ private extension SummaryInfoCell {
     }
 
     func setAppearance() {
-        // 첫번째
-        headerHStackView.do {
-            $0.axis = .horizontal
-            $0.alignment = .center
-            $0.distribution = .equalSpacing
-        }
-        routineNameLabel.do {
-            $0.textColor = .white
-            $0.font = .systemFont(ofSize: 18, weight: .semibold)
-            $0.textAlignment = .center
-        }
-        saveButton.do {
-            $0.setTitle("저장", for: .normal)
-            $0.titleLabel?.font = .systemFont(ofSize: 16, weight: .medium)
-            $0.setTitleColor(.textTertiary, for: .normal)
-        }
-        confirmButton.do {
-            $0.setTitle("확인", for: .normal)
-            $0.titleLabel?.font = .systemFont(ofSize: 16, weight: .medium)
-            $0.setTitleColor(.brand, for: .normal)
-        }
-        headerVStackView.do {
-            $0.axis = .vertical
-            $0.alignment = .fill
-            $0.spacing = 8
-        }
         startToEndLabel.do {
             $0.textColor = .systemGray3
             $0.font = .systemFont(ofSize: 14, weight: .regular)
@@ -137,11 +90,8 @@ private extension SummaryInfoCell {
     }
 
     func setViewHierarchy() {
-        headerHStackView.addArrangedSubviews(saveButton, routineNameLabel, confirmButton)
-        headerVStackView.addArrangedSubviews(headerHStackView, startToEndLabel)
-
         contentView.addSubviews(
-            headerVStackView,
+            startToEndLabel,
             totalSummaryStackView,
             dividerView,
             workoutDetailTitleLabel
@@ -149,14 +99,15 @@ private extension SummaryInfoCell {
     }
 
     func setConstraints() {
-        headerVStackView.snp.makeConstraints {
+
+        startToEndLabel.snp.makeConstraints {
             $0.top.equalToSuperview().offset(8)
-            $0.horizontalEdges.equalToSuperview()
+            $0.centerX.equalToSuperview()
         }
 
         totalSummaryStackView.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview()
-            $0.top.equalTo(headerVStackView.snp.bottom).offset(20)
+            $0.top.equalTo(startToEndLabel.snp.bottom).offset(20)
         }
 
         dividerView.snp.makeConstraints {

--- a/HowManySet/Presentation/Feature/RecordDetail/Cell/SummaryInfoCell.swift
+++ b/HowManySet/Presentation/Feature/RecordDetail/Cell/SummaryInfoCell.swift
@@ -64,7 +64,7 @@ private extension SummaryInfoCell {
 
     func setAppearance() {
         startToEndLabel.do {
-            $0.textColor = .systemGray3
+            $0.textColor = .grey3
             $0.font = .systemFont(ofSize: 14, weight: .regular)
             $0.textAlignment = .center
         }
@@ -78,7 +78,7 @@ private extension SummaryInfoCell {
 
         // 세번째
         dividerView.do {
-            $0.backgroundColor = .systemGray5
+            $0.backgroundColor = .grey5
         }
 
         // 네번째
@@ -135,7 +135,7 @@ private extension SummaryInfoCell {
 
         let valueLabel = UILabel().then {
             $0.text = value
-            $0.textColor = .brand
+            $0.textColor = .green6
             $0.font = .systemFont(ofSize: 14, weight: .medium)
             $0.textAlignment = .center
         }

--- a/HowManySet/Presentation/Feature/RecordDetail/Cell/WorkoutDetailInfoCell.swift
+++ b/HowManySet/Presentation/Feature/RecordDetail/Cell/WorkoutDetailInfoCell.swift
@@ -28,14 +28,14 @@ final class WorkoutDetailInfoCell: UICollectionViewCell {
         let setCountLabel = UILabel().then {
             $0.text = "\(index + 1)세트"
             $0.font = .systemFont(ofSize: 12, weight: .regular)
-            $0.textColor = .systemGray3
+            $0.textColor = .grey2
             $0.textAlignment = .center
         }
 
         let setDetailLabel = UILabel().then {
             $0.text = "\(set.weight.clean)\(set.unit) * \(set.reps)회"
             $0.font = .systemFont(ofSize: 14, weight: .regular)
-            $0.textColor = .textTertiary
+            $0.textColor = .grey4
             $0.textAlignment = .center
         }
 

--- a/HowManySet/Presentation/Feature/RecordDetail/HeaderView/WorkoutDetailHeaderView.swift
+++ b/HowManySet/Presentation/Feature/RecordDetail/HeaderView/WorkoutDetailHeaderView.swift
@@ -34,7 +34,7 @@ private extension WorkoutDetailHeaderView {
     func setAppearance() {
         titleLabel.do {
             $0.font = .systemFont(ofSize: 16, weight: .medium)
-            $0.textColor = .white
+            $0.textColor = .grey1
         }
     }
 

--- a/HowManySet/Presentation/Feature/RecordDetail/Reactor/RecordDetailViewReactor.swift
+++ b/HowManySet/Presentation/Feature/RecordDetail/Reactor/RecordDetailViewReactor.swift
@@ -7,6 +7,7 @@ final class RecordDetailViewReactor: Reactor {
     // MARK: - Action is an user interaction
     enum Action {
         case tapConfirm
+        case tapSave
         case updateMemo(String?)
     }
     
@@ -39,6 +40,9 @@ final class RecordDetailViewReactor: Reactor {
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case .tapConfirm:
+            return .just(.setDismiss(true))
+
+        case .tapSave:
             let trimmedCurrent = currentState.memo?.trimmingCharacters(in: .whitespacesAndNewlines)
             let current = (trimmedCurrent == "메모를 입력해주세요.") ? nil : trimmedCurrent
             let original = currentState.record.comment?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -49,17 +53,17 @@ final class RecordDetailViewReactor: Reactor {
             // 둘 다 nil 또는 공백이면 변경 없음
             if isCurrentEmpty && isOriginalEmpty {
                 print("변경된 값 없음")
-                return .just(.setDismiss(true))
+                return .empty()
             }
 
             // 값이 다르면 변경된 것으로 간주
             if current != original {
                 print("변경된 메모 저장: \(current ?? "")")
-                return .just(.setDismiss(true))
+                return .empty()
             }
 
             print("변경된 값 없음")
-            return .just(.setDismiss(true))
+            return .empty()
 
         case let .updateMemo(text):
             return .just(.setMemo(text))

--- a/HowManySet/Presentation/Feature/RecordDetail/Reactor/RecordDetailViewReactor.swift
+++ b/HowManySet/Presentation/Feature/RecordDetail/Reactor/RecordDetailViewReactor.swift
@@ -39,7 +39,28 @@ final class RecordDetailViewReactor: Reactor {
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case .tapConfirm:
+            let trimmedCurrent = currentState.memo?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let current = (trimmedCurrent == "메모를 입력해주세요.") ? nil : trimmedCurrent
+            let original = currentState.record.comment?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            let isCurrentEmpty = current?.isEmpty ?? true
+            let isOriginalEmpty = original?.isEmpty ?? true
+
+            // 둘 다 nil 또는 공백이면 변경 없음
+            if isCurrentEmpty && isOriginalEmpty {
+                print("변경된 값 없음")
+                return .just(.setDismiss(true))
+            }
+
+            // 값이 다르면 변경된 것으로 간주
+            if current != original {
+                print("변경된 메모 저장: \(current ?? "")")
+                return .just(.setDismiss(true))
+            }
+
+            print("변경된 값 없음")
             return .just(.setDismiss(true))
+
         case let .updateMemo(text):
             return .just(.setMemo(text))
         }

--- a/HowManySet/Presentation/Feature/RecordDetail/Reactor/RecordDetailViewReactor.swift
+++ b/HowManySet/Presentation/Feature/RecordDetail/Reactor/RecordDetailViewReactor.swift
@@ -3,12 +3,16 @@ import RxSwift
 import ReactorKit
 
 final class RecordDetailViewReactor: Reactor {
-    
+    // MARK: - UseCase
+    private let saveRecordUseCase: SaveRecordUseCase
+    private let fetchRecordUseCase: FetchRecordUseCase
+
     // MARK: - Action is an user interaction
     enum Action {
         case tapConfirm
         case tapSave
         case updateMemo(String?)
+        case refreshRecord
     }
     
     // MARK: - Mutate is a state manipulator which is not exposed to a view
@@ -17,11 +21,12 @@ final class RecordDetailViewReactor: Reactor {
         case setMemo(String?)
         case setSaveButtonEnabled(Bool)
         case updateOriginalMemo(String?)
+        case setFetchedRecord(WorkoutRecord)
     }
     
     // MARK: - State is a current view state
     struct State {
-        let record: WorkoutRecord
+        var record: WorkoutRecord
         var memo: String?
         var originalMemo: String?
         var shouldDismiss: Bool
@@ -32,7 +37,12 @@ final class RecordDetailViewReactor: Reactor {
     let initialState: State
 
     // MARK: - Init
-    init(record: WorkoutRecord) {
+    init(saveRecordUseCase: SaveRecordUseCase,
+         fetchRecordUseCase: FetchRecordUseCase,
+         record: WorkoutRecord
+    ) {
+        self.saveRecordUseCase = saveRecordUseCase
+        self.fetchRecordUseCase = fetchRecordUseCase
         self.initialState = State(
             record: record,
             memo: record.comment,
@@ -53,11 +63,16 @@ final class RecordDetailViewReactor: Reactor {
                   memo != "메모를 입력해주세요.",
                   memo != currentState.originalMemo?.trimmingCharacters(in: .whitespacesAndNewlines)
             else {
-                print("변경된 값 없음")
+                print("변경된 값 없음") // ✅ print
                 return .empty()
             }
 
-            print("변경된 메모 저장: \(memo)")
+            let updatedRecord = currentState.record.withUpdatedComment(memo)
+
+            // 실제 저장 UseCase 호출
+            saveRecordUseCase.execute(uid: "", item: updatedRecord)
+
+            print("변경된 메모 저장: \(memo)") // ✅ print
             return Observable.from([
                 .updateOriginalMemo(memo),
                 .setSaveButtonEnabled(false)
@@ -67,12 +82,18 @@ final class RecordDetailViewReactor: Reactor {
             let trimmed = text?.trimmingCharacters(in: .whitespacesAndNewlines)
             let current = (trimmed == "메모를 입력해주세요.") ? nil : trimmed
             let original = currentState.record.comment?.trimmingCharacters(in: .whitespacesAndNewlines)
-            let isChanged = current != original && !(current?.isEmpty ?? true)
+            let isChanged = (current != original) && !(current?.isEmpty ?? true)
 
             return Observable.from([
                 .setMemo(text),
                 .setSaveButtonEnabled(isChanged)
             ])
+
+        case .refreshRecord:
+            // 실제 fetch 흐름
+            return fetchRecordUseCase.execute(uid: "")
+                .map { Mutation.setFetchedRecord($0.first ?? self.currentState.record) }
+                .asObservable()
         }
     }
 
@@ -88,7 +109,12 @@ final class RecordDetailViewReactor: Reactor {
             newState.isSaveButtonEnabled = isEnabled
         case let .updateOriginalMemo(newMemo):
             newState.originalMemo = newMemo
+        case let .setFetchedRecord(record): // fetch 처리
+            newState.record = record
+            newState.memo = record.comment
+            newState.originalMemo = record.comment
         }
+
         return newState
     }
 }

--- a/HowManySet/Presentation/Feature/RecordDetail/RecordDetailHeaderView.swift
+++ b/HowManySet/Presentation/Feature/RecordDetail/RecordDetailHeaderView.swift
@@ -63,7 +63,7 @@ private extension RecordDetailHeaderView {
         confirmButton.do {
             $0.setTitle("확인", for: .normal)
             $0.titleLabel?.font = .systemFont(ofSize: 16, weight: .medium)
-            $0.setTitleColor(.brand, for: .normal)
+            $0.setTitleColor(.green6, for: .normal)
         }
     }
 

--- a/HowManySet/Presentation/Feature/RecordDetail/RecordDetailHeaderView.swift
+++ b/HowManySet/Presentation/Feature/RecordDetail/RecordDetailHeaderView.swift
@@ -34,8 +34,7 @@ extension RecordDetailHeaderView {
 // MARK: - 저장버튼 활성화 상태 정하는 메서드
 extension RecordDetailHeaderView {
     func updateSaveButtonEnabled(_ isEnabled: Bool) {
-        publicSaveButton.isEnabled = isEnabled
-        publicSaveButton.setTitleColor(isEnabled ? .white : .systemGray, for: .normal)
+        publicSaveButton.isHidden = !isEnabled
     }
 }
 

--- a/HowManySet/Presentation/Feature/RecordDetail/RecordDetailHeaderView.swift
+++ b/HowManySet/Presentation/Feature/RecordDetail/RecordDetailHeaderView.swift
@@ -1,0 +1,90 @@
+import UIKit
+import SnapKit
+import Then
+
+final class RecordDetailHeaderView: UIView {
+    // MARK: - Properties
+    private let routineNameLabel = UILabel()
+    private let saveButton = UIButton()
+    private let confirmButton = UIButton()
+
+    // MARK: - Init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - configure
+    func configure(with record: WorkoutRecord) {
+        // 루틴명
+        routineNameLabel.text = record.workoutRoutine.name
+    }
+}
+
+// MARK: - Computed Properties
+extension RecordDetailHeaderView {
+    var publicConfirmButton: UIButton { confirmButton }
+    var publicSaveButton: UIButton { saveButton }
+}
+
+// MARK: - 저장버튼 활성화 상태 정하는 메서드
+extension RecordDetailHeaderView {
+    func updateSaveButtonEnabled(_ isEnabled: Bool) {
+        publicSaveButton.isEnabled = isEnabled
+        publicSaveButton.setTitleColor(isEnabled ? .white : .systemGray, for: .normal)
+    }
+}
+
+// MARK: - RecordDetailHeaderView UI 관련 extension
+private extension RecordDetailHeaderView {
+    func setupUI() {
+        backgroundColor = .clear
+        setAppearance()
+        setViewHierarchy()
+        setConstraints()
+    }
+
+    func setAppearance() {
+        routineNameLabel.do {
+            $0.textColor = .white
+            $0.font = .systemFont(ofSize: 18, weight: .semibold)
+            $0.textAlignment = .center
+        }
+
+        saveButton.do {
+            $0.setTitle("저장", for: .normal)
+            $0.titleLabel?.font = .systemFont(ofSize: 16, weight: .medium)
+            $0.setTitleColor(.textTertiary, for: .normal)
+        }
+
+        confirmButton.do {
+            $0.setTitle("확인", for: .normal)
+            $0.titleLabel?.font = .systemFont(ofSize: 16, weight: .medium)
+            $0.setTitleColor(.brand, for: .normal)
+        }
+    }
+
+    func setViewHierarchy() {
+        addSubviews(saveButton, routineNameLabel, confirmButton)
+    }
+
+    func setConstraints() {
+        saveButton.snp.makeConstraints {
+            $0.leading.equalToSuperview().offset(28)
+            $0.centerY.equalToSuperview()
+        }
+
+        confirmButton.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(28)
+            $0.centerY.equalToSuperview()
+        }
+
+        routineNameLabel.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+    }
+}

--- a/HowManySet/Presentation/Feature/RecordDetail/RecordDetailView.swift
+++ b/HowManySet/Presentation/Feature/RecordDetail/RecordDetailView.swift
@@ -4,6 +4,8 @@ import Then
 
 final class RecordDetailView: UIView {
 
+    private let recordDetailHeaderView = RecordDetailHeaderView()
+
     /// 동적 레이아웃을 적용한 컬렉션 뷰
     private let collectionView: UICollectionView = {
         let layout = UICollectionViewCompositionalLayout { _, _ in
@@ -25,6 +27,10 @@ final class RecordDetailView: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+}
+
+extension RecordDetailView {
+    var publicHeaderView: RecordDetailHeaderView { recordDetailHeaderView }
 }
 
 // MARK: - Record Detail UI 관련 extension
@@ -50,12 +56,19 @@ private extension RecordDetailView {
     }
 
     func setViewHierarchy() {
-        addSubview(collectionView)
+        addSubviews(recordDetailHeaderView, collectionView)
     }
 
     func setConstraints() {
+        recordDetailHeaderView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(12)
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(44)
+        }
+
         collectionView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+            $0.top.equalTo(recordDetailHeaderView.snp.bottom)
+            $0.horizontalEdges.bottom.equalToSuperview()
         }
     }
 }
@@ -95,7 +108,7 @@ private extension RecordDetailView {
             subitems: [item]
         )
         let section = NSCollectionLayoutSection(group: group)
-        section.contentInsets = .init(top: 28, leading: 28, bottom: 20, trailing: 28)
+        section.contentInsets = .init(top: 0, leading: 28, bottom: 20, trailing: 28)
         return section
     }
 

--- a/HowManySet/Presentation/Feature/RecordDetail/RecordDetailViewController.swift
+++ b/HowManySet/Presentation/Feature/RecordDetail/RecordDetailViewController.swift
@@ -140,12 +140,17 @@ extension RecordDetailViewController {
             }
             .disposed(by: disposeBag)
 
-        // 확인 버튼 탭 -> Reactor 액션 전달
+        // 저장 버튼, 확인 버튼 탭 -> Reactor 액션 전달
         recordDetailView.publicCollectionView.rx
             .willDisplayCell
             .compactMap { $0.cell as? SummaryInfoCell }
             .take(1)
             .bind(with: self) { (owner: RecordDetailViewController, cell: SummaryInfoCell) in
+                cell.publicSaveButton.rx.tap
+                    .map { RecordDetailViewReactor.Action.tapSave }
+                    .bind(to: reactor.action)
+                    .disposed(by: owner.disposeBag)
+
                 cell.publicConfirmButton.rx.tap
                     .map { RecordDetailViewReactor.Action.tapConfirm }
                     .bind(to: reactor.action)

--- a/HowManySet/Presentation/Feature/RecordDetail/RecordDetailViewController.swift
+++ b/HowManySet/Presentation/Feature/RecordDetail/RecordDetailViewController.swift
@@ -84,12 +84,6 @@ final class RecordDetailViewController: UIViewController, View {
         bindKeyboardNotifications()
         bindTapToDismissKeyboard()
     }
-
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-
-        reactor?.action.onNext(.refreshRecord)
-    }
 }
 
 // MARK: - UI Methods & Reactor Bind

--- a/HowManySet/Presentation/Feature/RecordDetail/RecordDetailViewController.swift
+++ b/HowManySet/Presentation/Feature/RecordDetail/RecordDetailViewController.swift
@@ -176,7 +176,7 @@ extension RecordDetailViewController {
                             textView.text = nil
                             textView.textColor = .white
                         }
-                        textView.layer.borderColor = UIColor.systemGray.cgColor
+                        textView.layer.borderColor = UIColor.grey3.cgColor
                         textView.layer.borderWidth = 1
                     }
                     .disposed(by: owner.disposeBag)
@@ -185,7 +185,7 @@ extension RecordDetailViewController {
                     .bind(with: owner) { _, _ in
                         if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                             textView.text = "메모를 입력해주세요."
-                            textView.textColor = .systemGray3
+                            textView.textColor = .grey3
                         }
                         textView.layer.borderWidth = 0
                     }

--- a/HowManySet/Presentation/Feature/RecordDetail/RecordDetailViewController.swift
+++ b/HowManySet/Presentation/Feature/RecordDetail/RecordDetailViewController.swift
@@ -91,6 +91,9 @@ extension RecordDetailViewController {
     /// 리액터 Binding
     func bind(reactor: RecordDetailViewReactor) {
         let record = reactor.currentState.record
+        let headerView = recordDetailView.publicHeaderView
+        
+        recordDetailView.publicHeaderView.configure(with: record)
 
         // 요약뷰 구성
         let summarySection = RecordDetailSectionModel(
@@ -127,45 +130,25 @@ extension RecordDetailViewController {
             .disposed(by: disposeBag)
 
         // MARK: - Data Binding
-        // collectionView에 있는 셀 탭 -> Reactor 액션 전달
-        recordDetailView.publicCollectionView.rx
-            .willDisplayCell
-            .compactMap { $0.cell as? SummaryInfoCell }
-            .take(1)
-            .bind(with: self) { (owner: RecordDetailViewController, cell: SummaryInfoCell) in
-                // 저장 버튼 탭
-                cell.publicSaveButton.rx.tap
-                    .map { RecordDetailViewReactor.Action.tapSave }
-                    .bind(to: reactor.action)
-                    .disposed(by: owner.disposeBag)
 
-                // 확인 버튼 탭
-                cell.publicConfirmButton.rx.tap
-                    .map { RecordDetailViewReactor.Action.tapConfirm }
-                    .bind(to: reactor.action)
-                    .disposed(by: owner.disposeBag)
-
-                // 저장 버튼 활성화 상태 바인딩
-                reactor.state
-                    .map(\.isSaveButtonEnabled)
-                    .distinctUntilChanged()
-                    .bind(with: owner) { _, isEnabled in
-                        cell.updateSaveButtonEnabled(isEnabled)
-                    }
-                    .disposed(by: owner.disposeBag)
-            }
+        // 저장 버튼 탭
+        headerView.publicSaveButton.rx.tap
+            .map { RecordDetailViewReactor.Action.tapSave }
+            .bind(to: reactor.action)
             .disposed(by: disposeBag)
 
-        // 저장 버튼 상태 변화 → 보이는 SummaryInfoCell에 직접 반영
+        // 확인 버튼 탭
+        headerView.publicConfirmButton.rx.tap
+            .map { RecordDetailViewReactor.Action.tapConfirm }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+
+        // 저장 버튼 활성화 상태 바인딩
         reactor.state
             .map(\.isSaveButtonEnabled)
             .distinctUntilChanged()
             .bind(with: self) { owner, isEnabled in
-                owner.recordDetailView.publicCollectionView.visibleCells.forEach { cell in
-                    if let summaryCell = cell as? SummaryInfoCell {
-                        summaryCell.updateSaveButtonEnabled(isEnabled)
-                    }
-                }
+                owner.recordDetailView.publicHeaderView.updateSaveButtonEnabled(isEnabled)
             }
             .disposed(by: disposeBag)
 

--- a/HowManySet/Presentation/Feature/RoutineList/Reactor/RoutineListViewReactor.swift
+++ b/HowManySet/Presentation/Feature/RoutineList/Reactor/RoutineListViewReactor.swift
@@ -38,7 +38,7 @@ final class RoutineListViewReactor: Reactor {
         saveRoutineUseCase: SaveRoutineUseCase,
         fsDeleteRoutineUseCase: FSDeleteRoutineUseCase,
         fsFetchRoutineUseCase: FSFetchRoutineUseCase,
-        fsSaveRoutineUseCase: FSSaveRoutineUseCase,
+        fsSaveRoutineUseCase: FSSaveRoutineUseCase
     ) {
         self.deleteRoutineUseCase = deleteRoutineUseCase
         self.fetchRoutineUseCase = fetchRoutineUseCase

--- a/HowManySet/Presentation/Feature/RoutineList/RoutineCell.swift
+++ b/HowManySet/Presentation/Feature/RoutineList/RoutineCell.swift
@@ -86,7 +86,7 @@ private extension RoutineCell {
 
     func setConstraints() {
         contentView.snp.makeConstraints {
-            $0.verticalEdges.equalToSuperview().inset(8)
+            $0.verticalEdges.equalToSuperview()
             $0.horizontalEdges.equalToSuperview()
         }
 

--- a/HowManySet/Presentation/Feature/RoutineList/RoutineCell.swift
+++ b/HowManySet/Presentation/Feature/RoutineList/RoutineCell.swift
@@ -46,7 +46,7 @@ private extension RoutineCell {
 
     func setAppearance() {
         contentView.do {
-            $0.backgroundColor = .cardBackground
+            $0.backgroundColor = .grey5
             $0.layer.cornerRadius = 20
             $0.clipsToBounds = true
         }

--- a/HowManySet/Presentation/Feature/RoutineList/RoutineListView.swift
+++ b/HowManySet/Presentation/Feature/RoutineList/RoutineListView.swift
@@ -78,13 +78,13 @@ private extension RoutineListView {
         }
 
         routineTableView.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(12)
+            $0.top.equalTo(titleLabel.snp.bottom).offset(24)
             $0.horizontalEdges.equalTo(safeAreaLayoutGuide).inset(20)
             $0.bottom.equalTo(safeAreaLayoutGuide)
         }
 
         addNewRoutineButton.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(20)
+            $0.top.equalToSuperview()
             $0.horizontalEdges.equalToSuperview()
             $0.bottom.equalToSuperview().inset(20)
             $0.height.equalTo(56)

--- a/HowManySet/Presentation/Feature/RoutineList/RoutineListView.swift
+++ b/HowManySet/Presentation/Feature/RoutineList/RoutineListView.swift
@@ -49,10 +49,10 @@ private extension RoutineListView {
         }
 
         addNewRoutineButton.do {
-            $0.backgroundColor = .brand // 임의로 색상 변경함‼️
+            $0.backgroundColor = .green6
             $0.setTitle("새 루틴 구성", for: .normal)
             $0.titleLabel?.font = .systemFont(ofSize: 18, weight: .regular)
-            $0.setTitleColor(.black, for: .normal) // 임의로 색상 변경함‼️
+            $0.setTitleColor(.background, for: .normal)
             $0.layer.cornerRadius = 12
             clipsToBounds = true
         }

--- a/HowManySet/Presentation/Feature/RoutineList/RoutineListView.swift
+++ b/HowManySet/Presentation/Feature/RoutineList/RoutineListView.swift
@@ -45,6 +45,7 @@ private extension RoutineListView {
         routineTableView.do {
             $0.backgroundColor = .clear
             $0.separatorStyle = .none
+            $0.showsVerticalScrollIndicator = false
         }
 
         addNewRoutineButton.do {

--- a/HowManySet/Presentation/Feature/RoutineList/RoutineListViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineList/RoutineListViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import RxDataSources
 import RxSwift
 import RxCocoa
 import ReactorKit
@@ -11,13 +12,19 @@ final class RoutineListViewController: UIViewController, View {
     let routineListView = RoutineListView()
     private var coordinator: RoutineListCoordinatorProtocol?
 
-    // DiffableDataSource 정의
-    private var dataSource: UITableViewDiffableDataSource<Section, WorkoutRoutine>!
+    // RxDataSource 사용을 위한 Model 생성
+    typealias RoutineSection = SectionModel<String, WorkoutRoutine>
 
-    // Section 정의
-    enum Section {
-        case main
-    }
+    // RxDataSource 정의
+    let dataSource = RxTableViewSectionedReloadDataSource<RoutineSection>(
+        configureCell: { _, tableView, indexPath, item in
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: RoutineCell.identifier, for: indexPath) as? RoutineCell else {
+                return UITableViewCell()
+            }
+            cell.configure(with: item)
+            return cell
+        }
+    )
 
     // MARK: - Init
     init(reactor: RoutineListViewReactor, coordinator: RoutineListCoordinatorProtocol) {
@@ -43,7 +50,6 @@ final class RoutineListViewController: UIViewController, View {
         super.viewDidLoad()
         setDelegates()
         setRegisters()
-        configureDataSource()
     }
 
     // MARK: - Bind
@@ -56,17 +62,19 @@ final class RoutineListViewController: UIViewController, View {
             .disposed(by: disposeBag)
         
         reactor.state
-            .skip(1)
-            .map { $0.routines }
-            .distinctUntilChanged()
-            .observe(on: MainScheduler.instance)
-            .subscribe(with: self) { owner, items in
-                owner.applySnapshot(with: items)
-            }.disposed(by: disposeBag)
+            .map { state in
+                state.routines.map { SectionModel(model: "", items: [$0]) }  // 루틴마다 하나의 섹션
+            }
+            .bind(to: routineListView.publicRoutineTableView.rx.items(dataSource: dataSource))
+            .disposed(by: disposeBag)
+
+        // tableView.delegate 바인딩
+        routineListView.publicRoutineTableView.rx.setDelegate(self)
+            .disposed(by: disposeBag)
     }
 }
 
-// MARK: - Delegate & DataSource & Register
+// MARK: - Delegate & Register
 private extension RoutineListViewController {
     func setDelegates() {
         routineListView.publicRoutineTableView.delegate = self
@@ -74,37 +82,6 @@ private extension RoutineListViewController {
 
     func setRegisters() {
         routineListView.publicRoutineTableView.register(RoutineCell.self, forCellReuseIdentifier: RoutineCell.identifier)
-    }
-
-    func configureDataSource() {
-        dataSource = UITableViewDiffableDataSource<Section, WorkoutRoutine>(
-            tableView: routineListView.publicRoutineTableView
-        ) { tableView, indexPath, routine in
-            guard let cell = tableView.dequeueReusableCell(
-                withIdentifier: RoutineCell.identifier,
-                for: indexPath
-            ) as? RoutineCell else {
-                return UITableViewCell()
-            }
-
-            // 데이터를 cell에 주입
-            cell.configure(with: routine)
-            return cell
-        }
-    }
-}
-
-// MARK: - Snapshot
-extension RoutineListViewController {
-    /// 현재 보여줄 데이터 전체 상태를 전달하는 메서드
-    func applySnapshot(with routines: [WorkoutRoutine], animatingDifferences: Bool = true) {
-        var snapshot = NSDiffableDataSourceSnapshot<Section, WorkoutRoutine>()
-        // Section 추가
-        snapshot.appendSections([.main])
-        // Item 추가
-        snapshot.appendItems(routines, toSection: .main)
-        // 실제 적용
-        dataSource.apply(snapshot, animatingDifferences: false)
     }
 }
 
@@ -120,8 +97,18 @@ extension RoutineListViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
 
-        guard let routine = dataSource.itemIdentifier(for: indexPath) else { return }
+        let routine = dataSource.sectionModels[indexPath.section].items[indexPath.row]
 
         coordinator?.pushEditRoutineView(with: routine)
+    }
+
+    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        let footer = UIView()
+        footer.backgroundColor = .clear
+        return footer
+    }
+
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        return 16
     }
 }

--- a/HowManySet/Presentation/Feature/RoutineList/RoutineListViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineList/RoutineListViewController.swift
@@ -102,6 +102,18 @@ extension RoutineListViewController: UITableViewDelegate {
         coordinator?.pushEditRoutineView(with: routine)
     }
 
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath)
+    -> UISwipeActionsConfiguration? {
+        let deleteAction = UIContextualAction(style: .destructive, title: "삭제") { [weak self] _, _, completion in
+            self?.reactor?.action.onNext(.deleteRoutine(indexPath))
+            completion(true)
+        }
+
+        deleteAction.backgroundColor = .error
+        return UISwipeActionsConfiguration(actions: [deleteAction])
+    }
+
+
     func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         let footer = UIView()
         footer.backgroundColor = .clear

--- a/HowManySet/Presentation/Feature/RoutineList/RoutineListViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineList/RoutineListViewController.swift
@@ -10,7 +10,7 @@ final class RoutineListViewController: UIViewController, View {
     var disposeBag = DisposeBag()
 
     let routineListView = RoutineListView()
-    private var coordinator: RoutineListCoordinatorProtocol?
+    private weak var coordinator: RoutineListCoordinatorProtocol?
 
     // RxDataSource 사용을 위한 Model 생성
     typealias RoutineSection = SectionModel<String, WorkoutRoutine>
@@ -41,6 +41,7 @@ final class RoutineListViewController: UIViewController, View {
     override func loadView() {
         view = routineListView
     }
+    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         reactor?.action.onNext(.viewWillAppear)

--- a/HowManySet/Presentation/Feature/RoutineList/RoutineListViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineList/RoutineListViewController.swift
@@ -91,7 +91,7 @@ extension RoutineListViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         /* height를 기본값으로 지정하는 이유
          => 다른 기기에서 셀 내부의 내용이 다 잘림. 어차피 스크롤이 되기 때문에 기본값으로 지정해줘도 괜찮다고 생각함. */
-        132
+        116
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/HowManySet/Presentation/Feature/RoutineList/RoutineListViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineList/RoutineListViewController.swift
@@ -94,6 +94,7 @@ extension RoutineListViewController: UITableViewDelegate {
         116
     }
 
+    /// TableView Cell이 선택되었을 때 실행하는 메서드
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
 
@@ -102,6 +103,7 @@ extension RoutineListViewController: UITableViewDelegate {
         coordinator?.pushEditRoutineView(with: routine)
     }
 
+    /// trailing -> leading 방향으로 스와이프하는 메서드
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath)
     -> UISwipeActionsConfiguration? {
         let deleteAction = UIContextualAction(style: .destructive, title: "삭제") { [weak self] _, _, completion in
@@ -113,13 +115,14 @@ extension RoutineListViewController: UITableViewDelegate {
         return UISwipeActionsConfiguration(actions: [deleteAction])
     }
 
-
+    /// tableView의 섹션 안에 있는 footerView를 설정하는 메서드
     func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         let footer = UIView()
         footer.backgroundColor = .clear
         return footer
     }
 
+    /// tableView의 섹션 안에 있는 footerView의 높이를 정하는 메서드
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         return 16
     }

--- a/HowManySet/Presentation/Feature/RoutineName/RoutineNameViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineName/RoutineNameViewController.swift
@@ -47,8 +47,8 @@ extension RoutineNameViewController {
             .bind(with: self) { owner, isEnabled in
                 let button = owner.routineNameView.publicNextButton
                 button.isEnabled = isEnabled
-                button.backgroundColor = isEnabled ? .brand : .disabledButton
-                button.setTitleColor(isEnabled ? .black : .dbTypo, for: .normal)
+                button.backgroundColor = isEnabled ? .green6 : .disabledButton
+                button.setTitleColor(isEnabled ? .background : .dbTypo, for: .normal)
             }
             .disposed(by: disposeBag)
 


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  closed: #79 
  closed: #80 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- #79, #80 같이 진행했습니다
- 스와이프 삭제 버튼이 커스텀하기엔 공수가 많이 들어 섹션별 하나의 셀 지정 + 빈 footerView로 공백 주었습니다
- RoutineList의 tableView DiffableDataSource에서 RxDataSource로 수정했습니다
- RecordDetail 페이지 튜터님께 피드백 받은대로 수정했습니다
    - 저장버튼, 루틴이름, 확인버튼 상단에 고정
    - 저장된 메모 내용 변경 없을 시 저장 버튼 hidden처리

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| RecordDetail | <img src = "https://github.com/user-attachments/assets/f21e0da9-4531-4216-a126-0143127ac7d3" width ="250"> |
| RoutineList Swipe Delete | <img src = "https://github.com/user-attachments/assets/cf803474-e80d-42f1-b03b-7e4da4a73dbf" width ="250"> |
| Calendar Swipe Delete | <img src = "https://github.com/user-attachments/assets/7b24c0e6-8cf0-41b0-a7ad-fd70e467317e" width ="250"> |

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 상세 기록 뷰에서 메모를 수정하고 수정 버튼 누른 다음 dismiss 후 다시 해당 셀에 들어가면 메모에 수정된 사항이 저장되지 않는 이슈 존재
- 일단 Reactor에 realmUseCase만 사용중. fsUseCase는 연결만 해놓고 추후 업데이트 예정
- 추후에 메모 수정될 때마다 수정되었다는 토스트 뷰 띄워주면 좋아보임