### PR TITLE
테이블 뷰 셀 내림차순 / 상세 기록 뷰 placeholder 적용 / 캘린더 페이지 진입 시 오늘 날짜 자동 선택

### DIFF
--- a/HowManySet/Presentation/Feature/Calendar/CalendarViewController.swift
+++ b/HowManySet/Presentation/Feature/Calendar/CalendarViewController.swift
@@ -15,6 +15,9 @@ final class CalendarViewController: UIViewController, View {
     // 기록이 있는 날짜를 담아놓을 배열 생성
     private var recordedDates: [Date] = []
 
+    // 오늘 날짜
+    let today = Date()
+
     // RxDataSource 사용을 위한 Model 생성
     typealias RecordSection = SectionModel<String, WorkoutRecord>
 
@@ -35,17 +38,15 @@ final class CalendarViewController: UIViewController, View {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        // 캘린더 날짜 선택 해제
-        if let selectedDate = calendarView.publicCalendar.selectedDate {
-            calendarView.publicCalendar.deselect(selectedDate)
-        }
+        // 캘린더에서 오늘 날짜 선택
+        calendarView.publicCalendar.select(today)
 
-        // Reactor 상태도 초기화
-        reactor?.action.onNext(.clearSelection)
+        // 선택된 날짜에 대한 액션 트리거
+        reactor?.action.onNext(.selectDate(today))
 
         // 선택된 날짜 기준 fetch
         reactor?.action.onNext(.viewWillAppear)
-        
+
         calendarView.publicCalendar.locale = Locale.current // 사용자 언어 설정에 따라서 캘린더 언어 설정 동일하게 설정
     }
 

--- a/HowManySet/Presentation/Feature/Calendar/Reactor/CalendarViewReactor.swift
+++ b/HowManySet/Presentation/Feature/Calendar/Reactor/CalendarViewReactor.swift
@@ -12,7 +12,6 @@ final class CalendarViewReactor: Reactor {
         case viewWillAppear
         case selectDate(Date)
         case deleteItem(IndexPath)
-        case clearSelection
     }
 
     // MARK: - Mutate is a state manipulator which is not exposed to a view
@@ -21,7 +20,6 @@ final class CalendarViewReactor: Reactor {
         case setSelectedDate(Date)
         case setSelectedRecords([WorkoutRecord])
         case deleteRecordAt(IndexPath)
-        case clearSelectedDate
     }
 
     // MARK: - State is a current view state
@@ -91,9 +89,6 @@ final class CalendarViewReactor: Reactor {
             deleteRecordUseCase.execute(uid: uid, item: recordToDelete)
 
             return .just(.deleteRecordAt(indexPath))
-
-        case .clearSelection:
-            return .just(.clearSelectedDate)
         }
     }
 
@@ -112,9 +107,6 @@ final class CalendarViewReactor: Reactor {
             var updatedRecords = state.selectedRecords
             updatedRecords.remove(at: indexPath.row)
             newState.selectedRecords = updatedRecords
-        case .clearSelectedDate:
-            newState.selectedDate = Date()
-            newState.selectedRecords = []
         }
 
         return newState

