### PR TITLE
전체적인 UI 수정 및 디테일 수정

### DIFF
--- a/HowManySet/Presentation/Common/Extension/UIView+Extension.swift
+++ b/HowManySet/Presentation/Common/Extension/UIView+Extension.swift
@@ -33,4 +33,17 @@ extension UIView {
             layer.render(in: rendererContext.cgContext)
         }
     }
+
+    /// tap했을 때 애니메이션 적용하는 메서드
+    func animateTap(completion: (() -> Void)? = nil) {
+        UIView.animate(withDuration: 0.1, animations: {
+            self.transform = CGAffineTransform(scaleX: 0.95, y: 0.95)
+        }) { _ in
+            UIView.animate(withDuration: 0.1, animations: {
+                self.transform = .identity
+            }, completion: { _ in
+                completion?()
+            })
+        }
+    }
 }

--- a/HowManySet/Presentation/Feature/Calendar/CalendarViewController.swift
+++ b/HowManySet/Presentation/Feature/Calendar/CalendarViewController.swift
@@ -174,13 +174,16 @@ extension CalendarViewController: UITableViewDelegate {
 
     /// TableView Cell이 선택되었을 때 실행하는 메서드
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        // 셀 클릭 시 배경색 남는 것을 방지하기 위한 선택 해지
-        calendarView.publicRecordTableView.deselectRow(at: indexPath, animated: true)
-        
-        // 해당 record 가져오기
+        guard let cell = tableView.cellForRow(at: indexPath) else { return }
+
+        cell.animateTap { [weak self] in
+            // 해당 record 가져오기
         guard let record = reactor?.currentState.selectedRecords[indexPath.section] else { return }
 
-        coordinator?.presentRecordDetailView(record: record)
+            self.coordinator?.presentRecordDetailView(record: record)
+        }
+
+        tableView.deselectRow(at: indexPath, animated: true)
     }
 
     /// trailing -> leading 방향으로 스와이프하는 메서드

