### PR TITLE
온보딩 리팩토링

### DIFF
--- a/HowManySet/App/Coordinator/AppCoordinator.swift
+++ b/HowManySet/App/Coordinator/AppCoordinator.swift
@@ -11,7 +11,6 @@ import RxSwift
 
 /// 앱의 전체 흐름을 관리하는 Coordinator
 /// - 로그인 여부, 온보딩 여부를 체크하고 적절한 흐름으로 분기
-/// - 출시 수준의 완전한 플로우 구현
 final class AppCoordinator: Coordinator {
     
     /// 앱의 최상위 UIWindow

--- a/HowManySet/App/Coordinator/OnBoardingCoordinator.swift
+++ b/HowManySet/App/Coordinator/OnBoardingCoordinator.swift
@@ -29,6 +29,9 @@ final class OnBoardingCoordinator: OnBoardingCoordinatorProtocol {
     
     /// RxSwift DisposeBag
     private let disposeBag = DisposeBag()
+    
+    /// 완료 처리 중 플래그 (중복 호출 방지)
+    private var isCompleting = false
 
     /// 생성자 - 의존성 주입 및 윈도우 연결
     init(navigationController: UINavigationController, container: DIContainer) {
@@ -39,7 +42,7 @@ final class OnBoardingCoordinator: OnBoardingCoordinatorProtocol {
     /// 온보딩 흐름 시작
     func start() {
         let onboardingVC = container.makeOnBoardingViewController(coordinator: self)
-        navigationController.pushViewController(onboardingVC, animated: true)
+        navigationController.pushViewController(onboardingVC, animated: false)
     }
 
     /// 닉네임 설정 완료 시 호출
@@ -70,6 +73,12 @@ final class OnBoardingCoordinator: OnBoardingCoordinatorProtocol {
 
     /// 온보딩 완료 시 호출
     func completeOnBoarding() {
+        // 중복 호출 방지
+        guard !isCompleting else { return }
+        isCompleting = true
+        
+        print("🟢 OnBoardingCoordinator: 온보딩 완료 처리 시작")
+        
         let firebaseAuthService = FirebaseAuthService()
         let authRepository = AuthRepositoryImpl(firebaseAuthService: firebaseAuthService)
         let authUseCase = AuthUseCase(repository: authRepository)
@@ -81,7 +90,9 @@ final class OnBoardingCoordinator: OnBoardingCoordinatorProtocol {
                     // 사용자가 없으면 로컬 저장만 하고 완료
                     print("🟡 OnBoardingCoordinator: 현재 사용자가 없음 - 로컬 저장만 진행")
                     UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
-                    self?.finishFlow?()
+                    DispatchQueue.main.async {
+                        self?.finishFlow?()
+                    }
                     return Observable.empty()
                 }
                 return authUseCase.completeOnboarding(uid: user.uid)

--- a/HowManySet/App/DIContainer.swift
+++ b/HowManySet/App/DIContainer.swift
@@ -9,12 +9,14 @@ import UIKit
 import FirebaseFirestore
 
 /// 의존성 주입 컨테이너
-/// - 출시 수준의 완전한 DI 구현
 final class DIContainer {
     
     /// 온보딩 화면을 생성하여 반환 (닉네임 입력 + 온보딩 통합)
     func makeOnBoardingViewController(coordinator: OnBoardingCoordinatorProtocol) -> UIViewController {
-        let reactor = OnBoardingViewReactor()
+        let firebaseAuthService = FirebaseAuthService()
+        let repository = AuthRepositoryImpl(firebaseAuthService: firebaseAuthService)
+        let authUseCase = AuthUseCase(repository: repository)
+        let reactor = OnBoardingViewReactor(authUseCase: authUseCase, coordinator: coordinator)
         return OnBoardingViewController(reactor: reactor, coordinator: coordinator)
     }
     

--- a/HowManySet/Data/Firebase/Repositories/AuthRepositoryImpl.swift
+++ b/HowManySet/Data/Firebase/Repositories/AuthRepositoryImpl.swift
@@ -16,9 +16,8 @@ import KakaoSDKUser
 
 /// 인증 관련 데이터 처리를 담당하는 Repository 구현체
 ///
-/// Firebase Auth와 각종 소셜 로그인을 통합하여 처리하며,
-/// 출시 수준의 완전한 로그인 플로우를 구현합니다.
-/// 로그아웃 후 재로그인 문제를 해결하여 온보딩 상태를 올바르게 유지합니다.
+/// Firebase Auth와 각종 소셜 로그인을 통합하여 처리
+/// 로그아웃 후 재로그인 문제를 해결하여 온보딩 상태를 올바르게 유지
 public final class AuthRepositoryImpl: AuthRepositoryProtocol {
     
     private let firebaseAuthService: FirebaseAuthServiceProtocol

--- a/HowManySet/Domain/UseCase/Auth/AuthUseCase.swift
+++ b/HowManySet/Domain/UseCase/Auth/AuthUseCase.swift
@@ -8,30 +8,28 @@
 import RxSwift
 import Foundation
 
-/// 인증 관련 비즈니스 로직을 처리하는 UseCase 구현체
+/// 인증 관련 비즈니스 로직을 담당하는 UseCase
 ///
-/// Repository를 통해 데이터를 처리하고 비즈니스 규칙을 적용하며,
-/// Clean Architecture 원칙에 따라 Firebase에 직접 접근하지 않습니다.
-/// Firestore 기반 닉네임 관리와 익명 사용자 로컬 저장, 완전한 계정 삭제를 지원합니다.
+/// 다양한 소셜 로그인 제공자를 지원하며, 사용자 인증과 온보딩 프로세스의
+/// 비즈니스 규칙을 구현합니다. Repository 계층과 Presentation 계층 사이의
+/// 중간 역할을 담당합니다.
 public final class AuthUseCase: AuthUseCaseProtocol {
-    /// 인증 데이터 처리를 담당하는 Repository
     private let repository: AuthRepositoryProtocol
-
-    /// AuthUseCase 인스턴스를 생성합니다
-    /// - Parameter repository: 인증 데이터 처리를 담당하는 Repository 구현체
+    
+    /// AuthUseCase 초기화
+    ///
+    /// - Parameter repository: 인증 관련 데이터 처리를 위한 Repository
     public init(repository: AuthRepositoryProtocol) {
         self.repository = repository
     }
-
+    
     /// 카카오 계정으로 로그인을 수행합니다
     ///
-    /// 로그인 성공 시 UserDefaults에 백업 데이터를 저장하며,
-    /// 기존 온보딩 상태를 유지합니다.
+    /// 로그인 성공 시 UserDefaults에 사용자 정보를 저장합니다.
     /// - Returns: 로그인된 사용자 정보를 방출하는 Observable
     public func loginWithKakao() -> Observable<User> {
         return repository.signInWithKakao()
             .do(onNext: { user in
-                print("🟢 카카오 로그인 성공: \(user.name) (\(user.uid))")
                 UserDefaults.standard.set(user.name, forKey: "userNickname")
                 UserDefaults.standard.set("kakao", forKey: "userProvider")
                 UserDefaults.standard.set(user.uid, forKey: "userUID")
@@ -40,20 +38,15 @@ public final class AuthUseCase: AuthUseCaseProtocol {
                 }
                 UserDefaults.standard.synchronize()
             })
-            .do(onError: { error in
-                print("🔴 카카오 로그인 실패: \(error)")
-            })
     }
-
+    
     /// 구글 계정으로 로그인을 수행합니다
     ///
-    /// 로그인 성공 시 UserDefaults에 백업 데이터를 저장하며,
-    /// 기존 온보딩 상태를 유지합니다.
+    /// 로그인 성공 시 UserDefaults에 사용자 정보를 저장합니다.
     /// - Returns: 로그인된 사용자 정보를 방출하는 Observable
     public func loginWithGoogle() -> Observable<User> {
         return repository.signInWithGoogle()
             .do(onNext: { user in
-                print("🟢 구글 로그인 성공: \(user.name) (\(user.uid))")
                 UserDefaults.standard.set(user.name, forKey: "userNickname")
                 UserDefaults.standard.set("google", forKey: "userProvider")
                 UserDefaults.standard.set(user.uid, forKey: "userUID")
@@ -62,15 +55,11 @@ public final class AuthUseCase: AuthUseCaseProtocol {
                 }
                 UserDefaults.standard.synchronize()
             })
-            .do(onError: { error in
-                print("🔴 구글 로그인 실패: \(error)")
-            })
     }
-
+    
     /// Apple ID로 로그인을 수행합니다
     ///
-    /// 로그인 성공 시 UserDefaults에 백업 데이터를 저장하며,
-    /// 기존 온보딩 상태를 유지합니다.
+    /// 로그인 성공 시 UserDefaults에 사용자 정보를 저장합니다.
     /// - Parameters:
     ///   - token: Apple ID 토큰
     ///   - nonce: 보안을 위한 nonce 값
@@ -78,7 +67,6 @@ public final class AuthUseCase: AuthUseCaseProtocol {
     public func loginWithApple(token: String, nonce: String) -> Observable<User> {
         return repository.signInWithApple(token: token, nonce: nonce)
             .do(onNext: { user in
-                print("🟢 Apple 로그인 성공: \(user.name) (\(user.uid))")
                 UserDefaults.standard.set(user.name, forKey: "userNickname")
                 UserDefaults.standard.set("apple", forKey: "userProvider")
                 UserDefaults.standard.set(user.uid, forKey: "userUID")
@@ -87,11 +75,8 @@ public final class AuthUseCase: AuthUseCaseProtocol {
                 }
                 UserDefaults.standard.synchronize()
             })
-            .do(onError: { error in
-                print("🔴 Apple 로그인 실패: \(error)")
-            })
     }
-
+    
     /// 익명 로그인을 수행합니다
     ///
     /// 익명 사용자의 경우 모든 데이터를 로컬(UserDefaults)에만 저장합니다.
@@ -99,26 +84,20 @@ public final class AuthUseCase: AuthUseCaseProtocol {
     public func loginAnonymously() -> Observable<User> {
         return repository.signInAnonymously()
             .do(onNext: { user in
-                print("🟢 익명 로그인 성공: \(user.name) (\(user.uid))")
                 UserDefaults.standard.set("비회원", forKey: "userNickname")
                 UserDefaults.standard.set("anonymous", forKey: "userProvider")
                 UserDefaults.standard.set(user.uid, forKey: "userUID")
                 UserDefaults.standard.synchronize()
             })
-            .do(onError: { error in
-                print("🔴 익명 로그인 실패: \(error)")
-            })
     }
     
     /// 현재 사용자를 로그아웃시킵니다
     ///
-    /// Firestore의 온보딩 상태는 유지하고 UserDefaults만 초기화합니다.
-    /// 재로그인 시 기존 온보딩 상태를 복원할 수 있습니다.
+    /// UserDefaults의 사용자 정보를 초기화합니다.
     /// - Returns: 로그아웃 완료를 알리는 Observable
     public func logout() -> Observable<Void> {
         return repository.signOut()
             .do(onNext: { _ in
-                print("🟢 로그아웃 성공 - Firestore 온보딩 상태는 유지됨")
                 UserDefaults.standard.removeObject(forKey: "hasCompletedOnboarding")
                 UserDefaults.standard.removeObject(forKey: "hasSkippedOnboarding")
                 UserDefaults.standard.removeObject(forKey: "userNickname")
@@ -127,20 +106,15 @@ public final class AuthUseCase: AuthUseCaseProtocol {
                 UserDefaults.standard.removeObject(forKey: "hasSetNickname")
                 UserDefaults.standard.synchronize()
             })
-            .do(onError: { error in
-                print("🔴 로그아웃 실패: \(error)")
-            })
     }
     
     /// 현재 사용자의 계정을 완전히 삭제합니다
     ///
-    /// 소셜 로그인 연결 해제, Firestore 데이터 삭제, 로컬 데이터 초기화를
-    /// 모두 수행합니다.
+    /// UserDefaults의 사용자 정보를 초기화합니다.
     /// - Returns: 계정 삭제 완료를 알리는 Observable
     public func deleteAccount() -> Observable<Void> {
         return repository.deleteAccount()
             .do(onNext: { _ in
-                print("🟢 계정 삭제 성공 - 모든 데이터 완전 초기화")
                 let keysToRemove = [
                     "hasCompletedOnboarding",
                     "hasSkippedOnboarding",
@@ -149,50 +123,35 @@ public final class AuthUseCase: AuthUseCaseProtocol {
                     "userUID",
                     "hasSetNickname"
                 ]
-                
                 for key in keysToRemove {
                     UserDefaults.standard.removeObject(forKey: key)
                 }
                 UserDefaults.standard.synchronize()
             })
-            .do(onError: { error in
-                print("🔴 계정 삭제 실패: \(error)")
-            })
     }
-
+    
     /// 사용자의 온보딩 상태를 조회합니다
     ///
-    /// 익명 사용자는 로컬 상태를, 일반 사용자는 Firestore 상태를 확인하여
-    /// 온보딩 필요 여부를 판단합니다.
+    /// 익명 사용자는 로컬 상태를, 일반 사용자는 Firestore 상태를 확인합니다.
     /// - Parameter uid: 사용자 고유 식별자
     /// - Returns: 사용자 온보딩 상태를 방출하는 Observable
     public func getUserStatus(uid: String) -> Observable<UserStatus> {
         let userProvider = UserDefaults.standard.string(forKey: "userProvider") ?? ""
-        
         if userProvider == "anonymous" {
             let hasCompletedOnboarding = UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
             let hasSetNickname = UserDefaults.standard.bool(forKey: "hasSetNickname")
-            
             if !hasSetNickname || !hasCompletedOnboarding {
-                print("🔴 익명 사용자 온보딩 미완료 - 로컬 확인")
                 return Observable.just(.needsOnboarding)
             } else {
-                print("🟢 익명 사용자 온보딩 완료 - 로컬 확인")
                 return Observable.just(.complete)
             }
         } else {
             return repository.fetchUserInfo(uid: uid)
                 .map { user in
-                    guard let user = user else {
-                        print("🔴 사용자 정보 없음 - 온보딩 필요")
-                        return .needsOnboarding
-                    }
-                    
+                    guard let user = user else { return .needsOnboarding }
                     if !user.hasSetNickname || !user.hasCompletedOnboarding {
-                        print("🔴 온보딩 미완료 - 닉네임: \(user.hasSetNickname), 온보딩: \(user.hasCompletedOnboarding)")
                         return .needsOnboarding
                     } else {
-                        print("🟢 온보딩 완료 - 메인 화면으로")
                         UserDefaults.standard.set(user.name, forKey: "userNickname")
                         UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
                         UserDefaults.standard.set(true, forKey: "hasSetNickname")
@@ -200,15 +159,9 @@ public final class AuthUseCase: AuthUseCaseProtocol {
                         return .complete
                     }
                 }
-                .do(onNext: { status in
-                    print("🔍 사용자 상태 조회 결과: \(status)")
-                })
-                .do(onError: { error in
-                    print("🔴 사용자 상태 조회 실패: \(error)")
-                })
         }
     }
-
+    
     /// 사용자의 닉네임 설정을 완료합니다
     ///
     /// 닉네임 유효성 검사를 수행하며, 익명 사용자는 로컬에,
@@ -219,18 +172,14 @@ public final class AuthUseCase: AuthUseCaseProtocol {
     /// - Returns: 닉네임 설정 완료를 알리는 Observable
     public func completeNicknameSetting(uid: String, nickname: String) -> Observable<Void> {
         guard isValidNickname(nickname) else {
-            return Observable.error(NSError(domain: "InvalidNickname", code: -1, userInfo: [NSLocalizedDescriptionKey: "유효하지 않은 닉네임입니다. (한글/영문 2~8자)"]))
+            return Observable.error(NSError(domain: "InvalidNickname", code: -1, userInfo: [NSLocalizedDescriptionKey: "유효하지 않은 닉네임입니다. (한글/영문/숫자 2~8자)"]))
         }
-        
         let userProvider = UserDefaults.standard.string(forKey: "userProvider") ?? ""
-        
         if userProvider == "anonymous" {
             return Observable.create { observer in
                 UserDefaults.standard.set(nickname, forKey: "userNickname")
                 UserDefaults.standard.set(true, forKey: "hasSetNickname")
                 UserDefaults.standard.synchronize()
-                
-                print("🟢 익명 사용자 닉네임 로컬 저장: \(nickname)")
                 observer.onNext(())
                 observer.onCompleted()
                 return Disposables.create()
@@ -238,17 +187,13 @@ public final class AuthUseCase: AuthUseCaseProtocol {
         } else {
             return repository.updateUserNickname(uid: uid, nickname: nickname)
                 .do(onNext: { _ in
-                    print("🟢 닉네임 Firestore 저장 완료: \(nickname)")
                     UserDefaults.standard.set(nickname, forKey: "userNickname")
                     UserDefaults.standard.set(true, forKey: "hasSetNickname")
                     UserDefaults.standard.synchronize()
                 })
-                .do(onError: { error in
-                    print("🔴 닉네임 Firestore 저장 실패: \(error)")
-                })
         }
     }
-
+    
     /// 사용자의 온보딩 프로세스를 완료합니다
     ///
     /// 익명 사용자는 로컬에, 일반 사용자는 Firestore에 완료 상태를 저장합니다.
@@ -256,13 +201,10 @@ public final class AuthUseCase: AuthUseCaseProtocol {
     /// - Returns: 온보딩 완료를 알리는 Observable
     public func completeOnboarding(uid: String) -> Observable<Void> {
         let userProvider = UserDefaults.standard.string(forKey: "userProvider") ?? ""
-        
         if userProvider == "anonymous" {
             return Observable.create { observer in
                 UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
                 UserDefaults.standard.synchronize()
-                
-                print("🟢 익명 사용자 온보딩 로컬 저장 완료")
                 observer.onNext(())
                 observer.onCompleted()
                 return Disposables.create()
@@ -270,16 +212,11 @@ public final class AuthUseCase: AuthUseCaseProtocol {
         } else {
             return repository.updateOnboardingStatus(uid: uid, completed: true)
                 .do(onNext: { _ in
-                    print("🟢 온보딩 Firestore 저장 완료")
                     UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
-                    UserDefaults.standard.synchronize()
-                })
-                .do(onError: { error in
-                    print("🔴 온보딩 Firestore 저장 실패: \(error)")
                 })
         }
     }
-
+    
     /// 사용자의 온보딩 상태를 초기화합니다
     ///
     /// 개발 및 테스트 목적으로 사용되며, 온보딩을 처음부터 다시 진행할 수 있도록 합니다.
@@ -287,15 +224,12 @@ public final class AuthUseCase: AuthUseCaseProtocol {
     /// - Returns: 온보딩 상태 초기화 완료를 알리는 Observable
     public func resetUserOnboardingStatus(uid: String) -> Observable<Void> {
         let userProvider = UserDefaults.standard.string(forKey: "userProvider") ?? ""
-        
         if userProvider == "anonymous" {
             return Observable.create { observer in
                 UserDefaults.standard.removeObject(forKey: "hasCompletedOnboarding")
                 UserDefaults.standard.removeObject(forKey: "hasSetNickname")
                 UserDefaults.standard.set("비회원", forKey: "userNickname")
                 UserDefaults.standard.synchronize()
-                
-                print("🟢 익명 사용자 온보딩 상태 로컬 초기화 완료")
                 observer.onNext(())
                 observer.onCompleted()
                 return Disposables.create()
@@ -303,26 +237,55 @@ public final class AuthUseCase: AuthUseCaseProtocol {
         } else {
             return repository.resetUserOnboardingStatus(uid: uid)
                 .do(onNext: { _ in
-                    print("🟢 사용자 온보딩 상태 초기화 완료")
                     UserDefaults.standard.removeObject(forKey: "hasCompletedOnboarding")
                     UserDefaults.standard.removeObject(forKey: "hasSkippedOnboarding")
                     UserDefaults.standard.removeObject(forKey: "hasSetNickname")
                     UserDefaults.standard.synchronize()
                 })
-                .do(onError: { error in
-                    print("🔴 온보딩 상태 초기화 실패: \(error)")
-                })
         }
     }
-
-    /// 닉네임의 유효성을 검사합니다
+    
+    /// 닉네임 유효성 검사
     ///
-    /// 한글, 영문, 숫자 조합으로 2~8자 길이의 닉네임만 허용합니다.
+    /// 한글, 영문, 숫자 2~8자만 허용합니다.
     /// - Parameter nickname: 검사할 닉네임
-    /// - Returns: 유효한 닉네임이면 true, 그렇지 않으면 false
+    /// - Returns: 유효한 닉네임이면 true, 아니면 false
     private func isValidNickname(_ nickname: String) -> Bool {
         let trimmed = nickname.trimmingCharacters(in: .whitespacesAndNewlines)
         let regex = "^[가-힣a-zA-Z0-9]{2,8}$"
         return NSPredicate(format: "SELF MATCHES %@", regex).evaluate(with: trimmed)
+    }
+    
+    /// 닉네임 유효성 검사 결과를 Observable로 반환합니다
+    ///
+    /// - Parameter nickname: 검사할 닉네임
+    /// - Returns: 유효성 결과를 방출하는 Observable
+    public func checkNicknameValid(_ nickname: String) -> Observable<Bool> {
+        return Observable.just(isValidNickname(nickname))
+    }
+    
+    /// 온보딩 프로세스를 완료합니다 (uid 없이 내부에서 처리)
+    ///
+    /// 현재 로그인된 사용자의 uid를 내부적으로 관리하여,
+    /// Presentation 계층에서는 uid를 직접 전달하지 않습니다.
+    /// - Returns: 온보딩 완료를 알리는 Observable
+    public func completeOnboarding() -> Observable<Void> {
+        guard let uid = UserDefaults.standard.string(forKey: "userUID") else {
+            return Observable.error(NSError(domain: "NoUser", code: -1))
+        }
+        return completeOnboarding(uid: uid)
+    }
+    
+    /// 닉네임 설정을 완료합니다 (uid 없이 내부에서 처리)
+    ///
+    /// 현재 로그인된 사용자의 uid를 내부적으로 관리하여,
+    /// Presentation 계층에서는 uid를 직접 전달하지 않습니다.
+    /// - Parameter nickname: 설정할 닉네임
+    /// - Returns: 닉네임 설정 완료를 알리는 Observable
+    public func completeNicknameSetting(nickname: String) -> Observable<Void> {
+        guard let uid = UserDefaults.standard.string(forKey: "userUID") else {
+            return Observable.error(NSError(domain: "NoUser", code: -1))
+        }
+        return completeNicknameSetting(uid: uid, nickname: nickname)
     }
 }

--- a/HowManySet/Domain/UseCase/Protocols/Auth/AuthUseCaseProtocol.swift
+++ b/HowManySet/Domain/UseCase/Protocols/Auth/AuthUseCaseProtocol.swift
@@ -13,7 +13,6 @@ import RxSwift
 /// 비즈니스 규칙을 추상화합니다. Repository 계층과 Presentation 계층 사이의
 /// 중간 역할을 담당합니다.
 public protocol AuthUseCaseProtocol {
-    
     /// 카카오 계정으로 로그인을 수행합니다
     ///
     /// 로그인 성공 시 UserDefaults에 백업 데이터를 저장하며,
@@ -21,7 +20,7 @@ public protocol AuthUseCaseProtocol {
     /// - Returns: 로그인된 사용자 정보를 방출하는 Observable
     func loginWithKakao() -> Observable<User>
     
-    /// 구글 계정으로 로그인을 수행합니다
+    /// 구글 계정로 로그인을 수행합니다
     ///
     /// 로그인 성공 시 UserDefaults에 백업 데이터를 저장하며,
     /// 기존 온보딩 상태를 유지합니다.
@@ -89,4 +88,25 @@ public protocol AuthUseCaseProtocol {
     /// - Parameter uid: 사용자 고유 식별자
     /// - Returns: 온보딩 상태 초기화 완료를 알리는 Observable
     func resetUserOnboardingStatus(uid: String) -> Observable<Void>
+    
+    /// 닉네임 유효성 검사
+    ///
+    /// - Parameter nickname: 검사할 닉네임
+    /// - Returns: 유효성 결과를 방출하는 Observable
+    func checkNicknameValid(_ nickname: String) -> Observable<Bool>
+    
+    /// 온보딩 프로세스를 완료합니다 (uid 없이 내부에서 처리)
+    ///
+    /// 현재 로그인된 사용자의 uid를 내부적으로 관리하여,
+    /// Presentation 계층에서는 uid를 직접 전달하지 않습니다.
+    /// - Returns: 온보딩 완료를 알리는 Observable
+    func completeOnboarding() -> Observable<Void>
+    
+    /// 닉네임 설정을 완료합니다 (uid 없이 내부에서 처리)
+    ///
+    /// 현재 로그인된 사용자의 uid를 내부적으로 관리하여,
+    /// Presentation 계층에서는 uid를 직접 전달하지 않습니다.
+    /// - Parameter nickname: 설정할 닉네임
+    /// - Returns: 닉네임 설정 완료를 알리는 Observable
+    func completeNicknameSetting(nickname: String) -> Observable<Void>
 }

--- a/HowManySet/Presentation/Feature/OnBoarding/OnBoardingViewController.swift
+++ b/HowManySet/Presentation/Feature/OnBoarding/OnBoardingViewController.swift
@@ -9,239 +9,129 @@ import UIKit
 import ReactorKit
 import RxSwift
 import RxCocoa
+import SnapKit
 
-final class OnBoardingViewController: UIViewController {
-    // MARK: - Properties
-
-    /// 온보딩 플로우 종료 및 화면 전환을 담당하는 Coordinator. 약한 참조로 메모리 누수 방지.
+final class OnBoardingViewController: UIViewController, View {
+    
+    var disposeBag = DisposeBag()
+    var reactor: OnBoardingViewReactor!
     private weak var coordinator: OnBoardingCoordinatorProtocol?
-    
-    /// ReactorKit 기반 상태 관리 객체. 온보딩 화면의 상태와 액션을 처리.
-    private var reactor: OnBoardingViewReactor
-    
-    /// 온보딩 안내 페이지(타이틀, 이미지, 인디케이터, 버튼 등)를 포함하는 뷰.
+
     private let onboardingView = OnboardingView()
-    
-    /// 닉네임 입력 및 "다음" 버튼을 포함하는 뷰.
     private let nicknameInputView = NicknameInputView()
-    
-    /// RxSwift DisposeBag. 바인딩 해제 및 메모리 관리에 사용.
-    private var disposeBag = DisposeBag()
-    
-    /// OnBoardingViewController 생성자. Reactor와 Coordinator를 주입받아 초기화.
-    /// - Parameters:
-    ///   - reactor: 온보딩 상태 및 액션 관리를 위한 ReactorKit 객체
-    ///   - coordinator: 온보딩 플로우 종료 시 호출할 Coordinator
+
     init(reactor: OnBoardingViewReactor, coordinator: OnBoardingCoordinatorProtocol) {
         self.reactor = reactor
         self.coordinator = coordinator
         super.init(nibName: nil, bundle: nil)
     }
-    
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     deinit {
         NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
     }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    // MARK: - LifeCycle
-    
-    /// 뷰 로드 후 UI 세팅 및 닉네임 유효성 바인딩.
-    /// 온보딩/닉네임 입력 뷰의 초기 표시 상태를 설정.
+
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
-        bindNicknameValidation()
-        onboardingView.isHidden = true
-        nicknameInputView.isHidden = false
-        
-        bindUIEvents()
-        setupKeyboardObserver()
+        onboardingView.pageIndicator.numberOfPages = OnBoardingViewReactor.onboardingPages.count
+        bind(reactor: reactor)
     }
-}
 
-private extension OnBoardingViewController {
-    /// 전체 UI Appearance, 계층, 제약조건, 액션, 델리게이트 설정을 일괄 처리.
-    func setupUI() {
-        setAppearance()
-        setActions()
-        setViewHierarchy()
-        setConstraints()
-    }
-    
-    /// 배경색 및 온보딩 페이지 인디케이터의 페이지 수 등 Appearance 관련 설정.
-    func setAppearance() {
+    private func setupUI() {
         view.backgroundColor = .background
         navigationController?.setNavigationBarHidden(true, animated: false)
-        onboardingView.pageIndicator.numberOfPages = onboardingPages.count
-    }
-    
-    /// 각 버튼의 액션(Target) 연결. 닉네임 "다음", 온보딩 "다음/시작하기", 닫기(X) 버튼 등.
-    func setActions() {
-        nicknameInputView.nextButton.addTarget(self, action: #selector(nicknameInputViewNextButtonAction), for: .touchUpInside)
-        onboardingView.nextButton.addTarget(self, action: #selector(onboardingViewNextButtonAction), for: .touchUpInside)
-        onboardingView.closeButton.addTarget(self, action: #selector(onboardingViewCloseButtonAction), for: .touchUpInside)
-    }
-    
-    /// 닉네임 입력 뷰와 온보딩 뷰를 뷰 계층에 추가.
-    func setViewHierarchy() {
-        view.addSubviews(nicknameInputView, onboardingView)
-    }
-    
-    /// SnapKit을 활용한 온보딩/닉네임 입력 뷰의 오토레이아웃 제약조건 설정.
-    func setConstraints() {
-        onboardingView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
-        }
-        nicknameInputView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
-        }
-    }
-}
+        
+        view.addSubviews(onboardingView, nicknameInputView)
+        onboardingView.snp.makeConstraints { $0.edges.equalToSuperview() }
+        nicknameInputView.snp.makeConstraints { $0.edges.equalToSuperview() }
+        
+        onboardingView.isHidden = true
+        nicknameInputView.isHidden = false
 
-private extension OnBoardingViewController {
-    /// 닉네임 입력 "다음" 버튼 클릭 시 온보딩 페이지로 전환. 첫 페이지로 초기화.
-    @objc func nicknameInputViewNextButtonAction() {
-        guard let nickname = nicknameInputView.nicknameTextField.text,
-              !nickname.isEmpty else {
-            return
-        }
-        
-        // 닉네임 설정 완료 처리
-        coordinator?.completeNicknameSetting(nickname: nickname)
-        
-        // 온보딩 화면으로 전환
-        nicknameInputView.isHidden = true
-        onboardingView.isHidden = false
-        currentPageIndex = 0
-        
-        dismissKeyboard()
+        setupKeyboardObserver()
+        bindUIEvents()
     }
-    
-    /// 닉네임 유효성에 따라 "다음" 버튼 활성화/비활성화 및 스타일 변경.
-    /// - Parameter isEnabled: 버튼 활성화 여부
-    func updateNextButtonState(isEnabled: Bool) {
-        nicknameInputView.nextButton.isEnabled = isEnabled
-        if isEnabled {
-            nicknameInputView.nextButton.backgroundColor = UIColor(named: "brand")
-            nicknameInputView.nextButton.setTitleColor(.black, for: .normal)
-        } else {
-            nicknameInputView.nextButton.backgroundColor = .darkGray
-            nicknameInputView.nextButton.setTitleColor(.lightGray, for: .normal)
-        }
-    }
-}
 
-private extension OnBoardingViewController {
-    /// 온보딩 "다음"/"시작하기" 버튼 클릭 시 다음 페이지로 이동하거나, 마지막 페이지면 온보딩 완료 처리.
-    @objc func onboardingViewNextButtonAction() {
-        goToNextPage()
-    }
-    
-    /// 온보딩 닫기(X) 버튼 클릭 시 온보딩을 건너뛰고 바로 완료 처리.
-    @objc func onboardingViewCloseButtonAction() {
-        // 온보딩 건너뛰었음을 별도로 저장 (향후 재안내 등에 활용 가능)
-        UserDefaults.standard.set(true, forKey: "hasSkippedOnboarding")
-        
-        // Coordinator를 통해 온보딩 완료 처리
-        coordinator?.completeOnBoarding()
-    }
-}
-
-// MARK: - 닉네임 입력 유효성 바인딩
-private extension OnBoardingViewController {
-    /// Rx 바인딩을 통해 닉네임 입력값이 변경될 때마다 유효성 검사 및 버튼 상태 업데이트.
-    func bindNicknameValidation() {
+    func bind(reactor: OnBoardingViewReactor) {
         nicknameInputView.nicknameTextField.rx.text.orEmpty
-            .map { [weak self] text in
-                self?.isValidNickname(text) ?? false
+            .map(OnBoardingViewReactor.Action.inputNickname)
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+
+        nicknameInputView.nextButton.rx.tap
+            .map { _ in OnBoardingViewReactor.Action.completeNicknameSetting }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+
+        onboardingView.closeButton.rx.tap
+            .map { _ in OnBoardingViewReactor.Action.skipOnboarding }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+
+        onboardingView.nextButton.rx.tap
+            .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
+            .map { _ in OnBoardingViewReactor.Action.moveToNextPage }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+
+        reactor.state.map { $0.isNicknameValid }
+            .distinctUntilChanged()
+            .bind(to: nicknameInputView.nextButton.rx.isEnabled)
+            .disposed(by: disposeBag)
+        
+        reactor.state.map { $0.isNicknameValid }
+            .distinctUntilChanged()
+            .bind { [weak self] isValid in
+                self?.nicknameInputView.nextButton.backgroundColor = isValid ? .brand : .darkGray
+                self?.nicknameInputView.nextButton.setTitleColor(isValid ? .black : .lightGray, for: .normal)
             }
+            .disposed(by: disposeBag)
+
+        reactor.state.map { $0.isNicknameComplete }
+            .filter { $0 }
+            .observe(on: MainScheduler.instance)
+            .bind { [weak self] _ in
+                guard let self = self else { return }
+                self.nicknameInputView.isHidden = true
+                self.onboardingView.isHidden = false
+                self.onboardingView.pageIndicator.currentPage = 0
+                self.updatePageContent(index: 0)
+                self.dismissKeyboard()
+            }
+            .disposed(by: disposeBag)
+
+        reactor.state.map { $0.currentPageIndex }
             .distinctUntilChanged()
             .observe(on: MainScheduler.instance)
-            .bind { [weak self] isValid in
-                self?.updateNextButtonState(isEnabled: isValid)
+            .bind { [weak self] index in
+                self?.updatePageContent(index: index)
             }
             .disposed(by: disposeBag)
     }
-    
-    /// 닉네임 유효성 검사(한글/영문 2~8자).
-    /// - Parameter nickname: 입력된 닉네임 문자열
-    /// - Returns: 유효하면 true, 아니면 false
-    func isValidNickname(_ nickname: String) -> Bool {
-        let regex = "^[가-힣a-zA-Z]{2,8}$"
-        return NSPredicate(format: "SELF MATCHES %@", regex).evaluate(with: nickname)
-    }
-}
 
-// MARK: - 온보딩 페이지 관리
-private extension OnBoardingViewController {
-    /// 온보딩 각 페이지의 데이터(타이틀, 서브타이틀, 이미지명) 정의.
-    struct OnboardingPageData {
-        let title: String
-        let subtitle: String
-        let imageName: String
-    }
-
-    /// 온보딩 페이지 데이터 배열. 페이지 순서대로 정의.
-    var onboardingPages: [OnboardingPageData] {
-        return [
-            .init(title: "운동 이름부터 세트 수까지", subtitle: " 내 루틴에 맞게 직접 설정해보세요", imageName: "Onboard_SetRoutine"),
-            .init(title: "오늘은 어떤 운동할까?", subtitle: "원하는 루틴만 골라 시작하세요", imageName: "Onboard_RoutineList"),
-            .init(title: "운동을 완료하면 세트 완료를 클릭하고,", subtitle: "휴식 시간을 미리 설정해보세요", imageName: "Onboard_BreakTime"),
-            .init(title: "운동 중 화면에서 무게, 횟수 클릭 시", subtitle: "세트 수, 무게를 변경할 수 있어요", imageName: "Onboard_WorkOutSetting"),
-            .init(title: "휴식 타이머를 확인하고,", subtitle: "물 한 잔으로 리프레시해요!", imageName: "Onboard_Water"),
-            .init(title: "운동 중엔 앱을 꺼도 OK!", subtitle: "잠금화면에서 운동 완료, 휴식까지 한 번에", imageName: "Onboard_LiveActivity")
-        ]
-    }
-
-    /// 현재 온보딩 페이지 인덱스. 변경 시 UI 업데이트.
-    var currentPageIndex: Int {
-        get { onboardingView.pageIndicator.currentPage }
-        set {
-            onboardingView.pageIndicator.currentPage = newValue
-            updatePageContent(index: newValue)
-        }
-    }
-
-    /// 온보딩 페이지 UI를 현재 인덱스에 맞게 업데이트.
-    /// - Parameter index: 표시할 페이지 인덱스
-    func updatePageContent(index: Int) {
-        guard onboardingPages.indices.contains(index) else { return }
-        let page = onboardingPages[index]
+    private func updatePageContent(index: Int) {
+        guard OnBoardingViewReactor.onboardingPages.indices.contains(index) else { return }
+        let page = OnBoardingViewReactor.onboardingPages[index]
         onboardingView.titleLabel.text = page.title
         onboardingView.subTitleLabel.text = page.subtitle
         onboardingView.centerImageView.image = UIImage(named: page.imageName)
-        
-        let isLastPage = index == onboardingPages.count - 1
-        let buttonTitle = isLastPage ? "시작하기" : "다음"
-        onboardingView.nextButton.setTitle(buttonTitle, for: .normal)
+        onboardingView.pageIndicator.currentPage = index
+        let isLastPage = index == OnBoardingViewReactor.onboardingPages.count - 1
+        onboardingView.nextButton.setTitle(isLastPage ? "시작하기" : "다음", for: .normal)
     }
 
-    /// 다음 온보딩 페이지로 이동하거나, 마지막 페이지면 온보딩 완료 처리(coordinator 호출).
-    func goToNextPage() {
-        let nextIndex = currentPageIndex + 1
-        if nextIndex < onboardingPages.count {
-            currentPageIndex = nextIndex
-        } else {
-            print("goToNextPage() - else")
-            coordinator?.completeOnBoarding()
-        }
-    }
-}
-
-private extension OnBoardingViewController {
-    func setupKeyboardObserver() {
-
+    private func setupKeyboardObserver() {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(keyboardWillShow),
             name: UIResponder.keyboardWillShowNotification,
             object: nil
         )
-        
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(keyboardWillHide),
@@ -249,38 +139,32 @@ private extension OnBoardingViewController {
             object: nil
         )
     }
-    
-    /// 키보드가 나타날 때 버튼 위로 이동
-    @objc func keyboardWillShow(notification: NSNotification) {
+
+    @objc private func keyboardWillShow(notification: NSNotification) {
         guard let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
-        
         let keyboardHeight = keyboardFrame.cgRectValue.height
         let safeAreaBottom = view.safeAreaInsets.bottom
         let adjustedKeyboardHeight = keyboardHeight - safeAreaBottom
-        
         nicknameInputView.adjustButtonForKeyboard(keyboardHeight: adjustedKeyboardHeight)
-        
         UIView.animate(withDuration: 0.3) {
             self.view.layoutIfNeeded()
         }
     }
 
-    /// 키보드가 사라질 때 버튼을 원래 위치로 복원
-    @objc func keyboardWillHide(notification: NSNotification) {
+    @objc private func keyboardWillHide(notification: NSNotification) {
         nicknameInputView.adjustButtonForKeyboard(keyboardHeight: 0)
-        
         UIView.animate(withDuration: 0.3) {
             self.view.layoutIfNeeded()
         }
     }
 
-    func bindUIEvents() {
-        let tap: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+    private func bindUIEvents() {
+        let tap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
         tap.cancelsTouchesInView = true
         view.addGestureRecognizer(tap)
     }
 
-    @objc func dismissKeyboard() {
+    @objc private func dismissKeyboard() {
         view.endEditing(true)
     }
 }

--- a/HowManySet/Presentation/Feature/OnBoarding/Reactor/OnBoardingViewReactor.swift
+++ b/HowManySet/Presentation/Feature/OnBoarding/Reactor/OnBoardingViewReactor.swift
@@ -97,7 +97,7 @@ final class OnBoardingViewReactor: Reactor {
             if nextPage < OnBoardingViewReactor.onboardingPages.count {
                 return Observable.just(.setPageIndex(nextPage))
             } else {
-                // AuthUseCase의 completeOnboarding() 메서드 활용 (uid 내부 처리)
+                // 마지막 페이지에서는 페이지 인덱스를 변경하지 않고 바로 완료 처리
                 return authUseCase.completeOnboarding()
                     .map { _ in .setOnboardingComplete }
                     .catch { error in Observable.just(.setError(error)) }
@@ -138,6 +138,7 @@ final class OnBoardingViewReactor: Reactor {
             newState.currentPageIndex = index
         case .setOnboardingComplete:
             newState.isOnboardingComplete = true
+            // 즉시 coordinator 호출하여 화면 전환 시작
             coordinator?.completeOnBoarding()
         case .setNicknameComplete:
             newState.isNicknameComplete = true

--- a/HowManySet/Presentation/Feature/OnBoarding/Reactor/OnBoardingViewReactor.swift
+++ b/HowManySet/Presentation/Feature/OnBoarding/Reactor/OnBoardingViewReactor.swift
@@ -2,45 +2,173 @@
 //  OnBoardingViewReactor.swift
 //  HowManySet
 //
-//  Created by 정근호 on 6/3/25.
+//  Created by GO on 6/3/25.
 //
 
 import Foundation
 import RxSwift
 import ReactorKit
 
+/**
+ 온보딩 및 닉네임 입력의 상태와 비즈니스 로직을 관리하는 Reactor.
+ 
+ - 역할: 사용자 입력(닉네임, 페이지 이동, 온보딩 완료 등)을 Action으로 받아 상태를 Mutation으로 변경하고, State로 반영합니다.
+ - 특징: ReactorKit의 핵심 컴포넌트로, UI 로직과 분리된 비즈니스 로직을 담당합니다.
+ - 의존성: 닉네임 설정 및 온보딩 완료 처리를 위한 AuthUseCaseProtocol 주입.
+ */
 final class OnBoardingViewReactor: Reactor {
-    
-    // Action is an user interaction
+    // MARK: - Action
+    /// 사용자 상호작용을 정의한 액션 타입
     enum Action {
-
+        case inputNickname(String)      // 닉네임 입력 액션
+        case moveToNextPage             // 다음 페이지 이동 액션
+        case skipOnboarding             // 온보딩 건너뛰기 액션
+        case completeNicknameSetting    // 닉네임 설정 완료 액션
     }
     
-    // Mutate is a state manipulator which is not exposed to a view
+    // MARK: - Mutation
+    /// 상태 변경을 위한 변이 타입
     enum Mutation {
-
+        case setNickname(String)        // 닉네임 상태 업데이트
+        case setPageIndex(Int)          // 페이지 인덱스 업데이트
+        case setOnboardingComplete      // 온보딩 완료 상태 업데이트
+        case setNicknameComplete        // 닉네임 설정 완료 상태 업데이트
+        case setError(Error?)           // 에러 상태 업데이트
+        case setNicknameValid(Bool)     // 닉네임 유효성 결과 업데이트
     }
     
-    // State is a current view state
+    // MARK: - State
+    /// 현재 뷰의 상태를 나타내는 타입
     struct State {
-
+        var nickname: String?           // 현재 입력된 닉네임
+        var currentPageIndex: Int = 0   // 현재 페이지 인덱스 (0부터 시작)
+        var isOnboardingComplete = false// 온보딩 완료 여부
+        var isNicknameComplete = false  // 닉네임 설정 완료 여부
+        var error: Error?               // 발생한 에러
+        var isNicknameValid: Bool = false // 닉네임 유효성 결과
     }
     
+    // MARK: - Properties
     let initialState: State
+    private let authUseCase: AuthUseCaseProtocol
+    private weak var coordinator: OnBoardingCoordinatorProtocol?
     
-    init() {
-        self.initialState = State()
+    // MARK: - Initialization
+    /**
+     Reactor 초기화
+     
+     - Parameters:
+       - authUseCase: 닉네임 설정 및 온보딩 완료 처리를 위한 UseCase
+       - coordinator: 온보딩 플로우 완료 시 호출할 Coordinator
+       - initialState: 초기 상태 값 (기본값: State())
+     */
+    init(
+        authUseCase: AuthUseCaseProtocol,
+        coordinator: OnBoardingCoordinatorProtocol,
+        initialState: State = State()
+    ) {
+        self.authUseCase = authUseCase
+        self.coordinator = coordinator
+        self.initialState = initialState
     }
     
-//    // Action -> Mutation
-//    func mutate(action: Action) -> Observable<Mutation> {
-//
-//    }
-//    
-//    // Mutation -> State
-//    func reduce(state: State, mutation: Mutation) -> State {
-//        
-//    }
+    // MARK: - Mutation Handler
+    /**
+     액션을 변이로 변환하는 메서드
+     
+     - Parameter action: 사용자 액션
+     - Returns: 해당 액션에 대응하는 Mutation Observable
+     */
+    func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .inputNickname(let nickname):
+            // AuthUseCase의 checkNicknameValid를 활용
+            return authUseCase.checkNicknameValid(nickname)
+                .flatMap { isValid -> Observable<Mutation> in
+                    Observable.concat([
+                        Observable.just(.setNickname(nickname)),
+                        Observable.just(.setError(nil)),
+                        Observable.just(.setNicknameValid(isValid))
+                    ])
+                }
+            
+        case .moveToNextPage:
+            let nextPage = currentState.currentPageIndex + 1
+            if nextPage < OnBoardingViewReactor.onboardingPages.count {
+                return Observable.just(.setPageIndex(nextPage))
+            } else {
+                // AuthUseCase의 completeOnboarding() 메서드 활용 (uid 내부 처리)
+                return authUseCase.completeOnboarding()
+                    .map { _ in .setOnboardingComplete }
+                    .catch { error in Observable.just(.setError(error)) }
+            }
+            
+        case .skipOnboarding:
+            // AuthUseCase의 completeOnboarding() 메서드 활용 (uid 내부 처리)
+            return authUseCase.completeOnboarding()
+                .map { _ in .setOnboardingComplete }
+                .catch { error in Observable.just(.setError(error)) }
+            
+        case .completeNicknameSetting:
+            guard let nickname = currentState.nickname else {
+                return Observable.just(.setError(NSError(domain: "NicknameRequired", code: -1)))
+            }
+            // AuthUseCase의 completeNicknameSetting(nickname:) 메서드 활용 (uid 내부 처리)
+            return authUseCase.completeNicknameSetting(nickname: nickname)
+                .map { _ in .setNicknameComplete }
+                .catch { error in Observable.just(.setError(error)) }
+        }
+    }
+    
+    // MARK: - State Reducer
+    /**
+     변이를 현재 상태에 적용하는 메서드
+     
+     - Parameters:
+       - state: 현재 상태
+       - mutation: 적용할 변이
+     - Returns: 변이가 적용된 새로운 상태
+     */
+    func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        switch mutation {
+        case .setNickname(let nickname):
+            newState.nickname = nickname
+        case .setPageIndex(let index):
+            newState.currentPageIndex = index
+        case .setOnboardingComplete:
+            newState.isOnboardingComplete = true
+            coordinator?.completeOnBoarding()
+        case .setNicknameComplete:
+            newState.isNicknameComplete = true
+        case .setError(let error):
+            newState.error = error
+        case .setNicknameValid(let isValid):
+            newState.isNicknameValid = isValid
+        }
+        return newState
+    }
+    
+    // MARK: - Onboarding Data
+    /**
+     온보딩 페이지 데이터 구조체
+     */
+    struct OnboardingPageData {
+        let title: String
+        let subtitle: String
+        let imageName: String
+    }
+    
+    /**
+     정적 온보딩 페이지 데이터 배열
+     - Note: 각 페이지의 타이틀, 서브타이틀, 이미지명을 포함
+     */
+    static let onboardingPages: [OnboardingPageData] = [
+        .init(title: "운동 이름부터 세트 수까지", subtitle: "내 루틴에 맞게 직접 설정해보세요", imageName: "Onboard_SetRoutine"),
+        .init(title: "오늘은 어떤 운동할까?", subtitle: "원하는 루틴만 골라 시작하세요", imageName: "Onboard_RoutineList"),
+        .init(title: "운동을 완료하면 세트 완료를 클릭하고,", subtitle: "휴식 시간을 미리 설정해보세요", imageName: "Onboard_BreakTime"),
+        .init(title: "운동 중 화면에서 무게, 횟수 클릭 시", subtitle: "세트 수, 무게를 변경할 수 있어요", imageName: "Onboard_WorkOutSetting"),
+        .init(title: "휴식 타이머를 확인하고,", subtitle: "물 한 잔으로 리프레시해보세요!", imageName: "Onboard_Water"),
+        .init(title: "운동 중엔 앱을 꺼도 OK!", subtitle: "잠금화면에서 운동 완료, 휴식까지 한 번에", imageName: "Onboard_LiveActivity")
+    ]
 }
-
-


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  - closed: #61 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
 - OnboardingViewController -> OnboardingViewController + OnboardingViewReactor로 리팩토링

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/f82d0e8c-b136-4a7b-a7a5-ce21598fd967" width ="250"> |

## 📌 추가
 - 닉네임 입력 완료 이후에도 isNicknameComplete == true 상태가 계속 유지되고 있는 상태였습니다.
 - 해당 값을 구독하는 스트림이 살아 있어서, 마지막 페이지에서 “시작하기”(온보딩 완료) 버튼을 눌렀을 때도 다시 트리거
 - filter { $0.isNicknameComplete && !$0.isOnboardingComplete }로 온보딩 완료 상태일 때는 차단
 - take(1)을 추가해 최초 한 번 방출 후 자동 dispose하는 방식으로 해결