### PR TITLE
EditAndMemoViewController화면 textView UI 수정

### DIFF
--- a/HowManySet/Presentation/Feature/Home/EditAndMemoViewController.swift
+++ b/HowManySet/Presentation/Feature/Home/EditAndMemoViewController.swift
@@ -54,6 +54,11 @@ final class EditAndMemoViewController: UIViewController, View {
         $0.font = .systemFont(ofSize: 16)
         $0.layer.cornerRadius = 12
         $0.textContainerInset = UIEdgeInsets(top: 12, left: 12, bottom: 12, right: 12)
+
+        // 키보드 관련
+        $0.autocorrectionType = .no // 자동 수정 끔
+        $0.spellCheckingType = .no // 맞춤법 검사 끔
+        $0.smartInsertDeleteType = .no // 스마트 삽입/삭제 끔
     }
     
     

--- a/HowManySet/Presentation/Feature/Home/EditAndMemoViewController.swift
+++ b/HowManySet/Presentation/Feature/Home/EditAndMemoViewController.swift
@@ -49,7 +49,8 @@ final class EditAndMemoViewController: UIViewController, View {
     
     lazy var memoTextView = UITextView().then {
         $0.backgroundColor = .bsInputFieldBG
-        $0.textColor = .lightGray
+        $0.text = memoPlaceHolderText
+        $0.textColor = .grey3
         $0.font = .systemFont(ofSize: 16)
         $0.layer.cornerRadius = 12
         $0.textContainerInset = UIEdgeInsets(top: 12, left: 12, bottom: 12, right: 12)
@@ -76,6 +77,7 @@ final class EditAndMemoViewController: UIViewController, View {
         bindUIEvents()
         
         memoTextView.delegate = self
+        applyInitialMemoPlaceholderIfNeeded()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -142,27 +144,37 @@ private extension EditAndMemoViewController {
 extension EditAndMemoViewController: UITextViewDelegate {
     
     func textViewDidBeginEditing(_ textView: UITextView) {
-        if textView.textColor == .placeholderText {
+        if textView.text == memoPlaceHolderText {
+            textView.text = nil
             textView.textColor = .white
-        } else {
-            return
         }
+        textView.layer.borderColor = UIColor.grey4.cgColor
+        textView.layer.borderWidth = 1
     }
     
     func textViewDidEndEditing(_ textView: UITextView) {
-        if textView.text.isEmpty {
+        if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             textView.text = memoPlaceHolderText
-            textView.textColor = .lightGray
+            textView.textColor = .grey3
         } else {
             let text = textView.text
             textView.textColor = .white
             print("📋 입력된 메모: \(String(describing: text))")
         }
+        textView.layer.borderWidth = 0
     }
 }
 
 extension EditAndMemoViewController {
-    
+    /// placeholder 상태 강제 적용 메서드
+    private func applyInitialMemoPlaceholderIfNeeded() {
+        let text = memoTextView.text ?? ""
+        if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || text == memoPlaceHolderText {
+            memoTextView.text = memoPlaceHolderText
+            memoTextView.textColor = .grey3
+        }
+    }
+
     func bind(reactor: HomeViewReactor) {
         
         reactor.state.map { $0.currentExerciseIndex }
@@ -170,7 +182,14 @@ extension EditAndMemoViewController {
             .bind { [weak self] index in
                 guard let self else { return }
                 let memoText = reactor.currentState.workoutCardStates[index].memoInExercise
-                self.memoTextView.text = memoText
+
+                if memoText?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true {
+                    self.memoTextView.text = self.memoPlaceHolderText
+                    self.memoTextView.textColor = .grey3
+                } else {
+                    self.memoTextView.text = memoText
+                    self.memoTextView.textColor = .white
+                }
             }
             .disposed(by: disposeBag)
     }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  closed: #157 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- textView에 커서가 있으면 borderLine on, 커서 없으면 off
- placeholder일 때, 색상 회색에 placeholder 역할 수행
- 키보드 설정 추가

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/aef93f2a-2e56-4e2f-afc0-94b8c08f433d" width ="250"> |


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 로직은 건들이지 않았는데, 운동마다 따로 저장되지 않는듯하여 로직 수정 필요
- 처음 시뮬 실행하면 textView에 무조건 "폼 집중하기"가 뜨고 있음 -> 수정 필요