### PR TITLE
#356 - 홈 운동/휴식 타이머 로직 Date 이용하여 변경

### DIFF
--- a/HowManySet/Presentation/Feature/Home/HomeViewController.swift
+++ b/HowManySet/Presentation/Feature/Home/HomeViewController.swift
@@ -652,7 +652,11 @@ extension HomeViewController {
             })
             .disposed(by: disposeBag)
         
-        // MARK: - LiveActivity 관련
+        bindLiveActivity(reactor: reactor)
+    }//bind
+    
+    // MARK: - LiveActivity 관련
+    func bindLiveActivity(reactor: HomeViewReactor) {
         // contentState 캐싱
         var cachedContentState: HowManySetWidgetAttributes.ContentState?
         
@@ -734,7 +738,7 @@ extension HomeViewController {
                 LiveActivityService.shared.update(state: contentState)
             })
             .disposed(by: disposeBag)
-    }//bind
+    }
 }
 
 

--- a/HowManySet/Presentation/Feature/Home/Reactor/HomeViewReactor+Extension.swift
+++ b/HowManySet/Presentation/Feature/Home/Reactor/HomeViewReactor+Extension.swift
@@ -14,12 +14,12 @@ extension HomeViewReactor {
     // MARK: - 타이머
     /// 운동시간 타이머
     func makeWorkoutTimer() -> Observable<HomeViewReactor.Mutation> {
-        return Observable<Int>.interval(.seconds(1), scheduler: ConcurrentDispatchQueueScheduler(qos: .userInteractive))
-            .take(until: self.state.map { !$0.isWorkingout }.filter { $0 }) // 운동 끝나면 중단
-            .withLatestFrom(self.state.map { $0.isWorkoutPaused }) { _, isPaused in return isPaused }
+        return Observable<Int>.interval(.seconds(1), scheduler: MainScheduler.instance)
+            .take(until: self.state.map { !$0.isWorkingout }
+                .filter { $0 })
+            .withLatestFrom(self.state.map { $0.isWorkoutPaused })
             .filter { !$0 }
             .map { _ in Mutation.workoutTimeUpdating }
-            .observe(on: MainScheduler.instance)
     }
     
     /// 휴식시간 타이머: 현재 0.05초 간격으로 진행
@@ -291,7 +291,7 @@ extension HomeViewReactor {
             restRemainingTime: 60.0,
             restTime: 60.0, // 기본 60초로 설정
             restStartTime: nil,
-            date: Date(),
+            date: Date.now,
             memoInRoutine: initialWorkoutRecord.comment,
             currentExerciseAllSetsCompleted: false,
             isEditAndMemoViewPresented: false,
@@ -308,7 +308,13 @@ extension HomeViewReactor {
             documentID: initialRoutine.documentID,
             recordID: "",
             liveRestStartDate: nil,
-            liveRestTime: 60
+            liveRestTime: 60,
+            workoutStartDate: nil, // Live와의 딜레이로 인해 초기 nil, reactor에서 현재 시각 설정
+            workoutPausedDuration: 0,
+            workoutPauseStartDate: nil,
+            restStartDate: nil,
+            restPausedDuration: 0,
+            restPauseStartDate: nil
         )
     }
     

--- a/HowManySet/Presentation/Feature/Home/Reactor/HomeViewReactor+Extension.swift
+++ b/HowManySet/Presentation/Feature/Home/Reactor/HomeViewReactor+Extension.swift
@@ -11,10 +11,10 @@ import ReactorKit
 
 extension HomeViewReactor {
     
-    // MARK: - 타이머
-    /// 운동시간 타이머
+    // MARK: - 타이머 UI 업데이트
+    /// 운동시간 UI 업데이트
     func makeWorkoutTimer() -> Observable<HomeViewReactor.Mutation> {
-        return Observable<Int>.interval(.seconds(1), scheduler: MainScheduler.instance)
+        return Observable<Int>.interval(.seconds(1), scheduler: MainScheduler.asyncInstance)
             .take(until: self.state.map { !$0.isWorkingout }
                 .filter { $0 })
             .withLatestFrom(self.state.map { $0.isWorkoutPaused })
@@ -22,11 +22,9 @@ extension HomeViewReactor {
             .map { _ in Mutation.workoutTimeUpdating }
     }
     
-    /// 휴식시간 타이머: 현재 0.05초 간격으로 진행
+    /// 휴식시간 UI 업데이트
     func makeRestTimer(_ restTime: Float) -> Observable<HomeViewReactor.Mutation> {
-        let tickCount = restTime * 20
-        return Observable<Int>.interval(.milliseconds(50), scheduler: ConcurrentDispatchQueueScheduler(qos: .userInteractive))
-            .take(Int(tickCount))
+        return Observable<Int>.interval(.milliseconds(50), scheduler: MainScheduler.asyncInstance)
             .take(until: self.state.map {
                 $0.isRestPaused || !$0.isResting || $0.isRestTimerStopped }
                 .filter { $0 }

--- a/HowManySet/Presentation/Feature/Home/Reactor/HomeViewReactor+Extension.swift
+++ b/HowManySet/Presentation/Feature/Home/Reactor/HomeViewReactor+Extension.swift
@@ -23,7 +23,7 @@ extension HomeViewReactor {
     }
     
     /// 휴식시간 UI 업데이트
-    func makeRestTimer(_ restTime: Float) -> Observable<HomeViewReactor.Mutation> {
+    func makeRestTimer() -> Observable<HomeViewReactor.Mutation> {
         return Observable<Int>.interval(.milliseconds(50), scheduler: MainScheduler.asyncInstance)
             .take(until: self.state.map {
                 $0.isRestPaused || !$0.isResting || $0.isRestTimerStopped }
@@ -50,9 +50,8 @@ extension HomeViewReactor {
         
         if isResting {
             let restTime = currentState.restTime
-            let tickCount = restTime * 20 // 0.05초 간격으로 진행
             // 휴식 타이머
-            restTimer = makeRestTimer(tickCount)
+            restTimer = makeRestTimer()
             if restTime > 0 {
                 NotificationService.shared.scheduleRestFinishedNotification(seconds: TimeInterval(restTime))
             }

--- a/HowManySet/Presentation/Feature/Home/Reactor/HomeViewReactor.swift
+++ b/HowManySet/Presentation/Feature/Home/Reactor/HomeViewReactor.swift
@@ -431,15 +431,14 @@ final class HomeViewReactor: Reactor {
                 let elapsed = Date.now.timeIntervalSince(restStartDate)
                 let paused = newState.restPausedDuration
                 let totalRestTime = newState.restTime
-                print("휴식정지시간", paused)
+//                print("휴식정지시간", paused)
                 newState.restRemainingTime = Float(max(Double(totalRestTime)-(elapsed-paused), 0))
                                 
                 if newState.restRemainingTime == 0.0 {
                     newState.isResting = false
                     newState.isRestTimerStopped = true
                 }
-                
-                print("남은 휴식시간", newState.restRemainingTime)
+//                print("남은 휴식시간", newState.restRemainingTime)
             }
             
         case let .pauseAndPlayWorkout(isPaused):
@@ -466,7 +465,6 @@ final class HomeViewReactor: Reactor {
                 if let restPauseStartDate = newState.restPauseStartDate {
                     newState.restPausedDuration += Date.now.timeIntervalSince(restPauseStartDate)
                     newState.restPauseStartDate = nil
-                    print("휴식정지시Interval: \(newState.restPausedDuration)")
                 }
                 // 현재 시각부터 타이머 재시작
                 newState.isRestPaused = false
@@ -478,10 +476,27 @@ final class HomeViewReactor: Reactor {
 
         case let .pauseAndPlayBoth(workout, rest):
             newState.isWorkoutPaused = workout
+            
+            if workout {
+                newState.workoutPauseStartDate = Date.now
+            } else {
+                if let workoutPauseStartDate = newState.workoutPauseStartDate {
+                    newState.workoutPausedDuration += Date.now.timeIntervalSince(workoutPauseStartDate)
+                    newState.workoutPauseStartDate = nil
+                }
+            }
+            
             if rest {
                 newState.isRestPaused = true
+                newState.restPauseStartDate = Date.now
                 NotificationService.shared.removeRestNotification()
             } else {
+                if let restPauseStartDate = newState.restPauseStartDate {
+                    newState.restPausedDuration += Date.now.timeIntervalSince(restPauseStartDate)
+                    newState.restPauseStartDate = nil
+                }
+                newState.isRestPaused = false
+                
                 if currentState.isResting, currentState.restRemainingTime > 0 {
                     NotificationService.shared.scheduleRestFinishedNotification(seconds: TimeInterval(currentState.restRemainingTime))
                 }

--- a/HowManySet/Presentation/Feature/Home/Reactor/HomeViewReactor.swift
+++ b/HowManySet/Presentation/Feature/Home/Reactor/HomeViewReactor.swift
@@ -228,7 +228,7 @@ final class HomeViewReactor: Reactor {
             if currentState.isWorkoutPaused { // 운동 정지 -> 재생
                 if currentState.isRestPaused && currentState.isResting {
                     // interval을 restSecondsRemaining에서 재시작
-                    let restTimer = makeRestTimer(currentState.restRemainingTime)
+                    let restTimer = makeRestTimer()
 
                     return .concat([
                         .just(.pauseAndPlayBoth(workout: false, rest: false)),
@@ -257,7 +257,7 @@ final class HomeViewReactor: Reactor {
             if currentState.isRestPaused {
                 // 현재 일시정지 상태 → 재생으로 전환
                 // interval을 restSecondsRemaining에서 재시작
-                let restTimer = makeRestTimer(currentState.restRemainingTime)
+                let restTimer = makeRestTimer()
                 
                 return .concat([
                     .just(.pauseAndPlayRest(false)),

--- a/HowManySet/Presentation/Feature/Home/Reactor/HomeViewReactor.swift
+++ b/HowManySet/Presentation/Feature/Home/Reactor/HomeViewReactor.swift
@@ -53,7 +53,7 @@ final class HomeViewReactor: Reactor {
         case workoutTimeUpdating
         case restRemainingUpdating
         case pauseAndPlayWorkout(Bool)
-        case pauseRest(Bool)
+        case pauseAndPlayRest(Bool)
         /// 휴식 중 운동 정지 시 -> 중복으로 인해 따로 구현
         case pauseAndPlayBoth(workout: Bool, rest: Bool)
         /// 운동 완료 시 usecase이용해서 데이터 저장
@@ -200,7 +200,7 @@ final class HomeViewReactor: Reactor {
                 return .empty()
             } else {
                 return .concat([
-                    .just(.pauseRest(false)),
+                    .just(.pauseAndPlayRest(false)),
                     .just(.stopRestTimer(false)),
                     .just(.setUpdatingIndex(cardIndex)),
                     handleWorkoutFlow(cardIndex, isResting: true, restTime: currentState.restTime)
@@ -213,13 +213,13 @@ final class HomeViewReactor: Reactor {
             if currentState.isResting {
                 // 휴식 중일 때 휴식만 종료
                 return .concat([
-                    .just(.pauseRest(false)),
+                    .just(.pauseAndPlayRest(false)),
                     .just(.stopRestTimer(true))
                 ])
             } else {
                 // 그 외엔 휴식 없이 바로 진행
                 return .concat([
-                    .just(.pauseRest(false)),
+                    .just(.pauseAndPlayRest(false)),
                     handleWorkoutFlow(cardIndex, isResting: false, restTime: currentState.restTime)
                 ])
             }
@@ -260,13 +260,13 @@ final class HomeViewReactor: Reactor {
                 let restTimer = makeRestTimer(currentState.restRemainingTime)
                 
                 return .concat([
-                    .just(.pauseRest(false)),
+                    .just(.pauseAndPlayRest(false)),
                     restTimer
                 ])
             } else {
                 // 재생 상태 → 일시정지로 전환
                 // interval 종료, 남은 시간만 보존
-                return .just(.pauseRest(true))
+                return .just(.pauseAndPlayRest(true))
             }
             
         case .stopButtonClicked:
@@ -340,27 +340,21 @@ final class HomeViewReactor: Reactor {
             newState.isWorkingout = isWorkingout
             // 운동 시작 시각 현재로 설정
             newState.workoutStartDate = Date.now
-                        
-        case let .pauseAndPlayWorkout(isPaused):
-            newState.isWorkoutPaused = isPaused
-            if isPaused {
-                // 일시정지 시작 시각 저장
-                newState.workoutPauseStartDate = Date.now
-            } else {
-                // 일시정지 해제: 누적 시간 계산
-                if let workoutPauseStartDate = newState.workoutPauseStartDate {
-                    newState.workoutPausedDuration += Date.now.timeIntervalSince(workoutPauseStartDate)
-                    newState.workoutPauseStartDate = nil
-                }
-            }
             
         case let .setResting(isResting):
             newState.isResting = isResting
-            newState.liveRestStartDate = Date.now
-            if !newState.isResting {
+            if isResting {
+                newState.restStartDate = Date.now
+                newState.restPausedDuration = 0.0
+                newState.restPauseStartDate = nil
+                newState.liveRestStartDate = Date.now
+            } else {
                 newState.restRemainingTime = 0.0
                 newState.restStartTime = nil
                 newState.liveRestStartDate = nil
+                newState.restStartDate = nil
+                newState.restPausedDuration = 0.0
+                newState.restPauseStartDate = nil
             }
             
             // 휴식 버튼으로 휴식 시간 설정 시
@@ -419,40 +413,67 @@ final class HomeViewReactor: Reactor {
             newState.currentExerciseIndex = 0 // 첫 운동으로 초기화
             
         case .workoutTimeUpdating:
-            // 기존 단순 카운팅(workoutTime += 1) 방식에서 Date로 변경
+            // 기존 단순 카운팅(workoutTime += 1) 방식에서 Date 계산으로 변경
             if let workoutStartDate = newState.workoutStartDate {
                 let elapsed = Date.now.timeIntervalSince(workoutStartDate)
                 let paused = newState.workoutPausedDuration
                 newState.workoutTime = Int(elapsed - paused)
-                print(newState.workoutTime)
             }
             
         case .restRemainingUpdating:
             if newState.isResting,
                !newState.isWorkoutPaused,
                !newState.isRestPaused,
-               !newState.isRestTimerStopped {
-                // 0.05초씩 감소
-                newState.restRemainingTime = max(newState.restRemainingTime - 0.05, 0)
+               !newState.isRestTimerStopped,
+               let restStartDate = newState.restStartDate {
                 
-//                print(newState.restRemainingTime)
+                // 기존 단순 카운팅(0.05씩 감소) 방식에서 Date 계산으로 변경
+                let elapsed = Date.now.timeIntervalSince(restStartDate)
+                let paused = newState.restPausedDuration
+                let totalRestTime = newState.restTime
+                print("휴식정지시간", paused)
+                newState.restRemainingTime = Float(max(Double(totalRestTime)-(elapsed-paused), 0))
                                 
-                if newState.restRemainingTime <= 0.1 {
+                if newState.restRemainingTime == 0.0 {
                     newState.isResting = false
                     newState.isRestTimerStopped = true
                 }
+                
+                print("남은 휴식시간", newState.restRemainingTime)
             }
             
-        case let .pauseRest(isPaused):
+        case let .pauseAndPlayWorkout(isPaused):
+            newState.isWorkoutPaused = isPaused
+            if isPaused {
+                // 일시정지 시작 시각 저장
+                newState.workoutPauseStartDate = Date.now
+            } else {
+                // 일시정지 해제: 누적 시간 계산
+                if let workoutPauseStartDate = newState.workoutPauseStartDate {
+                    newState.workoutPausedDuration += Date.now.timeIntervalSince(workoutPauseStartDate)
+                    newState.workoutPauseStartDate = nil
+                }
+            }
+            
+        case let .pauseAndPlayRest(isPaused):
             if isPaused {
                 newState.isRestPaused = true
+                // 휴식 일시정지 시각 저장
+                newState.restPauseStartDate = Date.now
                 NotificationService.shared.removeRestNotification()
             } else {
-                if currentState.isResting, currentState.restRemainingTime > 0 {
-                    NotificationService.shared.scheduleRestFinishedNotification(seconds: TimeInterval(currentState.restRemainingTime))
+                // 일시정지 해제: 누적 시간 계산
+                if let restPauseStartDate = newState.restPauseStartDate {
+                    newState.restPausedDuration += Date.now.timeIntervalSince(restPauseStartDate)
+                    newState.restPauseStartDate = nil
+                    print("휴식정지시Interval: \(newState.restPausedDuration)")
                 }
                 // 현재 시각부터 타이머 재시작
                 newState.isRestPaused = false
+                
+                if currentState.isResting, currentState.restRemainingTime > 0 {
+                    NotificationService.shared.scheduleRestFinishedNotification(seconds: TimeInterval(currentState.restRemainingTime))
+                }
             }
 
         case let .pauseAndPlayBoth(workout, rest):

--- a/HowManySet/Presentation/Feature/Home/Reactor/HomeViewReactor.swift
+++ b/HowManySet/Presentation/Feature/Home/Reactor/HomeViewReactor.swift
@@ -99,12 +99,13 @@ final class HomeViewReactor: Reactor {
         var isWorkingout: Bool
         /// 운동 중지 시
         var isWorkoutPaused: Bool
+        /// UI용 운동시간
         var workoutTime: Int
         var isResting: Bool
         var isRestPaused: Bool
-        /// 현재 남은 휴식 시간
+        /// UI용 현재 남은 휴식 시간
         var restRemainingTime: Float
-        /// 기본 휴식 시간
+        /// 기본 휴식 시간 (사용자 설정, UI)
         var restTime: Float
         /// 휴식이 시작될 때의 값 (프로그레스바 용)
         var restStartTime: Float?
@@ -134,6 +135,20 @@ final class HomeViewReactor: Reactor {
         // LiveActivity RestTimer 용
         var liveRestStartDate: Date?
         var liveRestTime: Float
+        
+        // MARK: - 시간 기반 타이머 계산용
+        /// 운동 시작 시각
+        var workoutStartDate: Date?
+        /// 운동 일시정지 누적 시간
+        var workoutPausedDuration: TimeInterval
+        /// 운동 일시정지 시작 시각
+        var workoutPauseStartDate: Date?
+        /// 휴식 시작 시각
+        var restStartDate: Date?
+        /// 휴식 일시정지 누적 시간
+        var restPausedDuration: TimeInterval
+        /// 휴식 일시정지 시작 시각
+        var restPauseStartDate: Date?
     }
     
     // initialState 주입으로 변경
@@ -323,9 +338,21 @@ final class HomeViewReactor: Reactor {
             
         case let .setWorkingout(isWorkingout):
             newState.isWorkingout = isWorkingout
+            // 운동 시작 시각 현재로 설정
+            newState.workoutStartDate = Date.now
                         
         case let .pauseAndPlayWorkout(isPaused):
             newState.isWorkoutPaused = isPaused
+            if isPaused {
+                // 일시정지 시작 시각 저장
+                newState.workoutPauseStartDate = Date.now
+            } else {
+                // 일시정지 해제: 누적 시간 계산
+                if let workoutPauseStartDate = newState.workoutPauseStartDate {
+                    newState.workoutPausedDuration += Date.now.timeIntervalSince(workoutPauseStartDate)
+                    newState.workoutPauseStartDate = nil
+                }
+            }
             
         case let .setResting(isResting):
             newState.isResting = isResting
@@ -392,7 +419,13 @@ final class HomeViewReactor: Reactor {
             newState.currentExerciseIndex = 0 // 첫 운동으로 초기화
             
         case .workoutTimeUpdating:
-            newState.workoutTime += 1
+            // 기존 단순 카운팅(workoutTime += 1) 방식에서 Date로 변경
+            if let workoutStartDate = newState.workoutStartDate {
+                let elapsed = Date.now.timeIntervalSince(workoutStartDate)
+                let paused = newState.workoutPausedDuration
+                newState.workoutTime = Int(elapsed - paused)
+                print(newState.workoutTime)
+            }
             
         case .restRemainingUpdating:
             if newState.isResting,

--- a/HowManySetWidget/View/HowManySetWidgetLiveActivity.swift
+++ b/HowManySetWidget/View/HowManySetWidgetLiveActivity.swift
@@ -73,21 +73,12 @@ struct HowManySetWidgetLiveActivity: Widget {
                             HStack {
                                 Image(systemName: "timer")
                                     .foregroundStyle(.brand)
-
-                                if !context.state.isWorkoutPaused {
-                                    Text(timerInterval: context.state.workoutStartDate...Date.distantFuture,
-                                         countsDown: false)
-                                        .foregroundStyle(.white)
-                                        .font(.system(size: 14))
-                                        .fontWeight(.semibold)
-                                        .monospacedDigit()
-                                } else {
-                                    Text(context.state.workoutTime.toWorkOutTimeLabelInLive())
-                                        .foregroundStyle(.white)
-                                        .font(.system(size: 14))
-                                        .fontWeight(.semibold)
-                                        .monospacedDigit()
-                                }
+                                Text(timerInterval: context.state.workoutStartDate...Date.distantFuture,
+                                     countsDown: false)
+                                    .foregroundStyle(.white)
+                                    .font(.system(size: 14))
+                                    .fontWeight(.semibold)
+                                    .monospacedDigit()
                             }
                         } else { // 휴식 중 상단
                             HStack {


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  - closed: #356 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- 전에 타이머 로직 분리할 때는 잘 되었으나, 실제 실기기로 하니 홈 타이머가 백그라운드로 돌입 시 바로 멈췄습니다. 
- `ConcurrentDispatchScheduler`는 백그라운드 스케줄러에서 동작하게 끔 할 수 있는 것인데, xcode에서 디버깅 시 잘 작동되어 백그라운드 돌입 시에도 동작하는 걸로 혼동하였습니다.
- 결국 LiveActivity 로직과 마찬가지로 `Date`를 활용하도록 변경하였습니다.

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/629d9208-367b-4748-83f8-05dff443e8c1" width ="250"> |

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 반복되는 로직 부분들은 추후에 다른 issue에서 리팩토링 하겠습니다.
