### PR TITLE
#339 - 레이아웃 너비 수치 수정

### DIFF
--- a/HowManySet/Presentation/Common/Extension/UIStackView+Extensions.swift
+++ b/HowManySet/Presentation/Common/Extension/UIStackView+Extensions.swift
@@ -16,7 +16,7 @@ extension UIStackView {
         }
     }
     
-    /// 스택뷰 내 하위 뷰들의 크기를 일괄적으로 설정합니다.
+    /// 스택뷰 내 하위 뷰들의 크기를 일괄적으로 설정합니다. 
     ///
     /// - 첫 번째와 마지막 뷰는 너비와 높이를 40으로 고정합니다.
     /// - 그 외의 뷰들은 너비를 90, 높이를 40으로 설정합니다.
@@ -32,7 +32,7 @@ extension UIStackView {
                 }
             } else {
                 subviews[i].snp.makeConstraints {
-                    $0.width.equalTo(90)
+                    $0.width.equalTo(80)
                     $0.height.equalTo(40)
                 }
             }

--- a/HowManySet/Presentation/Feature/EditExercise/EditExerciseContentView/EditExerciseHorizontalContentStackView.swift
+++ b/HowManySet/Presentation/Feature/EditExercise/EditExerciseContentView/EditExerciseHorizontalContentStackView.swift
@@ -150,7 +150,7 @@ private extension EditExerciseHorizontalContentStackView {
     
     /// 스택뷰 내부 컴포넌트에 대한 오토레이아웃을 설정합니다.
     func setConstraints() {
-        self.configureContentLayoutArrangeSubViews()  // 이 함수는 외부에서 정의된 커스텀 메서드로 추정됩니다.
+        self.configureContentLayoutArrangeSubViews()
     }
 
     /// weightTextField, repsTextField의 delegate 설정


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  - closed: #339 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- SE버전 (가장 너비가 적은 모델)에서 레이아웃 설정중에 너비가 초과하는 일 발생
- SE버전 기준으로 충돌이 일어나지 않도록 width 값 수치 조정

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
|    모델    |   iPhone 15 Pro   | iPhone 8 Plus   | iPhone SE (3rd)   |
| :-------------: | :----------: | :----------: | :----------: |
| IMG | <img src = "https://github.com/user-attachments/assets/dd8a6685-263e-4837-adfb-85b0a036410a" width ="250"> | <img src = "https://github.com/user-attachments/assets/3bba2832-88b6-46a2-86a9-027e44d47ef0" width ="250"> | <img src = "https://github.com/user-attachments/assets/a7821141-29db-4d49-bb20-0c146d3a5edf" width ="250"> |