--- a/HowManySet/Presentation/Feature/Calendar/Reactor/CalendarViewReactor.swift
+++ b/HowManySet/Presentation/Feature/Calendar/Reactor/CalendarViewReactor.swift
@@ -54,9 +54,9 @@ final class CalendarViewReactor: Reactor {
         case let .selectDate(date):
             let fetchRecords = fetchRecordUseCase.execute(uid: uid)
                 .map { allRecords in
-                    let filteredRecords = allRecords.filter {
-                        Calendar.current.isDate($0.date, inSameDayAs: date)
-                    }
+                    let filteredRecords = allRecords
+                        .filter { Calendar.current.isDate($0.date, inSameDayAs: date) }
+                        .sorted { $0.date > $1.date }
                     return Mutation.setSelectedRecords(filteredRecords)
                 }
                 .asObservable()

--- a/HowManySet/Presentation/Feature/Home/Reactor/HomeViewReactor.swift
+++ b/HowManySet/Presentation/Feature/Home/Reactor/HomeViewReactor.swift
@@ -616,6 +616,9 @@ final class HomeViewReactor: Reactor {
             
             // MARK: - 루틴 메모 업데이트
         case let .updateRoutineMemo(with: newMemo):
+            let placeholder = String(localized: "메모를 입력해주세요.")
+            let newComment = (newMemo == nil || newMemo == "" || newMemo == placeholder) ? nil : newMemo
+
             // 저장되는 WorkoutRecord (state의 recordID를 가져옴)
             let updatedWorkoutRecord = WorkoutRecord(
                 rmID: newState.recordID,
@@ -624,12 +627,12 @@ final class HomeViewReactor: Reactor {
                 workoutRoutine: newState.workoutRoutine,
                 totalTime: newState.workoutTime,
                 workoutTime: newState.workoutTime,
-                comment: newMemo, // 새로운 루틴 메모
+                comment: newComment, // 새로운 루틴 메모
                 date: Date()
             )
             print("updatedWorkoutRecord: \(updatedWorkoutRecord)")
-            print("새로운 루틴 메모: \(String(describing: newMemo))")
-            
+            print("새로운 루틴 메모: \(String(describing: newComment))")
+
             updateRecordUseCase.execute(uid: uid, item: updatedWorkoutRecord)
             
         case let .setUpdatingIndex(cardIndex):

--- a/HowManySet/Presentation/Feature/RecordDetail/Cell/MemoInfoCell.swift
+++ b/HowManySet/Presentation/Feature/RecordDetail/Cell/MemoInfoCell.swift
@@ -22,10 +22,13 @@ final class MemoInfoCell: UICollectionViewCell {
 
     // MARK: - configure
     func configure(comment: String?) {
-        let isEmpty = (comment?.isEmpty ?? true)
+        let isEmpty = comment?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true
         memoTextView.text = isEmpty ? placeholderText : comment
         memoTextView.textColor = isEmpty ? .grey3 : .white
         memoTextView.layer.borderWidth = 0
+        
+        print("configure - comment: \(comment ?? "nil")")
+        print("❓ placeholder 적용됐는지: \(isEmpty)")
     }
 }
 

--- a/HowManySet/Presentation/Feature/RecordDetail/RecordDetailViewController.swift
+++ b/HowManySet/Presentation/Feature/RecordDetail/RecordDetailViewController.swift
@@ -198,9 +198,12 @@ extension RecordDetailViewController {
 
                 textView.rx.didEndEditing
                     .bind(with: owner) { _, _ in
-                        if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        let trimmed = textView.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if trimmed.isEmpty {
                             textView.text = String(localized: "메모를 입력해주세요.")
                             textView.textColor = .grey3
+                        } else {
+                            textView.textColor = .white
                         }
                         textView.layer.borderWidth = 0
                     }

--- a/HowManySet/Presentation/Feature/RoutineComplete/RoutineCompleteViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineComplete/RoutineCompleteViewController.swift
@@ -24,7 +24,7 @@ final class RoutineCompleteViewController: UIViewController, View {
     
     private let exerciseCompletedText = String(localized: "운동 완료! 수고했어요")
     private let exerciseRecordSavedText = String(localized: "운동 기록 저장됨")
-    private let memoPlaceHolderText = String(localized: "메모를 입력해 주세요.")
+    private let memoPlaceHolderText = String(localized: "메모를 입력해주세요.")
     private let confirmText = String(localized: "확인")
         
     private let cardInset: CGFloat = UIScreen.main.bounds.width <= 375 ? 24 : 28

--- a/HowManySet/Presentation/Feature/RoutineList/Reactor/RoutineListViewReactor.swift
+++ b/HowManySet/Presentation/Feature/RoutineList/Reactor/RoutineListViewReactor.swift
@@ -77,7 +77,7 @@ final class RoutineListViewReactor: Reactor {
                     deleteRoutineUseCase.execute(uid: uid, item: routines[i])
                 }
             }
-            newState.routines = newRoutines
+            newState.routines = newRoutines.reversed() // 내림차순 정렬
         case let .deleteRoutineAt(indexPath):
             var updated = state.routines
             updated.remove(at: indexPath.section)

--- a/HowManySet/Resources/Localizable/Localizable.xcstrings
+++ b/HowManySet/Resources/Localizable/Localizable.xcstrings
@@ -907,6 +907,7 @@
       }
     },
     "메모를 입력해 주세요." : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  closed: #264 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- 루틴 리스트 페이지에서 루틴 정보 테이블 뷰 셀 내림차순으로 정렬 (비회원/회원 로그인 시 모두 내림차순으로 통일)
- 캘린더 페이지에서 운동 기록 테이블 뷰 셀 내림차순으로 정렬 (비회원/회원 로그인 시 모두 내림차순으로 통일)
- 탭 바에서 캘린더 페이지로 가면 오늘 날짜 자동으로 선택되도록 수정
- 운동 상세 기록 페이지의 메모칸 placeholder 적용되도록 수정

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/da9144d1-1d51-49d8-baa9-ec82f17871f6" width ="250"> |
| GIF | <img src = "https://github.com/user-attachments/assets/bd4720a4-a6ef-450b-b754-d6dc18d01269" width ="250"> |



## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 운동 상세 기록 페이지의 메모칸 placeholder 적용되지 않았던 이유가 운동 완료 페이지에서 메모를 빈값으로 저장하도록 구현되어있지만, 실제로는 placeholder값이 그대로 저장되고 있어서 빈값이 저장되는 게 아니었습니다.
- 따라서 운동 완료 페이지의 메모칸에 placeholder가 값이 들어있으면 nil이 저장되도록(빈값) 제약을 걸어 수정했습니다.
