### PR TITLE
refactor: #131 - EditRoutineVC에 UpdateRoutineUseCase 주입 / 드래그 앤 드롭 막아둠

### DIFF
--- a/HowManySet/App/Coordinator/HomeCoordinator.swift
+++ b/HowManySet/App/Coordinator/HomeCoordinator.swift
@@ -102,9 +102,11 @@ final class HomeCoordinator: HomeCoordinatorProtocol {
         let routineRepository = RoutineRepositoryImpl()
         let saveRoutineUseCase = SaveRoutineUseCase(repository: routineRepository)
         let deleteRoutineUseCase = DeleteRoutineUseCase(repository: routineRepository)
+        let updateRoutineUseCase = UpdateRoutineUseCase(repository: routineRepository)
         let reactor = EditRoutineViewReactor(with: routine,
                                              saveRoutineUseCase: saveRoutineUseCase,
-                                             deleteRoutineUseCase: deleteRoutineUseCase)
+                                             deleteRoutineUseCase: deleteRoutineUseCase,
+                                             updateRoutineUseCase: updateRoutineUseCase)
         let editRoutineVC = EditRoutineViewController(reactor: reactor)
         
         if let sheet = editRoutineVC.sheetPresentationController {

--- a/HowManySet/App/Coordinator/RoutineListCoordinator.swift
+++ b/HowManySet/App/Coordinator/RoutineListCoordinator.swift
@@ -93,9 +93,11 @@ final class RoutineListCoordinator: RoutineListCoordinatorProtocol {
         let routineRepository = RoutineRepositoryImpl()
         let saveRoutineUseCase = SaveRoutineUseCase(repository: routineRepository)
         let deleteRoutineUseCase = DeleteRoutineUseCase(repository: routineRepository)
+        let updateRoutineUseCase = UpdateRoutineUseCase(repository: routineRepository)
         let reactor = EditRoutineViewReactor(with: routine,
                                              saveRoutineUseCase: saveRoutineUseCase,
-                                             deleteRoutineUseCase: deleteRoutineUseCase)
+                                             deleteRoutineUseCase: deleteRoutineUseCase,
+                                             updateRoutineUseCase: updateRoutineUseCase)
         let editRoutineVC = EditRoutineViewController(reactor: reactor)
         
         navigationController.pushViewController(editRoutineVC, animated: true)

--- a/HowManySet/Presentation/Feature/EditExcercise/Reactor/EditExcerciseViewReactor.swift
+++ b/HowManySet/Presentation/Feature/EditExcercise/Reactor/EditExcerciseViewReactor.swift
@@ -129,8 +129,12 @@ final class EditExcerciseViewReactor: Reactor {
                 if case .success = self.validationWorkout(workout: newWorkout) {
                     observer.onNext(.addExcercise(newWorkout))
                 }
-                self.alertRelay.accept(self.validationWorkout(workout: newWorkout))
                 observer.onCompleted()
+                
+                DispatchQueue.main.async {
+                    self.alertRelay.accept(self.validationWorkout(workout: newWorkout))
+                }
+                
                 return Disposables.create()
             }
             

--- a/HowManySet/Presentation/Feature/EditRoutine/EditRoutineTableView.swift
+++ b/HowManySet/Presentation/Feature/EditRoutine/EditRoutineTableView.swift
@@ -29,9 +29,10 @@ final class EditRoutineTableView: UITableView {
     override init(frame: CGRect, style: UITableView.Style) {
         super.init(frame: frame, style: style)
         delegate = self
-        dragInteractionEnabled = true
-        dragDelegate = self
-        dropDelegate = self
+        // TODO: 마이너 패치때 도입
+//        dragInteractionEnabled = true
+//        dragDelegate = self
+//        dropDelegate = self
         bind()
         backgroundColor = .background
     }

--- a/HowManySet/Presentation/Feature/EditRoutine/EditRoutineViewController.swift
+++ b/HowManySet/Presentation/Feature/EditRoutine/EditRoutineViewController.swift
@@ -61,6 +61,7 @@ final class EditRoutineViewController: UIViewController, View {
             .disposed(by: disposeBag)
         
         tableView.dragDropRelay
+            .distinctUntilChanged { $0.source == $1.source && $0.destination == $1.destination }
             .map{ Reactor.Action.reorderWorkout(source: $0, destination: $1) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
@@ -107,15 +108,15 @@ final class EditRoutineViewController: UIViewController, View {
     }
     
     func presentEditExerciseVC() {
-            let vc = EditExcerciseViewController(
-                reactor: EditExcerciseViewReactor(
-                    routineName: reactor?.currentState.routine.name ?? "알수없음",
-                    saveRoutineUseCase: SaveRoutineUseCase(repository: RoutineRepositoryImpl()),
-                    workoutStateForEdit: nil,
-                    caller: .forEditing)
-            )
-            self.present(vc, animated: true)
-        }
+        let vc = EditExcerciseViewController(
+            reactor: EditExcerciseViewReactor(
+                routineName: reactor?.currentState.routine.name ?? "알수없음",
+                saveRoutineUseCase: SaveRoutineUseCase(repository: RoutineRepositoryImpl()),
+                workoutStateForEdit: nil,
+                caller: .forEditing)
+        )
+        self.present(vc, animated: true)
+    }
 }
 
 // MARK: - UI 구성 관련 private 메서드

--- a/HowManySet/Presentation/Feature/EditRoutine/Reactor/EditRoutineViewReactor.swift
+++ b/HowManySet/Presentation/Feature/EditRoutine/Reactor/EditRoutineViewReactor.swift
@@ -13,6 +13,7 @@ final class EditRoutineViewReactor: Reactor {
     
     private let saveRoutineUseCase: SaveRoutineUseCase
     private let deleteRoutineUseCase: DeleteRoutineUseCase
+    private let updateRoutineUseCase: UpdateRoutineUseCase
     // Action is an user interaction
     enum Action {
         case viewDidLoad
@@ -32,7 +33,7 @@ final class EditRoutineViewReactor: Reactor {
         case removeSelectedWorkout
         case changeListOrder
         case plusExcerciseButtonTapped
-        case reorderRoutine(WorkoutRoutine)
+        case reorderRoutine(source: IndexPath, destination: IndexPath)
     }
     
     // State is a current view state
@@ -46,11 +47,13 @@ final class EditRoutineViewReactor: Reactor {
     
     init(with routine: WorkoutRoutine,
          saveRoutineUseCase: SaveRoutineUseCase,
-         deleteRoutineUseCase: DeleteRoutineUseCase
+         deleteRoutineUseCase: DeleteRoutineUseCase,
+         updateRoutineUseCase: UpdateRoutineUseCase
     ) {
         self.initialState = State(routine: routine)
         self.saveRoutineUseCase = saveRoutineUseCase
         self.deleteRoutineUseCase = deleteRoutineUseCase
+        self.updateRoutineUseCase = updateRoutineUseCase
     }
     
     // Action -> Mutation
@@ -69,10 +72,12 @@ final class EditRoutineViewReactor: Reactor {
         case .plusExcerciseButtonTapped:
             return .just(.plusExcerciseButtonTapped)
         case .reorderWorkout(source: let source, destination: let destination):
-            var new = currentState.routine
-            new.workouts.swapAt(source.item, destination.item)
-            deleteRoutineUseCase.execute(item: currentState.routine)
-            return .just(.reorderRoutine(new))
+            guard source != destination,
+                  source.row < currentState.routine.workouts.count,
+                  destination.row < currentState.routine.workouts.count
+            else { return .empty() }
+            return .just(.reorderRoutine(source: source, destination: destination))
+                .observe(on: MainScheduler.asyncInstance)
         }
     }
     
@@ -99,9 +104,17 @@ final class EditRoutineViewReactor: Reactor {
             break
         case .plusExcerciseButtonTapped:
             break
-        case .reorderRoutine(let routine):
-            var newRoutine = routine
-            saveRoutineUseCase.execute(item: routine)
+        case .reorderRoutine(let source, let destination):
+            break
+            // TODO: 마이너 패치로 들어감
+//            var newRoutine = state.routine
+//            var sourceItem = newRoutine.workouts[source.row]
+//            var destinationItem = newRoutine.workouts[destination.row]
+//            
+//            newRoutine.workouts[source.row] = destinationItem
+//            newRoutine.workouts[destination.row] = sourceItem
+//            updateRoutineUseCase.execute(item: newRoutine)
+//            newState.routine = newRoutine
         }
         return newState
     }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  closed: #131 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- 드래그 앤 드롭 기능 제거 (마이너 패치때 도입)
- 순서변경 기능은 MVP때 없을 예정
- DropDelegate의 `performDropWith` 메서드가 실행되지 않는 현상 (공식문서의 코드도 실행안됨, 이유를 알 수 없음)
- 이를 EditMode로 전환하여 순서 변경 후 반영되는 기능으로 변경할 예정 (공수가 많이 들어서 마이너로 이전)
