### PR TITLE
운동 루틴 페이지 메모칸 UI 업데이트

### DIFF
--- a/HowManySet/Presentation/Feature/RoutineComplete/RoutineCompleteViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineComplete/RoutineCompleteViewController.swift
@@ -132,7 +132,9 @@ final class RoutineCompleteViewController: UIViewController, View {
     }
     
     private lazy var memoTextView = UITextView().then {
-        $0.backgroundColor = .black
+        $0.backgroundColor = .grey8
+        $0.text = memoPlaceHolderText
+        $0.textColor = .grey3
         $0.font = .systemFont(ofSize: 16, weight: .regular)
         $0.layer.cornerRadius = 12
         $0.textContainerInset = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
@@ -306,16 +308,19 @@ extension RoutineCompleteViewController: UITextViewDelegate {
     
     func textViewDidBeginEditing(_ textView: UITextView) {
         if textView.text == memoPlaceHolderText {
-            textView.text = ""
+            textView.text = nil
             textView.textColor = .white
         }
+        textView.layer.borderColor = UIColor.grey3.cgColor
+        textView.layer.borderWidth = 1
     }
     
     func textViewDidEndEditing(_ textView: UITextView) {
-        if textView.text.isEmpty {
+        if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             textView.text = memoPlaceHolderText
-            textView.textColor = .placeholderText
+            textView.textColor = .grey3
         }
+        textView.layer.borderWidth = 0
     }
 }
 
@@ -337,6 +342,14 @@ private extension RoutineCompleteViewController {
         exerciseTimeLabel.text = totalTime
         exerciseAndSetInfoLabel.text = "\(exerciseDidCount)개 운동, \(setDidCount)세트"
         memoTextView.text = routineMemo
+
+        // placeholder 적용 조건 판단
+        if memoTextView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            memoTextView.text = memoPlaceHolderText
+            memoTextView.textColor = .grey3
+        } else {
+            memoTextView.textColor = .white
+        }
     }
 }
 

--- a/HowManySet/Presentation/Feature/RoutineComplete/RoutineCompleteViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineComplete/RoutineCompleteViewController.swift
@@ -136,6 +136,11 @@ final class RoutineCompleteViewController: UIViewController, View {
         $0.font = .systemFont(ofSize: 16, weight: .regular)
         $0.layer.cornerRadius = 12
         $0.textContainerInset = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+
+        // 키보드 관련
+        $0.autocorrectionType = .no // 자동 수정 끔
+        $0.spellCheckingType = .no // 맞춤법 검사 끔
+        $0.smartInsertDeleteType = .no // 스마트 삽입/삭제 끔
     }
     
     private lazy var confirmButton = UIButton().then {


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  closed: #144 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- 루티 완료 페이지 메모칸 placeholder 설정
- 메모칸에 커서가 올라가 있으면 borderLine on / 커서가 없으면 borderLine off

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/8ff54919-db1f-4631-82ce-2982fc6bfb1d" width ="250"> |


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 운동 save관련 로직은 근호님 브랜치에서 수정되어서 UI만 업데이트 함
