### PR TITLE
로그인 플로우 개선/ 비회원 uid 삭제 및 플로우 수정

### DIFF
--- a/HowManySet/App/Coordinator/AppCoordinator.swift
+++ b/HowManySet/App/Coordinator/AppCoordinator.swift
@@ -56,8 +56,7 @@ final class AppCoordinator: Coordinator {
 
     /// 앱 시작 시 호출
     func start() {
-        authStateListenerHandle
-            = Auth.auth().addStateDidChangeListener { [weak self] _, user in
+        authStateListenerHandle = Auth.auth().addStateDidChangeListener { [weak self] _, user in
             guard let self else { return }
 
             // 이미 한 번 분기했으면 이후 콜백은 상태 변화 처리로 사용
@@ -82,26 +81,24 @@ final class AppCoordinator: Coordinator {
             // 2) 첫 콜백이 nil → 잠시 대기 후 여전히 nil이면 비로그인 플로우
             else {
                 self.authWaitTimer?.dispose()
-                self.authWaitTimer
-                    = Observable<Int>.timer(self.initialAuthWait,
-                                            scheduler: MainScheduler.instance)
-                      .subscribe(onNext: { [weak self] _ in
-                          guard let self, !self.hasRouted else { return }
-                          self.hasRouted = true
-                          self.route(using: nil)
-                      })
+                self.authWaitTimer = Observable<Int>.timer(self.initialAuthWait, scheduler: MainScheduler.instance)
+                    .subscribe(onNext: { [weak self] _ in
+                        guard let self, !self.hasRouted else { return }
+                        self.hasRouted = true
+                        self.route(using: nil)
+                    })
             }
         }
     }
 
-    /// ★ 토큰(세션) 유효성 검사 – 만료·삭제된 계정이면 false
-    private func validateSession(_ user: FirebaseAuth.User,
-                                 completion: @escaping (Bool) -> Void) {
+    /// 토큰(세션) 유효성 검사 – 만료·삭제된 계정이면 false
+    private func validateSession(_ user: FirebaseAuth.User, completion: @escaping (Bool) -> Void) {
         user.reload { error in
             if let error {
                 print("🔴 token invalid:", error)
                 try? Auth.auth().signOut()
                 UserDefaults.standard.removeObject(forKey: "hasCompletedOnboarding")
+                UserDefaults.standard.removeObject(forKey: "hasSetNickname")
                 completion(false)
             } else {
                 completion(true)
@@ -111,27 +108,57 @@ final class AppCoordinator: Coordinator {
 
     /// user 존재 여부에 따른 라우팅
     private func route(using user: FirebaseAuth.User?) {
+        validateUserState() // 디버깅용 로그
+        
         if let user {
+            print("🟢 Firebase 사용자 존재: \(user.uid)")
             checkUserStatusWithFirestore(uid: user.uid)
         } else {
-            checkLocalUserStatus()
+            print("🔴 Firebase 사용자 없음")
+            
+            // 🟢 수정: Firebase 사용자가 없으면 provider 확인
+            let provider = UserDefaults.standard.string(forKey: "userProvider") ?? "none"
+            if provider == "none" || provider.isEmpty {
+                print("🔴 Provider 없음 - 로그인 화면으로 이동")
+                showAuthFlow()
+            } else {
+                print("🔴 Provider 있음 - 로컬 상태 확인")
+                checkLocalUserStatus()
+            }
         }
     }
 
     /// 로컬 사용자 상태 확인 (Firebase Auth 없을 때)
     private func checkLocalUserStatus() {
         let hasCompleted = UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
+        let hasSetNickname = UserDefaults.standard.bool(forKey: "hasSetNickname")
+        let provider = UserDefaults.standard.string(forKey: "userProvider") ?? "none"
 
-        if hasCompleted {
+        print("🔍 checkLocalUserStatus 호출")
+        print("   - Provider: \(provider)")
+        print("   - hasSetNickname: \(hasSetNickname)")
+        print("   - hasCompleted: \(hasCompleted)")
+
+        // 🟢 수정: provider가 "none"이면 로그인 화면으로
+        if provider == "none" || provider.isEmpty {
+            print("🔴 Provider 없음 - 로그인 화면으로 이동")
+            showAuthFlow()
+            return
+        }
+
+        if !hasSetNickname {
+            print("🔴 로컬 닉네임 미설정 - 닉네임 입력 화면")
+            showNicknameFlow()
+        } else if !hasCompleted {
+            print("🔴 로컬 온보딩 미완료 - 온보딩 화면")
+            showOnboardingFlow()
+        } else {
             print("🟡 로컬 온보딩 완료 상태 - 메인 화면")
             showTabBarFlow()
-        } else {
-            print("🔴 로컬 온보딩 미완료 - 로그인 화면")
-            showAuthFlow()
         }
     }
 
-    /// Firestore 기반 사용자 상태 확인
+    /// Firestore 기반 사용자 상태 확인 (수정된 버전)
     private func checkUserStatusWithFirestore(uid: String) {
         let authRepo = AuthRepositoryImpl(firebaseAuthService: FirebaseAuthService())
         let authUseCase = AuthUseCase(repository: authRepo)
@@ -143,16 +170,16 @@ final class AppCoordinator: Coordinator {
                 onNext: { [weak self] status in
                     guard let self else { return }
                     switch status {
+                    case .needsNickname:
+                        print("🔴 서버: 닉네임 설정 필요")
+                        self.showNicknameFlow()
                     case .needsOnboarding:
-                        // 로컬 플래그가 true인데 서버가 false라면 유령 세션 → 로그아웃
-                        if UserDefaults.standard.bool(forKey: "hasCompletedOnboarding") {
-                            try? Auth.auth().signOut()
-                            self.showAuthFlow()
-                        } else {
-                            self.showOnboardingFlow()
-                        }
+                        print("🔴 서버: 온보딩 필요")
+                        self.showOnboardingFlow()
                     case .complete:
+                        print("🟢 서버: 온보딩 완료")
                         UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
+                        UserDefaults.standard.set(true, forKey: "hasSetNickname")
                         self.showTabBarFlow()
                     }
                 },
@@ -171,8 +198,7 @@ final class AppCoordinator: Coordinator {
         defer { isSwitchingRoot = false }
 
         print("🔑 로그인 화면 표시")
-        let coord = AuthCoordinator(navigationController: UINavigationController(),
-                                    container: container)
+        let coord = AuthCoordinator(navigationController: UINavigationController(), container: container)
         childCoordinators.append(coord)
 
         coord.finishFlow = { [weak self, weak coord] in
@@ -190,15 +216,37 @@ final class AppCoordinator: Coordinator {
         window.makeKeyAndVisible()
     }
 
-    /// 온보딩 흐름 시작
+    /// 닉네임 입력만 하는 플로우
+    private func showNicknameFlow() {
+        guard !isSwitchingRoot else { return }
+        isSwitchingRoot = true
+        defer { isSwitchingRoot = false }
+
+        print("✏️ 닉네임 입력 화면 표시")
+        let coord = OnBoardingCoordinator(navigationController: UINavigationController(), container: container)
+        childCoordinators.append(coord)
+
+        coord.finishFlow = { [weak self, weak coord] in
+            guard let self, let coord else { return }
+            self.childDidFinish(coord)
+            // 닉네임 완료 후 바로 메인으로 이동 (온보딩은 ViewController 내부에서 처리)
+            UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
+            self.showTabBarFlow()
+        }
+
+        coord.startWithNicknameOnly()
+        window.rootViewController = coord.navigationController
+        window.makeKeyAndVisible()
+    }
+
+    /// 온보딩만 하는 플로우
     private func showOnboardingFlow() {
         guard !isSwitchingRoot else { return }
         isSwitchingRoot = true
         defer { isSwitchingRoot = false }
 
         print("👋 온보딩 화면 표시")
-        let coord = OnBoardingCoordinator(navigationController: UINavigationController(),
-                                          container: container)
+        let coord = OnBoardingCoordinator(navigationController: UINavigationController(), container: container)
         childCoordinators.append(coord)
 
         coord.finishFlow = { [weak self, weak coord] in
@@ -208,32 +256,58 @@ final class AppCoordinator: Coordinator {
             self.showTabBarFlow()
         }
 
-        coord.start()
+        coord.startWithOnboardingOnly()
         window.rootViewController = coord.navigationController
         window.makeKeyAndVisible()
     }
 
-    /// 메인 탭바 흐름 시작
+
+    /// 메인 탭바 흐름 시작 (수정된 버전)
     private func showTabBarFlow() {
         guard !isSwitchingRoot else { return }
         isSwitchingRoot = true
         defer { isSwitchingRoot = false }
 
         print("🏠 메인 화면 표시")
-        let coord = TabBarCoordinator(tabBarController: UITabBarController(),
-                                      container: container)
+        let coord = TabBarCoordinator(tabBarController: UITabBarController(), container: container)
         childCoordinators.append(coord)
 
         coord.finishFlow = { [weak self, weak coord] in
             guard let self, let coord else { return }
             self.childDidFinish(coord)
-            UserDefaults.standard.removeObject(forKey: "hasCompletedOnboarding")
+            // 로그아웃 시 모든 상태 초기화
+            let keysToRemove = [
+                "hasCompletedOnboarding",
+                "hasSkippedOnboarding",
+                "userNickname",
+                "userProvider",
+                "userUID",
+                "hasSetNickname"
+            ]
+            for key in keysToRemove {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+            UserDefaults.standard.synchronize()
             self.showAuthFlow()
         }
 
         coord.start()
         window.rootViewController = coord.tabBarController
         window.makeKeyAndVisible()
+    }
+
+    /// 디버깅을 위한 상태 검증 메서드
+    private func validateUserState() {
+        let hasNickname = UserDefaults.standard.bool(forKey: "hasSetNickname")
+        let hasOnboarding = UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
+        let provider = UserDefaults.standard.string(forKey: "userProvider") ?? "none"
+        let nickname = UserDefaults.standard.string(forKey: "userNickname") ?? "없음"
+        
+        print("🔍 현재 사용자 상태:")
+        print("   - Provider: \(provider)")
+        print("   - 닉네임: \(nickname)")
+        print("   - 닉네임 설정: \(hasNickname)")
+        print("   - 온보딩 완료: \(hasOnboarding)")
     }
 
     private func childDidFinish(_ child: Coordinator) {

--- a/HowManySet/App/Coordinator/MyPageCoordinator.swift
+++ b/HowManySet/App/Coordinator/MyPageCoordinator.swift
@@ -46,23 +46,8 @@ final class MyPageCoordinator: MyPageCoordinatorProtocol {
     /// 시작, 마이페이지 뷰 푸시
     func start() {
         let myPageVC = container.makeMyPageViewController(coordinator: self)
-        
         navigationController.pushViewController(myPageVC, animated: true)
     }
-    
-    /// 언어 변경
-    /// 알림 설정
-    /// 앱 평가
-    /// 버전 정보
-    /// 개인정보처리방침
-    /// 문제제보
-    /// 로그아웃
-    /// 계정탈퇴
-    /// -----------------
-    /// 팝업: 로그아웃, 계정탈퇴
-    /// 설정으로 이동: 언어 변경
-    /// View Push: 알림 설정
-    /// alert: 버전정보
     
     /// 언어 변경 처리 (설정 앱 이동 알림)
     func presentLanguageSettingAlert() {
@@ -81,7 +66,6 @@ final class MyPageCoordinator: MyPageCoordinatorProtocol {
         })
 
         alert.addAction(UIAlertAction(title: "취소", style: .cancel, handler: nil))
-
         navigationController.present(alert, animated: true)
     }
     
@@ -102,7 +86,6 @@ final class MyPageCoordinator: MyPageCoordinatorProtocol {
         })
 
         alert.addAction(UIAlertAction(title: "취소", style: .cancel, handler: nil))
-
         navigationController.present(alert, animated: true)
     }
     
@@ -181,7 +164,7 @@ final class MyPageCoordinator: MyPageCoordinatorProtocol {
         
         let deleteAccountVC = DefaultPopupViewController(title: "로그아웃 하시겠습니까?",
                                                          okButtonText: "로그아웃") {
-            // 🔥 Reactor의 confirmLogout 액션 호출
+            // Reactor의 confirmLogout 액션 호출
             myPageVC.reactor?.action.onNext(.confirmLogout)
         }
         navigationController.present(deleteAccountVC, animated: true)
@@ -194,7 +177,7 @@ final class MyPageCoordinator: MyPageCoordinatorProtocol {
         let deleteAccountVC = DefaultPopupViewController(title: "정말 탈퇴하시겠습니까?",
                                                          content: "탈퇴 시 모든 운동 기록과 데이터가 삭제되며, 복구할 수 없습니다.",
                                                          okButtonText: "계정 삭제") {
-            // 🔥 Reactor의 confirmDeleteAccount 액션 호출
+            // Reactor의 confirmDeleteAccount 액션 호출
             myPageVC.reactor?.action.onNext(.confirmDeleteAccount)
         }
         navigationController.present(deleteAccountVC, animated: true)
@@ -202,12 +185,28 @@ final class MyPageCoordinator: MyPageCoordinatorProtocol {
     
     /// 인증 화면으로 이동 (로그아웃/계정삭제 후)
     func navigateToAuth() {
-        print("로그아웃 / 계정삭제 후 화면 전환")
+        guard !isMovingToAuth else { return }
+        isMovingToAuth = true
+        
+        print("🟢 로그아웃/계정삭제 후 상태 완전 초기화")
+        
+        // 모든 상태 완전 초기화
+        let keysToRemove = [
+            "hasCompletedOnboarding",
+            "hasSkippedOnboarding",
+            "userNickname",
+            "userProvider",
+            "userUID",
+            "hasSetNickname"
+        ]
+        for key in keysToRemove {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+        UserDefaults.standard.synchronize()
+        
         finishFlow?()
     }
-    
 }
-
 
 private extension MyPageCoordinator {
     /// 앱스토러에 등록된 앱의 버전 불러오기

--- a/HowManySet/App/Coordinator/OnBoardingCoordinator.swift
+++ b/HowManySet/App/Coordinator/OnBoardingCoordinator.swift
@@ -93,7 +93,7 @@ final class OnBoardingCoordinator: OnBoardingCoordinatorProtocol {
             .disposed(by: disposeBag)
     }
     
-    /// 온보딩 완료 시 호출
+    /// 온보딩 완료 시 호출 (익명 사용자 처리 추가)
     func completeOnBoarding() {
         guard !isCompleting else { return }
         isCompleting = true
@@ -101,11 +101,23 @@ final class OnBoardingCoordinator: OnBoardingCoordinatorProtocol {
         
         print("🟢 OnBoardingCoordinator: 온보딩 완료 처리 시작")
         
+        let provider = UserDefaults.standard.string(forKey: "userProvider") ?? ""
+        
+        // 🟢 익명 사용자는 로컬에만 저장
+        if provider == "anonymous" {
+            UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
+            UserDefaults.standard.synchronize()
+            print("🟢 익명 사용자 온보딩 완료 - 로컬 저장")
+            finishFlow?()
+            return
+        }
+        
+        // 기존 소셜 로그인 사용자 Firebase 처리 로직 유지
         authRepository.getCurrentUser()
             .flatMap { [weak self] user -> Observable<Void> in
                 guard let self else { return .empty() }
                 guard let user,
-                      let uid = user.uid else {  // uid를 안전하게 언래핑
+                      let uid = user.uid else {
                     UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
                     self.finishFlow?()
                     return .empty()

--- a/HowManySet/App/Coordinator/OnBoardingCoordinator.swift
+++ b/HowManySet/App/Coordinator/OnBoardingCoordinator.swift
@@ -74,10 +74,12 @@ final class OnBoardingCoordinator: OnBoardingCoordinatorProtocol {
     func completeNicknameSetting(nickname: String) {
         authRepository.getCurrentUser()
             .flatMap { [weak self] user -> Observable<Void> in
-                guard let self, let user else {
+                guard let self,
+                      let user,
+                      let uid = user.uid else {  // uid를 안전하게 언래핑
                     return Observable.error(NSError(domain: "NoCurrentUser", code: -1))
                 }
-                return self.authUseCase.completeNicknameSetting(uid: user.uid, nickname: nickname)
+                return self.authUseCase.completeNicknameSetting(uid: uid, nickname: nickname)
             }
             .observe(on: MainScheduler.instance)
             .subscribe(
@@ -102,12 +104,13 @@ final class OnBoardingCoordinator: OnBoardingCoordinatorProtocol {
         authRepository.getCurrentUser()
             .flatMap { [weak self] user -> Observable<Void> in
                 guard let self else { return .empty() }
-                guard let user else {
+                guard let user,
+                      let uid = user.uid else {  // uid를 안전하게 언래핑
                     UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
                     self.finishFlow?()
                     return .empty()
                 }
-                return self.authUseCase.completeOnboarding(uid: user.uid)
+                return self.authUseCase.completeOnboarding(uid: uid)
             }
             .observe(on: MainScheduler.instance)
             .subscribe(

--- a/HowManySet/App/Coordinator/OnBoardingCoordinator.swift
+++ b/HowManySet/App/Coordinator/OnBoardingCoordinator.swift
@@ -49,6 +49,27 @@ final class OnBoardingCoordinator: OnBoardingCoordinatorProtocol {
         navigationController.pushViewController(onboardingVC, animated: false)
     }
     
+    /// 닉네임만 입력하는 시작점
+    func startWithNicknameOnly() {
+        print("🔍 OnBoardingCoordinator: startWithNicknameOnly 호출")
+        let onboardingVC = container.makeOnBoardingViewController(coordinator: self)
+        
+        navigationController.pushViewController(onboardingVC, animated: false)
+        print("🔍 OnBoardingViewController 푸시 완료")
+    }
+
+
+    /// 온보딩만 하는 시작점
+    func startWithOnboardingOnly() {
+        let onboardingVC = container.makeOnBoardingViewController(coordinator: self)
+        // 온보딩만 시작하도록 설정
+        if let vc = onboardingVC as? OnBoardingViewController {
+            vc.startWithOnboardingOnly()
+        }
+        navigationController.pushViewController(onboardingVC, animated: false)
+    }
+
+    
     /// 닉네임 설정 완료 시 호출
     func completeNicknameSetting(nickname: String) {
         authRepository.getCurrentUser()
@@ -56,7 +77,8 @@ final class OnBoardingCoordinator: OnBoardingCoordinatorProtocol {
                 guard let self, let user else {
                     return Observable.error(NSError(domain: "NoCurrentUser", code: -1))
                 }
-                return self.authUseCase.completeNicknameSetting(uid: user.uid, nickname: nickname)}
+                return self.authUseCase.completeNicknameSetting(uid: user.uid, nickname: nickname)
+            }
             .observe(on: MainScheduler.instance)
             .subscribe(
                 onNext: { _ in

--- a/HowManySet/Data/Firebase/Repositories/AuthRepositoryImpl.swift
+++ b/HowManySet/Data/Firebase/Repositories/AuthRepositoryImpl.swift
@@ -623,6 +623,16 @@ public final class AuthRepositoryImpl: AuthRepositoryProtocol {
     private func reconnectExistingKakaoUser(_ user: User, kakaoId: Int64, nickname: String, email: String?, completion: @escaping (Result<User, Error>) -> Void) {
         print("🔄 기존 카카오 사용자 Firebase Auth 재연결 시작")
         
+        guard let userUID = user.uid else {
+            print("🔴 사용자 UID가 없습니다")
+            completion(.failure(NSError(
+                domain: "UserError",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "사용자 UID를 찾을 수 없습니다."]
+            )))
+            return
+        }
+        
         Auth.auth().signInAnonymously { authResult, error in
             if let error = error {
                 print("🔴 Firebase Auth 재연결 실패: \(error)")
@@ -648,7 +658,7 @@ public final class AuthRepositoryImpl: AuthRepositoryProtocol {
             )
             
             let db = Firestore.firestore()
-            db.collection("users").document(user.uid).delete { deleteError in
+            db.collection("users").document(userUID).delete { deleteError in
                 if let deleteError = deleteError {
                     print("🔴 기존 문서 삭제 실패: \(deleteError)")
                 }

--- a/HowManySet/Data/Firebase/Repositories/AuthRepositoryImpl.swift
+++ b/HowManySet/Data/Firebase/Repositories/AuthRepositoryImpl.swift
@@ -284,22 +284,24 @@ public final class AuthRepositoryImpl: AuthRepositoryProtocol {
         }
     }
 
-    /// 익명 로그인을 수행합니다
-    /// - Returns: 익명 사용자 정보를 방출하는 Observable
+    /// 익명 로그인을 수행합니다 (Firebase Auth 제거)
     public func signInAnonymously() -> Observable<User> {
         return Observable.create { observer in
-            print("익명 로그인 시작")
-            self.firebaseAuthService.signInAnonymously { result in
-                switch result {
-                case .success(let user):
-                    print("익명 로그인 성공: \(user.uid)")
-                    observer.onNext(user)
-                    observer.onCompleted()
-                case .failure(let error):
-                    print("익명 로그인 실패: \(error)")
-                    observer.onError(error)
-                }
-            }
+            print("익명 로그인 시작 - Firebase Auth 없이 진행")
+            
+            // Firebase Auth 없이 단순한 User 객체 생성
+            let anonymousUser = User(
+                uid: nil,
+                name: "비회원",
+                provider: "anonymous",
+                email: nil,
+                hasSetNickname: true,  // 닉네임 입력 스킵
+                hasCompletedOnboarding: false
+            )
+            
+            print("익명 로그인 성공 - 단순 객체 생성")
+            observer.onNext(anonymousUser)
+            observer.onCompleted()
             return Disposables.create()
         }
     }

--- a/HowManySet/Domain/Entity/User.swift
+++ b/HowManySet/Domain/Entity/User.swift
@@ -24,7 +24,7 @@ public enum UserStatus {
 /// 다양한 로그인 제공자(카카오, 구글, Apple, 익명)를 지원합니다.
 public struct User {
     /// Firebase Auth에서 제공하는 고유 사용자 식별자
-    public let uid: String
+    public let uid: String?
     
     /// 사용자 닉네임
     public let name: String
@@ -54,7 +54,7 @@ public struct User {
     ///   - hasSetNickname: 닉네임 설정 완료 여부 (기본값: false)
     ///   - hasCompletedOnboarding: 온보딩 완료 여부 (기본값: false)
     public init(
-        uid: String,
+        uid: String? = nil,
         name: String,
         provider: String,
         email: String? = nil,

--- a/HowManySet/Domain/Entity/User.swift
+++ b/HowManySet/Domain/Entity/User.swift
@@ -9,11 +9,14 @@ import Foundation
 
 /// 사용자 온보딩 상태를 나타내는 열거형
 public enum UserStatus {
-    /// 온보딩이 필요한 상태 (닉네임 입력 + 온보딩 진행 필요)
+    /// 닉네임 설정이 필요한 상태
+    case needsNickname
+    /// 온보딩 진행이 필요한 상태 (닉네임은 설정 완료)
     case needsOnboarding
     /// 모든 설정이 완료된 상태
     case complete
 }
+
 
 /// 앱 전체에서 사용되는 통합된 사용자 도메인 모델
 ///

--- a/HowManySet/Presentation/Feature/OnBoarding/OnBoardingViewController.swift
+++ b/HowManySet/Presentation/Feature/OnBoarding/OnBoardingViewController.swift
@@ -41,6 +41,15 @@ final class OnBoardingViewController: UIViewController, View {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        // 🟢 익명 사용자는 닉네임 입력 스킵하고 바로 온보딩으로
+        let provider = UserDefaults.standard.string(forKey: "userProvider") ?? ""
+        if provider == "anonymous" {
+            print("🟢 익명 사용자 - 닉네임 입력 스킵하고 온보딩 시작")
+            // 온보딩 화면으로 바로 이동하는 로직 추가
+            startWithOnboardingOnly()
+            return
+        }
+        
         setupUI()
         onboardingView.pageIndicator.numberOfPages = OnBoardingViewReactor.onboardingPages.count
         bind(reactor: reactor)


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  - closed: #61 , #204 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
1. 로그인 플로우 개선
2. 비회원 uid 삭제 및 플로우 수정

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/ac2b5643-4e43-44f2-b372-d87c2b33b3ff" width ="250"> |

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 닉네임 입력 화면과 온보보딩 화면이 OnboardingViewController라는 하나의 VC에 속해서 화면을 나누는 작업이 힘들어졌습니다.
- 우선 비회원 로그인의 경우에는 닉네임 입력/온보딩 자체를 스킵하고 바로 홈으로 가도록 구현했습니다.