--- a/HowManySet/Presentation/Feature/Calendar/CalendarViewController.swift
+++ b/HowManySet/Presentation/Feature/Calendar/CalendarViewController.swift
@@ -178,9 +178,9 @@ extension CalendarViewController: UITableViewDelegate {
 
         cell.animateTap { [weak self] in
             // 해당 record 가져오기
-        guard let record = reactor?.currentState.selectedRecords[indexPath.section] else { return }
+            guard let record = self?.reactor?.currentState.selectedRecords[indexPath.section] else { return }
 
-            self.coordinator?.presentRecordDetailView(record: record)
+            self?.coordinator?.presentRecordDetailView(record: record)
         }
 
         tableView.deselectRow(at: indexPath, animated: true)

--- a/HowManySet/Presentation/Feature/EditExercise/AddExerciseView/AddExerciseViewReactor.swift
+++ b/HowManySet/Presentation/Feature/EditExercise/AddExerciseView/AddExerciseViewReactor.swift
@@ -188,7 +188,7 @@ final class AddExerciseViewReactor: Reactor {
     
     // MARK: - 유효성 검사
     func validationWorkout(workout: Workout) -> ValidWorkout {
-        if workout.name.isEmpty {
+        if workout.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             return ValidWorkout.workoutNameEmpty
         }
         if workout.name.count > 25 {

--- a/HowManySet/Presentation/Feature/EditExercise/EditExerciseContentView/EditExerciseContentView.swift
+++ b/HowManySet/Presentation/Feature/EditExercise/EditExerciseContentView/EditExerciseContentView.swift
@@ -167,9 +167,12 @@ private extension EditExerciseContentView {
         addContentButton.rx.tap
             .observe(on: MainScheduler.instance)
             .subscribe(with: self) { owner, _ in
-                owner.addContentView()
-            }.disposed(by: disposeBag)
-        
+                owner.addContentButton.animateTap {
+                    owner.addContentView()
+                }
+            }
+            .disposed(by: disposeBag)
+
         headerView.unitSelectionRelay
             .bind(to: unitSelectionRelay)
             .disposed(by: disposeBag)

--- a/HowManySet/Presentation/Feature/EditExercise/EditExerciseContentView/EditExerciseHorizontalContentStackView.swift
+++ b/HowManySet/Presentation/Feature/EditExercise/EditExerciseContentView/EditExerciseHorizontalContentStackView.swift
@@ -148,7 +148,12 @@ private extension EditExerciseHorizontalContentStackView {
 
         // 삭제 버튼 탭 이벤트 바인딩
         removeButton.rx.tap
-            .bind(to: removeButtonTap)
+            .subscribe(onNext: { [weak self] in
+                guard let self else { return }
+                self.removeButton.animateTap {
+                    self.removeButtonTap.accept(())
+                }
+            })
             .disposed(by: disposeBag)
     }
     

--- a/HowManySet/Presentation/Feature/EditExercise/EditExerciseFooterView/AddExerciseFooterView.swift
+++ b/HowManySet/Presentation/Feature/EditExercise/EditExerciseFooterView/AddExerciseFooterView.swift
@@ -69,11 +69,21 @@ final class AddExerciseFooterView: UIStackView {
     /// 버튼에 대한 Rx 바인딩 설정
     private func bind() {
         addExcerciseButton.rx.tap
-            .bind(to: addExcerciseButtonTapped)
+            .bind { [weak self] in
+                guard let self else { return }
+                self.addExcerciseButton.animateTap {
+                    self.addExcerciseButtonTapped.accept(())
+                }
+            }
             .disposed(by: disposeBag)
-        
+
         saveRoutineButton.rx.tap
-            .bind(to: saveRoutineButtonTapped)
+            .bind { [weak self] in
+                guard let self else { return }
+                self.saveRoutineButton.animateTap {
+                    self.saveRoutineButtonTapped.accept(())
+                }
+            }
             .disposed(by: disposeBag)
     }
 }

--- a/HowManySet/Presentation/Feature/EditExercise/EditExerciseHeaderView/EditExerciseHeaderView.swift
+++ b/HowManySet/Presentation/Feature/EditExercise/EditExerciseHeaderView/EditExerciseHeaderView.swift
@@ -46,6 +46,12 @@ final class EditExerciseHeaderView: UIView {
         let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: 15, height: $0.frame.height))
         $0.leftView = paddingView
         $0.leftViewMode = .always
+
+        // 키보드 관련
+        $0.autocorrectionType = .no // 자동 수정 끔
+        $0.spellCheckingType = .no // 맞춤법 검사 끔
+        $0.smartInsertDeleteType = .no // 스마트 삽입/삭제 끔
+        $0.autocapitalizationType = .none // 영문으로 시작할 때 자동 대문자 끔
     }
     
     // MARK: - Initializers

--- a/HowManySet/Presentation/Feature/EditExercise/EditExerciseView/EditExerciseFooterView.swift
+++ b/HowManySet/Presentation/Feature/EditExercise/EditExerciseView/EditExerciseFooterView.swift
@@ -49,7 +49,12 @@ private extension EditExerciseFooterView {
     
     func bind() {
         saveExcerciseButton.rx.tap
-            .bind(to: saveExcerciseButtonRelay)
+            .subscribe(onNext: { [weak self] in
+                guard let self else { return }
+                self.saveExcerciseButton.animateTap {
+                    self.saveExcerciseButtonRelay.accept(())
+                }
+            })
             .disposed(by: disposeBag)
     }
     

--- a/HowManySet/Presentation/Feature/EditExercise/EditExerciseView/EditExerciseViewController.swift
+++ b/HowManySet/Presentation/Feature/EditExercise/EditExerciseView/EditExerciseViewController.swift
@@ -57,7 +57,19 @@ final class EditExerciseViewController: UIViewController, View {
             }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
-        
+
+        // textField 밖에 누르면 키보드 내려가도록 구현
+        let tapGesture = UITapGestureRecognizer()
+        tapGesture.cancelsTouchesInView = false
+
+        view.addGestureRecognizer(tapGesture)
+        tapGesture.rx.event
+            .bind { [weak self] _ in
+                guard let self else { return }
+                self.view.endEditing(true)
+            }
+            .disposed(by: disposeBag)
+
         reactor.state
             .map{ $0.workout }
             .distinctUntilChanged()

--- a/HowManySet/Presentation/Feature/EditExercise/EditExerciseView/Reactor/EditExerciseViewReactor.swift
+++ b/HowManySet/Presentation/Feature/EditExercise/EditExerciseView/Reactor/EditExerciseViewReactor.swift
@@ -81,7 +81,7 @@ final class EditExerciseViewReactor: Reactor {
     
     // MARK: - 유효성 검사
     private func validationWorkout(workout: Workout) -> ValidWorkout {
-        if workout.name.isEmpty {
+        if workout.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             return ValidWorkout.workoutNameEmpty
         }
         if workout.name.count > 25 {

--- a/HowManySet/Presentation/Feature/EditRoutine/EditRoutineBottomSheetViewController.swift
+++ b/HowManySet/Presentation/Feature/EditRoutine/EditRoutineBottomSheetViewController.swift
@@ -91,10 +91,18 @@ private extension EditRoutineBottomSheetViewController {
     
     func bind() {
         excerciseChangeButton.rx.tap
-            .bind(to: excerciseChangeButtonSubject)
+            .subscribe(with: self) { owner, _ in
+                owner.excerciseChangeButton.animateTap {
+                    owner.excerciseChangeButtonSubject.accept(())
+                }
+            }
             .disposed(by: disposeBag)
         removeExcerciseButton.rx.tap
-            .bind(to: removeExcerciseButtonSubject)
+            .subscribe(with: self) { owner, _ in
+                owner.removeExcerciseButton.animateTap {
+                    owner.removeExcerciseButtonSubject.accept(())
+                }
+            }
             .disposed(by: disposeBag)
         // TODO: 순서변경 마이너패치때
 //        changeExcerciseListButton.rx.tap

--- a/HowManySet/Presentation/Feature/EditRoutine/EditRoutineViewController.swift
+++ b/HowManySet/Presentation/Feature/EditRoutine/EditRoutineViewController.swift
@@ -138,8 +138,11 @@ final class EditRoutineViewController: UIViewController, View {
             }.disposed(by: editRoutineBottomSheetViewController.disposeBag)
         
         editRoutineBottomSheetViewController.removeExcerciseButtonSubject
-            .map{ Reactor.Action.removeSelectedWorkout }
-            .bind(to: reactor!.action)
+            .observe(on: MainScheduler.instance)
+            .subscribe(with: self) { owner, _ in
+                owner.dismiss(animated: true) // 바텀시트 닫기
+                owner.reactor?.action.onNext(.removeSelectedWorkout) // 삭제 액션 전달
+            }
             .disposed(by: editRoutineBottomSheetViewController.disposeBag)
         
         // TODO: 순서변경 마이너패치때

--- a/HowManySet/Presentation/Feature/Home/EditAndMemoViewController.swift
+++ b/HowManySet/Presentation/Feature/Home/EditAndMemoViewController.swift
@@ -59,6 +59,7 @@ final class EditAndMemoViewController: UIViewController, View {
         $0.autocorrectionType = .no // 자동 수정 끔
         $0.spellCheckingType = .no // 맞춤법 검사 끔
         $0.smartInsertDeleteType = .no // 스마트 삽입/삭제 끔
+        $0.autocapitalizationType = .none // 영문으로 시작할 때 자동 대문자 끔
     }
     
     

--- a/HowManySet/Presentation/Feature/RecordDetail/Cell/MemoInfoCell.swift
+++ b/HowManySet/Presentation/Feature/RecordDetail/Cell/MemoInfoCell.swift
@@ -57,6 +57,7 @@ private extension MemoInfoCell {
             $0.autocorrectionType = .no // 자동 수정 끔
             $0.spellCheckingType = .no // 맞춤법 검사 끔
             $0.smartInsertDeleteType = .no // 스마트 삽입/삭제 끔
+            $0.autocapitalizationType = .none // 영문으로 시작할 때 자동 대문자 끔
         }
     }
 

--- a/HowManySet/Presentation/Feature/RoutineComplete/RoutineCompleteViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineComplete/RoutineCompleteViewController.swift
@@ -143,6 +143,7 @@ final class RoutineCompleteViewController: UIViewController, View {
         $0.autocorrectionType = .no // 자동 수정 끔
         $0.spellCheckingType = .no // 맞춤법 검사 끔
         $0.smartInsertDeleteType = .no // 스마트 삽입/삭제 끔
+        $0.autocapitalizationType = .none // 영문으로 시작할 때 자동 대문자 끔
     }
     
     private lazy var confirmButton = UIButton().then {

--- a/HowManySet/Presentation/Feature/RoutineList/RoutineListViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineList/RoutineListViewController.swift
@@ -63,20 +63,12 @@ final class RoutineListViewController: UIViewController, View {
         routineListView.publicAddNewRoutineButton.rx.tap
             .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
             .bind(with: self) { owner, _ in
-                let button = owner.routineListView.publicAddNewRoutineButton
-
-                UIView.animate(withDuration: 0.1, animations: {
-                    button.transform = CGAffineTransform(scaleX: 0.95, y: 0.95)
-                }, completion: { _ in
-                    UIView.animate(withDuration: 0.1, animations: {
-                        button.transform = .identity
-                    }, completion: { _ in
-                        owner.coordinator?.presentRoutineNameView()
-                    })
-                })
+                owner.routineListView.publicAddNewRoutineButton.animateTap {
+                    owner.coordinator?.presentRoutineNameView()
+                }
             }
             .disposed(by: disposeBag)
-        
+
         reactor.state
             .map { state in
                 state.routines.map { SectionModel(model: "", items: [$0]) }  // 루틴마다 하나의 섹션
@@ -115,22 +107,16 @@ extension RoutineListViewController: UITableViewDelegate {
         guard let cell = tableView.cellForRow(at: indexPath) else { return }
 
         // 셀 터치 애니메이션
-        UIView.animate(withDuration: 0.1, animations: {
-            cell.transform = CGAffineTransform(scaleX: 0.95, y: 0.95)
-        }, completion: { _ in
-            UIView.animate(withDuration: 0.1, animations: {
-                cell.transform = .identity
-            }, completion: { [weak self] _ in
-                guard let self else { return }
-                let routine = dataSource.sectionModels[indexPath.section].items[indexPath.row]
+        cell.animateTap { [weak self] in
+            guard let self else { return }
+            let routine = dataSource.sectionModels[indexPath.section].items[indexPath.row]
 
-                if caller == .fromHome {
-                    coordinator?.presentEditRoutinView(with: routine)
-                } else {
-                    coordinator?.pushEditRoutineView(with: routine)
-                }
-            })
-        })
+            if caller == .fromHome {
+                coordinator?.presentEditRoutinView(with: routine)
+            } else {
+                coordinator?.pushEditRoutineView(with: routine)
+            }
+        }
     }
 
     /// trailing -> leading 방향으로 스와이프하는 메서드

--- a/HowManySet/Presentation/Feature/RoutineName/RoutineNameView.swift
+++ b/HowManySet/Presentation/Feature/RoutineName/RoutineNameView.swift
@@ -55,6 +55,7 @@ private extension RoutineNameView {
             $0.autocorrectionType = .no // 자동 수정 끔
             $0.spellCheckingType = .no // 맞춤법 검사 끔
             $0.smartInsertDeleteType = .no // 스마트 삽입/삭제 끔
+            $0.autocapitalizationType = .none // 영문으로 시작할 때 자동 대문자 끔
         }
 
         nextButton.do {

--- a/HowManySet/Presentation/Feature/RoutineName/RoutineNameViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineName/RoutineNameViewController.swift
@@ -42,7 +42,7 @@ extension RoutineNameViewController {
     func bind(reactor: RoutineNameReactor) {
         // 텍스트 필드 입력에 따른 버튼 활성화
         routineNameView.publicRoutineNameTF.rx.text.orEmpty
-            .map { !$0.isEmpty }
+            .map { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
             .distinctUntilChanged()
             .bind(with: self) { owner, isEnabled in
                 let button = owner.routineNameView.publicNextButton
@@ -55,6 +55,7 @@ extension RoutineNameViewController {
         // 버튼 탭 이벤트
         routineNameView.publicNextButton.rx.tap
             .withLatestFrom(routineNameView.publicRoutineNameTF.rx.text.orEmpty)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) } // 혹시나 만약을 대비하여 여기도 추가
             .bind(with: self) { owner, text in
                 reactor.action.onNext(.setRoutineName(text))
                 owner.dismiss(animated: true) {

--- a/HowManySet/Presentation/Feature/RoutineName/RoutineNameViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineName/RoutineNameViewController.swift
@@ -56,25 +56,19 @@ extension RoutineNameViewController {
         routineNameView.publicNextButton.rx.tap
             .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
             .withLatestFrom(routineNameView.publicRoutineNameTF.rx.text.orEmpty)
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) } // 혹시나 만약을 대비하여 여기도 추가
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .bind(with: self) { owner, text in
                 guard !text.isEmpty else { return }
 
-                UIView.animate(withDuration: 0.1, delay: 0, options: [.curveEaseInOut], animations: {
-                    owner.routineNameView.publicNextButton.transform = CGAffineTransform(scaleX: 0.95, y: 0.95)
-                }, completion: { _ in
-                    UIView.animate(withDuration: 0.1, delay: 0, options: [.curveEaseInOut], animations: {
-                        owner.routineNameView.publicNextButton.transform = .identity
-                    }, completion: { _ in
-                        reactor.action.onNext(.setRoutineName(text))
-                        owner.dismiss(animated: true) {
-                            owner.coordinator?.pushEditExcerciseView(routineName: text)
-                        }
-                    })
-                })
+                owner.routineNameView.publicNextButton.animateTap {
+                    reactor.action.onNext(.setRoutineName(text))
+                    owner.dismiss(animated: true) {
+                        owner.coordinator?.pushEditExcerciseView(routineName: text)
+                    }
+                }
             }
             .disposed(by: disposeBag)
-        
+
 //        // 화면 탭하면 키보드 내리기
 //        let tapGesture = UITapGestureRecognizer()
 //        tapGesture.cancelsTouchesInView = false

--- a/HowManySet/Presentation/Feature/RoutineName/RoutineNameViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineName/RoutineNameViewController.swift
@@ -64,16 +64,21 @@ extension RoutineNameViewController {
             }
             .disposed(by: disposeBag)
         
-        // 화면 탭하면 키보드 내리기
-        let tapGesture = UITapGestureRecognizer()
-        tapGesture.cancelsTouchesInView = false
-        view.addGestureRecognizer(tapGesture)
-
-        tapGesture.rx.event
-            .bind { [weak self] _ in
-                guard let self else { return }
-                self.view.endEditing(true)
-            }
-            .disposed(by: disposeBag)
+//        // 화면 탭하면 키보드 내리기
+//        let tapGesture = UITapGestureRecognizer()
+//        tapGesture.cancelsTouchesInView = false
+//        view.addGestureRecognizer(tapGesture)
+//
+//        tapGesture.rx.event
+//            .bind { [weak self] _ in
+//                guard let self else { return }
+//                self.view.endEditing(true)
+//            }
+//            .disposed(by: disposeBag)
+/*
+ 다음 버튼을 누를 때 두번 탭해야하는 불편함이 생김
+ => 주석처리를 하게 되면 버튼을 누를때 한번만 눌러도 다음 화면으로 넘어감
+ => 어차피 전체 화면을 덮는 모달이 아니기 때문에 키보드를 취소하고 싶다면 모달 뒤를 탭하면 된다고 생각함
+*/
     }
 }

--- a/HowManySet/Presentation/Feature/RoutineName/RoutineNameViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineName/RoutineNameViewController.swift
@@ -54,13 +54,24 @@ extension RoutineNameViewController {
 
         // 버튼 탭 이벤트
         routineNameView.publicNextButton.rx.tap
+            .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
             .withLatestFrom(routineNameView.publicRoutineNameTF.rx.text.orEmpty)
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) } // 혹시나 만약을 대비하여 여기도 추가
             .bind(with: self) { owner, text in
-                reactor.action.onNext(.setRoutineName(text))
-                owner.dismiss(animated: true) {
-                    owner.coordinator?.pushEditExcerciseView(routineName: text)
-                }
+                guard !text.isEmpty else { return }
+
+                UIView.animate(withDuration: 0.1, delay: 0, options: [.curveEaseInOut], animations: {
+                    owner.routineNameView.publicNextButton.transform = CGAffineTransform(scaleX: 0.95, y: 0.95)
+                }, completion: { _ in
+                    UIView.animate(withDuration: 0.1, delay: 0, options: [.curveEaseInOut], animations: {
+                        owner.routineNameView.publicNextButton.transform = .identity
+                    }, completion: { _ in
+                        reactor.action.onNext(.setRoutineName(text))
+                        owner.dismiss(animated: true) {
+                            owner.coordinator?.pushEditExcerciseView(routineName: text)
+                        }
+                    })
+                })
             }
             .disposed(by: disposeBag)
         


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  closed: #206 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- "선택 운동 삭제" 버튼을 누르면 바텀시트 dismiss 구현
- EditExerciseVC 키보드 내려가도록 tap Gesture 추가
- 모든 textView, textField 키보드 설정 통일
- RoutineName 공백 입력 불가능 하도록 `$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty` 사용
- addExercise, editExercise textField도 공백이 입력되지 않도록 수정
- RoutineName tap Gesture 주석 처리 (불필요한 터치 횟수를 방지하기 위해)

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/33f53ec2-50e5-4cb8-9003-beff54a9d01c" width ="250"> |
| GIF | <img src = "https://github.com/user-attachments/assets/7e648264-cb63-45b0-8535-231e5dbafd23" width ="250"> |
| GIF | <img src = "https://github.com/user-attachments/assets/acd06143-1fc6-4472-96ca-0a66b1300a35" width ="250"> |


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- RoutineName에서 tap Gesture를 사용하게 되면 버튼 누를 때 2번 해야해서 일단 1번 누를 수 있게 임의로 tap Gesture 주석처리 함
