### PR TITLE
Feature/#325 - 루틴 생성 시 운동 추가 화면 변경 / RecordCell 색상 변경

### DIFF
--- a/HowManySet/App/Coordinator/RoutineListCoordinator.swift
+++ b/HowManySet/App/Coordinator/RoutineListCoordinator.swift
@@ -89,6 +89,7 @@ final class RoutineListCoordinator: RoutineListCoordinatorProtocol {
         )
         let editExcerciseVC = AddExerciseViewController(reactor: reactor)
         editExcerciseVC.setInitialUIState()
+        editExcerciseVC.hidesBottomBarWhenPushed = true // tabBar 숨김
         navigationController.pushViewController(editExcerciseVC, animated: true)
     }
 

--- a/HowManySet/Presentation/Feature/Calendar/RecordCell.swift
+++ b/HowManySet/Presentation/Feature/Calendar/RecordCell.swift
@@ -59,7 +59,7 @@ private extension RecordCell {
 
     func setAppearance() {
         contentView.do {
-            $0.backgroundColor = .grey5
+            $0.backgroundColor = #colorLiteral(red: 0.2697538137, green: 0.2697537839, blue: 0.2697538137, alpha: 1)
             $0.layer.cornerRadius = 20
             $0.clipsToBounds = true
         }

--- a/HowManySet/Presentation/Feature/EditExercise/AddExerciseView/AddExerciseViewController.swift
+++ b/HowManySet/Presentation/Feature/EditExercise/AddExerciseView/AddExerciseViewController.swift
@@ -33,8 +33,10 @@ final class AddExerciseViewController: UIViewController, View {
     // MARK: - UI Components
     
     /// 전체 화면을 스크롤 가능하게 만드는 스크롤 뷰입니다.
-    private let scrollView = UIScrollView()
-    
+    private let scrollView = UIScrollView().then {
+        $0.showsVerticalScrollIndicator = false
+    }
+
     /// 운동명을 입력하는 헤더 뷰입니다.
     private let headerView = EditExerciseHeaderView()
     

--- a/HowManySet/Presentation/Feature/EditExercise/EditExerciseFooterView/AddExerciseFooterView.swift
+++ b/HowManySet/Presentation/Feature/EditExercise/EditExerciseFooterView/AddExerciseFooterView.swift
@@ -32,20 +32,16 @@ final class AddExerciseFooterView: UIStackView {
     private let addExcerciseButton = UIButton().then {
         $0.setTitle(String(localized: "운동 추가"), for: .normal)
         $0.titleLabel?.font = .pretendard(size: 18, weight: .medium)
-        $0.setTitleColor(.background, for: .normal)
         $0.clipsToBounds = true
         $0.layer.cornerRadius = 12
-        $0.backgroundColor = .brand
     }
     
     /// 루틴 저장 버튼 - 흰색 스타일
     private let saveRoutineButton = UIButton().then {
         $0.setTitle(String(localized: "루틴 저장"), for: .normal)
         $0.titleLabel?.font = .pretendard(size: 18, weight: .medium)
-        $0.setTitleColor(.background, for: .normal)
         $0.clipsToBounds = true
         $0.layer.cornerRadius = 12
-        $0.backgroundColor = .white
     }
     
     /// 기본 생성자 - 수평 스택뷰로 구성 및 UI 초기화
@@ -105,5 +101,23 @@ private extension AddExerciseFooterView {
     /// 스택뷰 내 하위 버튼 추가
     func setViewHierarchy() {
         self.addArrangedSubviews(saveRoutineButton, addExcerciseButton)
+    }
+}
+
+// MARK: - addExcerciseButton,saveRoutineButton State Update
+extension AddExerciseFooterView {
+
+    /// addExcerciseButton 활성, 비활성하는 메서드
+    func setAddButtonEnabled(_ enabled: Bool) {
+        addExcerciseButton.isEnabled = enabled
+        addExcerciseButton.backgroundColor = enabled ? .brand : .disabledButton
+        addExcerciseButton.setTitleColor(enabled ? .background : .dbTypo, for: .normal)
+    }
+
+    /// saveRoutineButton 활성, 비활성하는 메서드
+    func setSaveButtonEnabled(_ enabled: Bool) {
+        saveRoutineButton.isEnabled = enabled
+        saveRoutineButton.backgroundColor = enabled ? .white : .disabledButton
+        saveRoutineButton.setTitleColor(enabled ? .background : .dbTypo, for: .normal)
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  closed: #325 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- 루틴 생성 시 운동 추가 화면에서 초기 화면은 두 버튼 모두 비활성화, 텍스트에 값을 넣으면 운동 추가 버튼만 활성화, 운동 추가 후 현재 운동 목록에 값이 있는 경우에만 루틴 저장 활성화 하는 방향으로 구현
- 루틴 생성 시 운동 추가 화면페이지 탭바 제거
- RecordCell 배경 색상 디자이너님이 수정하신 색상으로 변경 (hex: 353535)

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
|    전    |   후   |
| :-------------: | :----------: |
| <img src = "https://github.com/user-attachments/assets/d51f52d6-f2d4-4fae-bf5a-37f866d870e2" width ="250"> | <img src = "https://github.com/user-attachments/assets/29b126a4-eb61-4238-9c03-e973430fcb03" width ="250"> |
| <img src = "https://github.com/user-attachments/assets/e5c423d0-9718-4d59-b2ac-37dccb949708" width ="250"> | <img src = "https://github.com/user-attachments/assets/ed6b2945-f36d-44f6-92c8-e6f018c8daca" width ="250"> |
| <img src = "https://github.com/user-attachments/assets/78d93074-617c-4340-a4f4-9837cad2466b" width ="250"> | <img src = "https://github.com/user-attachments/assets/a3c286d8-ab3c-40a4-9aeb-fbbc68324f94" width ="250"> |

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
