### PR TITLE
RecordDetail 페이지 메모 수정 로직 수정 및 Calendar 페이지 자동 데이터 업데이트

### DIFF
--- a/HowManySet/Data/Repositories/RecordRepositoryImpl.swift
+++ b/HowManySet/Data/Repositories/RecordRepositoryImpl.swift
@@ -52,15 +52,13 @@ final class RecordRepositoryImpl: RecordRepository {
     func deleteAllRecord(uid: String) {
         RealmService.shared.deleteAll(type: .workoutRecord)
     }
-    
+
+    /// WorkoutRecord의 메모값을 변경하는 메서드
+    /// RecordDetail 페이지에서만 사용하기 때문에 comment만 변경함
     func updateRecord(uid: String, item: WorkoutRecord) {
-        if let record = RealmService.shared.read(type: .workoutRecord) as? RMWorkoutRecord {
+        if let record = RealmService.shared.read(type: .workoutRecord, primaryKey: item.id) as? RMWorkoutRecord {
             RealmService.shared.update(item: record) { (savedRecord: RMWorkoutRecord) in
                 savedRecord.comment = item.comment
-                savedRecord.date = item.date
-                savedRecord.totalTime = item.totalTime
-                savedRecord.workoutRoutine = RMWorkoutRoutine(dto: WorkoutRoutineDTO(entity: item.workoutRoutine))
-                savedRecord.workoutTime = item.workoutTime
             }
         }
     }

--- a/HowManySet/Presentation/Common/Extension/Notification.Name+Extension.swift
+++ b/HowManySet/Presentation/Common/Extension/Notification.Name+Extension.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Notification.Name + Extension으로 설정
+/// 전역변수로 Notification.Name 설정
+extension Notification.Name {
+    /// RecordDetail 페이지에서 dismiss 했을 때 사용하는 Notification
+    static let didDismissRecordDetail = Notification.Name("didDismissRecordDetail")
+}

--- a/HowManySet/Presentation/Feature/Calendar/CalendarViewController.swift
+++ b/HowManySet/Presentation/Feature/Calendar/CalendarViewController.swift
@@ -90,8 +90,15 @@ final class CalendarViewController: UIViewController, View {
         // tableView.delegate 바인딩
         calendarView.publicRecordTableView.rx.setDelegate(self)
             .disposed(by: disposeBag)
-        
-        
+
+        // NotificationCenter 이벤트 수신 바인딩
+        NotificationCenter.default.rx.notification(.didDismissRecordDetail)
+            .bind(with: self) { owner, _ in
+                let selectedDate = owner.reactor?.currentState.selectedDate ?? Date()
+                owner.reactor?.action.onNext(.selectDate(selectedDate))
+            }
+            .disposed(by: disposeBag)
+
         // 화면 탭하면 키보드 내리기
         let tapGesture = UITapGestureRecognizer()
         tapGesture.cancelsTouchesInView = false

--- a/HowManySet/Presentation/Feature/RecordDetail/Reactor/RecordDetailViewReactor.swift
+++ b/HowManySet/Presentation/Feature/RecordDetail/Reactor/RecordDetailViewReactor.swift
@@ -12,6 +12,7 @@ final class RecordDetailViewReactor: Reactor {
         case tapConfirm
         case tapSave
         case updateMemo(String?)
+        case resetDidUpdateMemo
     }
     
     // MARK: - Mutate is a state manipulator which is not exposed to a view
@@ -20,6 +21,7 @@ final class RecordDetailViewReactor: Reactor {
         case setMemo(String?)
         case setSaveButtonEnabled(Bool)
         case updateOriginalMemo(String?)
+        case setDidUpdateMemo(Bool)
     }
     
     // MARK: - State is a current view state
@@ -29,6 +31,7 @@ final class RecordDetailViewReactor: Reactor {
         var originalMemo: String?
         var shouldDismiss: Bool
         var isSaveButtonEnabled: Bool
+        var didUpdateMemo: Bool
     }
 
     // MARK: - Properties
@@ -44,7 +47,8 @@ final class RecordDetailViewReactor: Reactor {
             memo: record.comment,
             originalMemo: record.comment,
             shouldDismiss: false,
-            isSaveButtonEnabled: false
+            isSaveButtonEnabled: false,
+            didUpdateMemo: false
         )
     }
     
@@ -80,7 +84,8 @@ final class RecordDetailViewReactor: Reactor {
             print("변경된 메모 저장: \(memo)") // ✅ print
             return Observable.from([
                 .updateOriginalMemo(memo),
-                .setSaveButtonEnabled(false)
+                .setSaveButtonEnabled(false),
+                .setDidUpdateMemo(true)
             ])
 
         case let .updateMemo(text):
@@ -93,6 +98,9 @@ final class RecordDetailViewReactor: Reactor {
                 .setMemo(text),
                 .setSaveButtonEnabled(isChanged)
             ])
+
+        case .resetDidUpdateMemo:
+            return .just(.setDidUpdateMemo(false)) // 상태 초기화
         }
     }
 
