### PR TITLE
refactor: #166 - 운동 삭제 시 루틴 삭제 및 저장 했던 로직을 운동만 삭제하도록 변경

### DIFF
--- a/HowManySet/App/DIContainer.swift
+++ b/HowManySet/App/DIContainer.swift
@@ -121,16 +121,17 @@ final class DIContainer {
     func makeEditRoutineViewController(coordinator: EditRoutineCoordinator, with routine: WorkoutRoutine, caller: ViewCaller) -> UIViewController {
         
         let routineRepository = RoutineRepositoryImpl()
+        let workoutRepository = WorkoutRepositoryImpl()
         let saveRoutineUseCase = SaveRoutineUseCase(repository: routineRepository)
         let deleteRoutineUseCase = DeleteRoutineUseCase(repository: routineRepository)
         let updateRoutineUseCase = UpdateRoutineUseCase(repository: routineRepository)
-        let fetchRoutineUseCase = FetchRoutineUseCase(repository: routineRepository)
+        let deleteWorkoutUseCase = DeleteWorkoutUseCase(repository: workoutRepository)
         let editRoutineViewReactor = EditRoutineViewReactor(
             with: routine,
             saveRoutineUseCase: saveRoutineUseCase,
             deleteRoutineUseCase: deleteRoutineUseCase,
             updateRoutineUseCase: updateRoutineUseCase,
-            fetchRoutineUseCase: fetchRoutineUseCase
+            deleteWorkoutUseCase: deleteWorkoutUseCase
         )
         
         return EditRoutineViewController(reactor: editRoutineViewReactor, coordinator: coordinator, caller: caller)

--- a/HowManySet/Presentation/Feature/EditRoutine/Reactor/EditRoutineViewReactor.swift
+++ b/HowManySet/Presentation/Feature/EditRoutine/Reactor/EditRoutineViewReactor.swift
@@ -14,7 +14,7 @@ final class EditRoutineViewReactor: Reactor {
     private let saveRoutineUseCase: SaveRoutineUseCase
     private let deleteRoutineUseCase: DeleteRoutineUseCase
     private let updateRoutineUseCase: UpdateRoutineUseCase
-    private let fetchRoutineUseCase: FetchRoutineUseCase
+    private let deleteWorkoutUseCase: DeleteWorkoutUseCase
     
     private let disposeBag = DisposeBag()
     // Action is an user interaction
@@ -52,13 +52,13 @@ final class EditRoutineViewReactor: Reactor {
          saveRoutineUseCase: SaveRoutineUseCase,
          deleteRoutineUseCase: DeleteRoutineUseCase,
          updateRoutineUseCase: UpdateRoutineUseCase,
-         fetchRoutineUseCase: FetchRoutineUseCase
+         deleteWorkoutUseCase: DeleteWorkoutUseCase
     ) {
         self.initialState = State(routine: routine)
         self.saveRoutineUseCase = saveRoutineUseCase
         self.deleteRoutineUseCase = deleteRoutineUseCase
         self.updateRoutineUseCase = updateRoutineUseCase
-        self.fetchRoutineUseCase = fetchRoutineUseCase
+        self.deleteWorkoutUseCase = deleteWorkoutUseCase
     }
     
     // Action -> Mutation
@@ -106,10 +106,9 @@ final class EditRoutineViewReactor: Reactor {
         case .removeSelectedWorkout:
             var newRoutine = newState.routine
             guard let workout = currentState.currentSeclectedWorkout else { return newState }
-            deleteRoutineUseCase.execute(item: currentState.routine)
+            deleteWorkoutUseCase.execute(item: workout)
             guard let indexPath = currentState.currentSeclectedIndexPath else { return newState }
             newRoutine.workouts.remove(at: indexPath.row)
-            saveRoutineUseCase.execute(item: newRoutine)
             newState.routine = newRoutine
         case .changeListOrder:
             break


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  Closed: #166 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- 기존에 UpdateWorkoutUseCase, DeleteWorkoutUseCase가 구현되지 않았을 때 루틴 삭제 및 새로변경된 루틴 저장 로직을 사용했었음
- 위 로직때문에 같은 primaryKey를 갖는 데이터를 중복저장하여 앱 크래시 발생
- DeleteWorkoutUseCase를 가져와 운동만 삭제하도록 수정
