### PR TITLE
bug: #296 - 다국어 지원 누락 해결

### DIFF
--- a/HowManySet/App/Coordinator/HomeCoordinator.swift
+++ b/HowManySet/App/Coordinator/HomeCoordinator.swift
@@ -149,9 +149,9 @@ final class HomeCoordinator: HomeCoordinatorProtocol {
     func popUpEndWorkoutAlert(onConfirm: @escaping () -> WorkoutSummary, onCancel: @escaping () -> Void?) {
         
         let endWorkoutVC = ExercisePopupViewController(
-            title: "운동을 종료할까요?",
-            content: "지금까지의 기록만 저장됩니다.",
-            rightButtonText: "운동종료",
+            title: String(localized: "운동을 종료할까요?"),
+            content: String(localized: "지금까지의 기록만 저장됩니다."),
+            rightButtonText: String(localized: "운동종료"),
             rightButtonTitleColor: .white,
             rightButtonBackgroundColor: .pauseButton,
             nextAction: { [weak self] in

--- a/HowManySet/Presentation/Common/Extension/Int+Extension.swift
+++ b/HowManySet/Presentation/Common/Extension/Int+Extension.swift
@@ -35,6 +35,7 @@ extension Int {
     /// Int 값을 "00분" 형태의 String으로 반환하는 메서드 
     func toMinutesLabel() -> String {
         let minutes = self / 60
-        return "\(minutes)분"
+        let format = String(localized: "분")
+        return String(format: format, minutes)
     }
 }

--- a/HowManySet/Presentation/Feature/Calendar/CalendarViewController.swift
+++ b/HowManySet/Presentation/Feature/Calendar/CalendarViewController.swift
@@ -192,9 +192,9 @@ extension CalendarViewController: UITableViewDelegate {
 
     /// trailing -> leading 방향으로 스와이프하는 메서드
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-        let deleteAction = UIContextualAction(style: .destructive, title: "삭제") { [weak self] _, _, completion in
+        let deleteAction = UIContextualAction(style: .destructive, title: String(localized: "삭제")) { [weak self] _, _, completion in
             self?.reactor?.action.onNext(.deleteItem(IndexPath(row: indexPath.section, section: 0))) // Reactor로 이벤트 전달
-            self?.showToast(x: 0, y: 50, message: "운동 기록이 삭제되었습니다!")
+            self?.showToast(x: 0, y: 50, message: String(localized: "운동 기록이 삭제되었습니다!"))
                     completion(true)
                 }
 

--- a/HowManySet/Presentation/Feature/Home/Reactor/HomeViewReactor.swift
+++ b/HowManySet/Presentation/Feature/Home/Reactor/HomeViewReactor.swift
@@ -616,10 +616,15 @@ final class HomeViewReactor: Reactor {
             
             // MARK: - 루틴 메모 업데이트
         case let .updateRoutineMemo(with: newMemo):
-            let placeholder = String(localized: "메모를 입력해주세요.")
-            let newComment = (newMemo == nil || newMemo == "" || newMemo == placeholder) ? nil : newMemo
-
-            // 저장되는 WorkoutRecord (state의 recordID를 가져옴)
+            let placeholders = [
+                String(localized: "메모를 입력해주세요."),
+                "메모를 입력해주세요.",
+                "Please enter a memo.",
+                "メモを入力してください。"
+            ]
+            let trimmedMemo = newMemo?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let newComment = (trimmedMemo == nil || trimmedMemo == "" || placeholders.contains(trimmedMemo!)) ? nil : trimmedMemo
+            
             let updatedWorkoutRecord = WorkoutRecord(
                 rmID: newState.recordID,
                 documentID: newState.workoutRecord.documentID,
@@ -627,12 +632,12 @@ final class HomeViewReactor: Reactor {
                 workoutRoutine: newState.workoutRoutine,
                 totalTime: newState.workoutTime,
                 workoutTime: newState.workoutTime,
-                comment: newComment, // 새로운 루틴 메모
+                comment: newComment,
                 date: Date()
             )
             print("updatedWorkoutRecord: \(updatedWorkoutRecord)")
             print("새로운 루틴 메모: \(String(describing: newComment))")
-
+            
             updateRecordUseCase.execute(uid: uid, item: updatedWorkoutRecord)
             
         case let .setUpdatingIndex(cardIndex):

--- a/HowManySet/Resources/Localizable/Localizable.xcstrings
+++ b/HowManySet/Resources/Localizable/Localizable.xcstrings
@@ -927,7 +927,8 @@
             "value" : "메모를 입력해 주세요."
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "메모를 입력해주세요." : {
       "localizations" : {
@@ -1189,6 +1190,29 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "버전 정보"
+          }
+        }
+      }
+    },
+    "분" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "min"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "분"
           }
         }
       }
@@ -1988,7 +2012,6 @@
       }
     },
     "운동 기록이 삭제되었습니다!" : {
-      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {

--- a/HowManySet/Resources/Localizable/Localizable.xcstrings
+++ b/HowManySet/Resources/Localizable/Localizable.xcstrings
@@ -2384,6 +2384,29 @@
         }
       }
     },
+    "운동을 종료할까요?" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Want to end the workout?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "運動を終了しますか？"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "운동을 종료할까요?"
+          }
+        }
+      }
+    },
     "운동이 추가되었어요!" : {
       "localizations" : {
         "en" : {
@@ -2424,6 +2447,29 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "운동정보 입력"
+          }
+        }
+      }
+    },
+    "운동종료" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ending a workout"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "運動終了"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "운동종료"
           }
         }
       }
@@ -2712,6 +2758,29 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "종목 수: %d"
+          }
+        }
+      }
+    },
+    "지금까지의 기록만 저장됩니다." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Only the history up to this point is saved."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "これまでの記録のみが保存されます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "지금까지의 기록만 저장됩니다."
           }
         }
       }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  - closed: #296 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
 - 운동 중 메모 ("메모를 입력해주세요" 다국어 지원 문제 일부 해결 -> 이전 운동 기록의 언어 설정을 계속 따라가는 이슈를 추가확인함)
 - 운동 기록 스와이프 삭제 다국어 지원 적용
 - 운동 기록 스와이프 삭제 후 토스트 메시지 다국어 지원 적용

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/361c7b4e-52c1-4721-92bc-3253dca4745b" width ="250"> |

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
 - ⚠️ 기존에 다른 언어 데이터가 있으면 계속 해당 언어로 "메모를 입력해주세요." 문구가 나오는 이슈가 존재