### PR TITLE
#346 - LiveActivity (중복 start, 운동 정지 시 휴식 시간 오류)

### DIFF
--- a/HowManySet/Presentation/Feature/Home/HomeViewController.swift
+++ b/HowManySet/Presentation/Feature/Home/HomeViewController.swift
@@ -678,14 +678,21 @@ extension HomeViewController {
         // 운동/휴식시간, Pause 상태 제외 업데이트 (LiveActivity에서의 운동/휴식시간은 독립적으로 구현)
         reactor.state.map { $0.forLiveActivity }
             .distinctUntilChanged { $0.isEqualExcludingTimer(to: $1) }
+            .skip(1)
             .observe(on: ConcurrentDispatchQueueScheduler(qos: .userInitiated))
-            .map { data in
+            .compactMap { data -> HowManySetWidgetAttributes.ContentState? in
                 guard let cached = cachedContentState else {
                     let data = reactor.currentState.forLiveActivity
                     let newState = HowManySetWidgetAttributes.ContentState.init(from: data)
                     cachedContentState = newState
                     return newState
                 }
+
+                // Pause 상태가 변경된 경우 nil 반환 (별도 구독에서 처리)
+                if cached.isRestPaused != data.isRestPaused || cached.isWorkoutPaused != data.isWorkoutPaused {
+                    return nil
+                }
+
                 let updated = cached.updateLiveActivityContentStates(from: data)
                 cachedContentState = updated
                 return updated
@@ -696,20 +703,27 @@ extension HomeViewController {
             })
             .disposed(by: disposeBag)
         
-        // Pause 상태 변경 시 restStartDate/restEndDate 재계산하여 업데이트
-        reactor.state.map { $0.forLiveActivity.isRestPaused }
-            .distinctUntilChanged()
+        // 홈에서 Pause 상태 변경 시 restStartDate/restEndDate 재계산하여 업데이트
+        reactor.state.map { (
+            $0.forLiveActivity.isRestPaused,
+            $0.forLiveActivity.isWorkoutPaused,
+            $0.forLiveActivity.isResting
+        ) }
+            .distinctUntilChanged { $0 == $1 }
             .skip(1)
+            .filter { _, _, isResting in isResting } // 휴식 중일 때만 처리
             .observe(on: ConcurrentDispatchQueueScheduler(qos: .userInitiated))
-            .map { isRestPaused -> HowManySetWidgetAttributes.ContentState? in
+            .map { (isRestPaused: Bool, isWorkoutPaused: Bool, _) -> HowManySetWidgetAttributes.ContentState? in
                 guard var cached = cachedContentState else { return nil }
 
                 cached.isRestPaused = isRestPaused
-                
+                cached.isWorkoutPaused = isWorkoutPaused
+
                 // 휴식 PlayAndPause (PlayAndPauseRestIntent와 동일한 로직)
-                if isRestPaused {
+                if isRestPaused || isWorkoutPaused {
                     let remaining = cached.restEndDate?.timeIntervalSince(Date.now) ?? 0
                     cached.liveRestTime = Float(max(0, remaining))
+                    print("[Rest Play/Pause] remainingRest: \(remaining)")
                 } else {
                     cached.restStartDate = Date.now
                 }
@@ -722,7 +736,6 @@ extension HomeViewController {
                 LiveActivityService.shared.update(state: contentState)
             })
             .disposed(by: disposeBag)
-
     }//bind
 }
 

--- a/HowManySet/Presentation/Feature/Home/HomeViewController.swift
+++ b/HowManySet/Presentation/Feature/Home/HomeViewController.swift
@@ -543,6 +543,7 @@ extension HomeViewController {
         // 운동 중지 시
         reactor.state.map { ($0.isWorkoutPaused, $0.forLiveActivity) }
             .distinctUntilChanged { $0.0 == $1.0 }
+            .skip(1)
             .observe(on: MainScheduler.instance)
             .bind{ [weak self] isWorkoutPaused, liveActivityData in
                 guard let self else { return }

--- a/HowManySet/Presentation/Feature/Home/Reactor/HomeViewReactor.swift
+++ b/HowManySet/Presentation/Feature/Home/Reactor/HomeViewReactor.swift
@@ -54,6 +54,8 @@ final class HomeViewReactor: Reactor {
         case restRemainingUpdating
         case pauseAndPlayWorkout(Bool)
         case pauseRest(Bool)
+        /// 휴식 중 운동 정지 시 -> 중복으로 인해 따로 구현
+        case pauseAndPlayBoth(workout: Bool, rest: Bool)
         /// 운동 완료 시 usecase이용해서 데이터 저장
         case saveWorkoutData
         /// 스킵(다음) 버튼 클릭 시 세트/운동 카운팅
@@ -208,21 +210,24 @@ final class HomeViewReactor: Reactor {
             }
             
         case .workoutPauseButtonClicked:
-            if currentState.isRestPaused {
-                // 현재 일시정지 상태 → 재생으로 전환
-                // interval을 restSecondsRemaining에서 재시작
-                let restTimer = makeRestTimer(currentState.restRemainingTime)
-                
-                return .concat([
-                    .just(.pauseAndPlayWorkout(!currentState.isWorkoutPaused)),
-                    .just(.pauseRest(!currentState.isRestPaused)),
-                    restTimer
-                ])
-            } else {
-                return .concat([
-                    .just(.pauseAndPlayWorkout(!currentState.isWorkoutPaused)),
-                    .just(.pauseRest(!currentState.isRestPaused))
-                ])
+            if currentState.isWorkoutPaused { // 운동 정지 -> 재생
+                if currentState.isRestPaused && currentState.isResting {
+                    // interval을 restSecondsRemaining에서 재시작
+                    let restTimer = makeRestTimer(currentState.restRemainingTime)
+
+                    return .concat([
+                        .just(.pauseAndPlayBoth(workout: false, rest: false)),
+                        restTimer
+                    ])
+                } else {
+                    return .just(.pauseAndPlayWorkout(false))
+                }
+            } else { // 운동 재생 -> 정지
+                if currentState.isResting {
+                    return .just(.pauseAndPlayBoth(workout: true, rest: true))
+                } else {
+                    return .just(.pauseAndPlayWorkout(true))
+                }
             }
             
             // 하단 휴식 버튼 누를 시 동작
@@ -416,7 +421,19 @@ final class HomeViewReactor: Reactor {
                 // 현재 시각부터 타이머 재시작
                 newState.isRestPaused = false
             }
-            
+
+        case let .pauseAndPlayBoth(workout, rest):
+            newState.isWorkoutPaused = workout
+            if rest {
+                newState.isRestPaused = true
+                NotificationService.shared.removeRestNotification()
+            } else {
+                if currentState.isResting, currentState.restRemainingTime > 0 {
+                    NotificationService.shared.scheduleRestFinishedNotification(seconds: TimeInterval(currentState.restRemainingTime))
+                }
+                newState.isRestPaused = false
+            }
+
             // MARK: - 현재 운동 데이터 저장
             // 운동 완료 시 모든 정보(Record, Summary) 저장
         case .saveWorkoutData:

--- a/HowManySet/Presentation/Feature/RoutineComplete/RoutineCompleteViewController.swift
+++ b/HowManySet/Presentation/Feature/RoutineComplete/RoutineCompleteViewController.swift
@@ -427,20 +427,20 @@ extension RoutineCompleteViewController {
                 
                 self.navigationController?.popToRootViewController(animated: true)
 
-//                // 전면 광고 표시
-//                Task {
-//                    LoadingIndicator.showLoadingIndicator()
-//                    // 광고 로딩 대기
-//                    await self.loadInterstitial()
-//                    LoadingIndicator.hideLoadingIndicator()
-//                    // 광고 로드 확인
-//                    if let ad = self.interstitial {
-//                        ad.present(from: self)
-//                    } else {
-//                        print("Ad wasn't ready")
-//                    }
-//                    self.navigationController?.popToRootViewController(animated: true)
-//                }
+                // 전면 광고 표시
+                Task {
+                    LoadingIndicator.showLoadingIndicator()
+                    // 광고 로딩 대기
+                    await self.loadInterstitial()
+                    LoadingIndicator.hideLoadingIndicator()
+                    // 광고 로드 확인
+                    if let ad = self.interstitial {
+                        ad.present(from: self)
+                    } else {
+                        print("Ad wasn't ready")
+                    }
+                    self.navigationController?.popToRootViewController(animated: true)
+                }
             }
             .disposed(by: disposeBag)
     }

--- a/HowManySetWidget/View/HowManySetWidgetLiveActivity.swift
+++ b/HowManySetWidget/View/HowManySetWidgetLiveActivity.swift
@@ -414,7 +414,9 @@ extension HowManySetWidgetAttributes.ContentState {
     func updateLiveActivityContentStates(from data: WorkoutDataForLiveActivity) -> Self {
         // 휴식 중이고 isRestPaused가 변경된 경우 기존 liveRestTime, restStartDate 유지
         // (Intent에서 이미 업데이트했으므로)
-        let shouldPreserveRestData = self.isResting && (self.isRestPaused != data.isRestPaused)
+        let shouldPreserveRestData = self.isResting &&
+        ((self.isRestPaused != data.isRestPaused)
+         || (self.isWorkoutPaused != data.isWorkoutPaused))
 
         // 휴식이 새로 시작된 경우인지 확인 (이전에는 휴식 중이 아니었는데 지금 휴식 중인 경우)
         let isRestJustStarted = !self.isResting && data.isResting
@@ -457,12 +459,10 @@ extension WorkoutDataForLiveActivity {
     /// 운동/휴식시간, Pause 상태 제외한 값들만 비교
     func isEqualExcludingTimer(to other: WorkoutDataForLiveActivity) -> Bool {
         return self.isWorkingout == other.isWorkingout &&
-        self.isWorkoutPaused == other.isWorkoutPaused &&
         self.exerciseName == other.exerciseName &&
         self.exerciseInfo == other.exerciseInfo &&
         self.currentRoutineCompleted == other.currentRoutineCompleted &&
         self.isResting == other.isResting &&
-        // isRestPaused는 Intent에서 처리하므로 비교 제외
         self.currentSet == other.currentSet &&
         self.totalSet == other.totalSet &&
         self.currentIndex == other.currentIndex


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  - closed: #346 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->

<중복 start> 
- 운동 일시정지/재생 시 제거/시작을 추가하면서 생긴 오류였습니다.
-  $0.0 == $1.0 로 isWorkoutPaused만 비교하고, isWorkoutPaused를 초기에 false로 설정해놨는데 왜 실행됬는지 의문이었습니다.
알고보니 reactor.state는 BehaviorSubject 기반이라 구독 시점에 현재 상태를 즉시 방출한다고 합니다.
그 후 distinctUntilChanged에서 첫 번째 값은 비교할 이전 값이 없기 때문에 무조건 방출되어 start가 의도치 않게 실행되었습니다.

<홈에서 운동 정지 시 LiveActivity 휴식 시간 오류>
- 홈에서 운동 정지/재생 시 LiveActivity 휴식 시간이 급격히 주는 오류가 있었습니다.
.concat의 잘못된 사용으로 인해 .merge로 바꾸려했으나, 여전히 중복이 발생하여 휴식 중 운동 정지 시 mutation을 따로 만들었습니다.

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/bf9c626c-8905-4885-8c19-292bb4a1cb8c" width ="250">|

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 현재 시뮬에서 홈에서 루틴 선택 시 운동 추가 텍스트가 안보이는 오류가 있습니다.
