### PR TITLE
#337 - 운동 편집 페이지에서 이벤트 중복 호출 현상 해결

### DIFF
--- a/HowManySet/Presentation/Feature/EditExercise/EditExerciseView/EditExerciseViewController.swift
+++ b/HowManySet/Presentation/Feature/EditExercise/EditExerciseView/EditExerciseViewController.swift
@@ -83,14 +83,15 @@ final class EditExerciseViewController: UIViewController, View {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
-        Observable.combineLatest(
-            footerView.saveExcerciseButtonRelay,
-            headerView.exerciseNameRelay,
-            contentView.exerciseInfoRelay
-        )
-        .map { (_, name, sets) in
-            Reactor.Action.saveExcerciseButtonTapped((name, sets))
-        }
+        footerView.saveExcerciseButtonRelay
+            .map {[weak self] in
+                guard let exerciseName = self?.headerView.exerciseNameRelay.value,
+                      let weightSet = self?.contentView.exerciseInfoRelay.value
+                else {
+                    return Reactor.Action.saveExcerciseButtonTapped((name: "", weightSet: [[]]))
+                }
+                return Reactor.Action.saveExcerciseButtonTapped((name: exerciseName, weightSet: weightSet))
+            }
         .observe(on: MainScheduler.instance)
         .bind(onNext: { [weak self] action in
             guard let self else { return }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  - closed: #337 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- 기존 운동 편집페이지에서 저장버튼을 누른 경우 세트수, 무게의 값이 변경되어도 저장되는 현상 발생
- 세개의 이벤트 흐름을 분리

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/e666ae36-681d-46b0-89dc-6740f41f3911" width ="250"> |