@@ -108,6 +116,8 @@ final class RecordDetailViewReactor: Reactor {
             newState.isSaveButtonEnabled = isEnabled
         case let .updateOriginalMemo(newMemo):
             newState.originalMemo = newMemo
+        case let .setDidUpdateMemo(value):
+            newState.didUpdateMemo = value
         }
 
         return newState

--- a/HowManySet/Presentation/Feature/RecordDetail/RecordDetailViewController.swift
+++ b/HowManySet/Presentation/Feature/RecordDetail/RecordDetailViewController.swift
@@ -171,6 +171,8 @@ extension RecordDetailViewController {
             .distinctUntilChanged()
             .filter { $0 }
             .bind(with: self) { owner, _ in
+                // Notification 전송
+                NotificationCenter.default.post(name: .didDismissRecordDetail, object: nil)
                 owner.dismiss(animated: true)
             }
             .disposed(by: disposeBag)

--- a/HowManySet/Presentation/Feature/RecordDetail/RecordDetailViewController.swift
+++ b/HowManySet/Presentation/Feature/RecordDetail/RecordDetailViewController.swift
@@ -157,6 +157,7 @@ extension RecordDetailViewController {
             .map(\.didUpdateMemo)
             .distinctUntilChanged()
             .filter { $0 }
+            .observe(on: MainScheduler.asyncInstance)
             .bind(with: self) { owner, _ in
                 owner.showToast(x: 0, y: -20, message: "메모가 수정되었습니다.")
                 // tapSave가 되었을 때만(한 번만) 반응하기 위해 false로 다시 설정
@@ -205,7 +206,7 @@ extension RecordDetailViewController {
 
                 // 텍스트 업데이트 시 리액터로 전달
                 textView.rx.text.orEmpty
-//                    .skip(until: textView.rx.didBeginEditing)
+                    .skip(until: textView.rx.didBeginEditing)
                     .distinctUntilChanged()
                     .map { RecordDetailViewReactor.Action.updateMemo($0) }
                     .bind(to: reactor.action)

--- a/HowManySet/Presentation/Feature/RecordDetail/RecordDetailViewController.swift
+++ b/HowManySet/Presentation/Feature/RecordDetail/RecordDetailViewController.swift
@@ -152,6 +152,18 @@ extension RecordDetailViewController {
             }
             .disposed(by: disposeBag)
 
+        // 저장 버튼이 눌렸을 때 나타나는 토스트 뷰
+        reactor.state
+            .map(\.didUpdateMemo)
+            .distinctUntilChanged()
+            .filter { $0 }
+            .bind(with: self) { owner, _ in
+                owner.showToast(x: 0, y: -20, message: "메모가 수정되었습니다.")
+                // tapSave가 되었을 때만(한 번만) 반응하기 위해 false로 다시 설정
+                owner.reactor?.action.onNext(.resetDidUpdateMemo)
+            }
+            .disposed(by: disposeBag)
+
         // shouldDismiss 상태 변화 -> 모달 닫기
         reactor.state
             .map(\.shouldDismiss)

--- a/HowManySet/Presentation/Feature/RecordDetail/RecordDetailViewController.swift
+++ b/HowManySet/Presentation/Feature/RecordDetail/RecordDetailViewController.swift
@@ -193,7 +193,7 @@ extension RecordDetailViewController {
 
                 // 텍스트 업데이트 시 리액터로 전달
                 textView.rx.text.orEmpty
-                    .skip(until: textView.rx.didBeginEditing)
+//                    .skip(until: textView.rx.didBeginEditing)
                     .distinctUntilChanged()
                     .map { RecordDetailViewReactor.Action.updateMemo($0) }
                     .bind(to: reactor.action)


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  closed: #145 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- 메모가 수정될 때마다 "메모가 수정되었습니다" 토스트 뷰 띄움
- `RecordrepositoryImpl` 파일에서 `updateRecord` 메서드 수정 (comment만 수정하기 때문에 comment만 수정하도록)
- `RecordDetail` 페이지에서 저장 버튼 누를 때 `Reentrancy anomaly` rx 중첩 경고 해결
- `RecordDetail` 페이지에서 확인 버튼 누르면 dismiss될 때 Calendar 페이지에서 바로 데이터 업데이트 되지 않는 이슈 -> `NotificationCenter`로 해결


## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/38a203ce-56e2-4155-8d56-7c05063ef33f" width ="250"> |

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
```
                textView.rx.text.orEmpty
                    .skip(until: textView.rx.didBeginEditing)
                    .distinctUntilChanged()
                    .map { RecordDetailViewReactor.Action.updateMemo($0) }
                    .bind(to: reactor.action)
                    .disposed(by: owner.disposeBag)
```
`.skip(until: textView.rx.didBeginEditing)`는 유저가 직접 텍스트뷰에 진입(편집 시작)하기 전까지는 이벤트를 무시함
따라서 유저 입력이 아니어도 상태가 바뀌거나 버튼이 활성화되는 의도치 않은 상태 변화가 생길 수 있음 
→ 이를 방지하고자 사용함