### PR TITLE
bind전 MainScheduler.instance로 쓰레드 전환

### DIFF
--- a/HowManySet/Presentation/Feature/Calendar/CalendarViewController.swift
+++ b/HowManySet/Presentation/Feature/Calendar/CalendarViewController.swift
@@ -81,11 +81,10 @@ final class CalendarViewController: UIViewController, View {
                 records.map { $0.date } // [Date]
             }
             .distinctUntilChanged() // 동일한 날짜 배열이면 업데이트 방지
+            .observe(on: MainScheduler.instance) // 명시적 Thread 전환
             .bind(with: self) { owner, dates in
                 owner.recordedDates = dates
-                DispatchQueue.main.async {
-                    owner.calendarView.publicCalendar.reloadData() // 점 갱신
-                }
+                owner.calendarView.publicCalendar.reloadData() // 점 갱신
             }
             .disposed(by: disposeBag)
 


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  closed: #225 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- `DispatchQueue.main.async` 대신에 bind전에 `.observe(on: MainScheduler.instance)`로 명시적 쓰레드 전환시킴.

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "" width ="250"> |

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
