### PR TITLE
마이페이지 셀 클릭 후 재접속마다 해당 Alert 뜨는 오류 개선

### DIFF
--- a/HowManySet/Presentation/Feature/MyPage/Reactor/MyPageViewReactor.swift
+++ b/HowManySet/Presentation/Feature/MyPage/Reactor/MyPageViewReactor.swift
@@ -35,7 +35,7 @@ final class MyPageViewReactor: Reactor {
     /// 상태 변화를 나타내는 Mutation (내부 상태 조작용)
     enum Mutation {
         /// 특정 셀 타입에 대한 화면 전환 지시
-        case presentTo(MyPageCellType)
+        case presentTo(MyPageCellType?)
         /// 로그아웃 성공
         case logoutSuccess
         /// 계정 삭제 성공
@@ -79,8 +79,11 @@ final class MyPageViewReactor: Reactor {
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case .cellTapped(let cell):
-            return .just(.presentTo(cell))
-            
+            return Observable.concat([
+                .just(.presentTo(cell)),
+                .just(.presentTo(nil)) // nil로 초기화(자동 재방출 방지)
+            ])
+
         case .loadUserName:
             // 🟢 Firestore에서 사용자 정보 fetch
             return fetchUserNameFromFirestore()


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  closed: #143 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- 뷰가 나타낼때마다 재구독 방지를 위해 nil 처리
- `MyPageViewController`의 `bind()` 내에서 `presentTarget` 값이 존재할 경우 `handleCellTapped()`을 호출하고 있음
- 이 값이 nil로 reset되지 않으면, 뷰가 다시 나타날 때 재구독이 일어나면서 이전 값이 다시 방출되어 Alert가 재실행되는 문제가 발생함
- 따라서 자동 재방출을 막기 위해 `MyPageViewReactor`에서 `.setPresentTarget(nil)`하여 실행 후 반드시 초기화하는 과정을 추가

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 알림 설정 | <img src = "https://github.com/user-attachments/assets/b15e80d8-8ffa-47f6-80f9-be0b4d8c73dd" width ="250"> |
| 언어 변경 | <img src = "https://github.com/user-attachments/assets/a976c714-c8dc-40a8-887a-707fde300139" width ="250"> |
| 버전 정보 | <img src = "https://github.com/user-attachments/assets/f4a471bc-ff2f-4f19-a822-4ac6ec954ae7" width ="250"> |
| 문제 제보하기 | <img src = "https://github.com/user-attachments/assets/93615dce-8445-4858-83da-884b0c4027f2" width ="250"> |
| 로그아웃 | <img src = "https://github.com/user-attachments/assets/297a0c36-b5fe-4a4f-8545-d70af8d68058" width ="250"> |
| 계정 삭제 | <img src = "https://github.com/user-attachments/assets/a0ce4ccb-9b42-4439-b54f-98e7029aeaff" width ="250"> |


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 개인정보 처리 방침은 이메일이 필요하던데 공용 이메일 하나 만들어야할 것 같습니다!