### PR TITLE
#331 - Update Alert 구현 (clean branch)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,5 @@ Secrets.xcconfig
 Package.resolved
 
 .claude/settings.local.json
+
+HowManySet/Resources/GoogleService-Info.plist

--- a/HowManySet/App/SceneDelegate.swift
+++ b/HowManySet/App/SceneDelegate.swift
@@ -13,6 +13,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
     var appCoordinator: AppCoordinator?
+    private let updateManager = UpdateAlertManager()
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
@@ -23,6 +24,18 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let coordinator = AppCoordinator(window: window, container: container)
         self.appCoordinator = coordinator
         coordinator.start()
+
+        // 앱 시작 후, 업데이트 필요 여부 체크
+        Task { [weak self] in
+            guard let self else { return }
+
+            if let type = await self.updateManager.checkUpdateAlertNeeded() {
+                DispatchQueue.main.async { [weak self] in
+                    guard let self, let rootVC = self.window?.rootViewController else { return }
+                    self.updateManager.showUpdateAlert(type: type, on: rootVC)
+                }
+            }
+        }
     }
     
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {

--- a/HowManySet/Presentation/Common/Alert/UpdateAlertManager.swift
+++ b/HowManySet/Presentation/Common/Alert/UpdateAlertManager.swift
@@ -1,0 +1,73 @@
+import UIKit
+
+final class UpdateAlertManager {
+
+    // App id
+    private let appId: String = "6746778243"
+
+    // App Store 최신 버전 조회 (iTunes lookup API)
+    func checkAppStoreVersion() async -> String {
+        guard let url = URL(string: "https://itunes.apple.com/lookup?id=\(appId)") else { return "" }
+
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            if let json = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any],
+               let results = json["results"] as? [[String: Any]],
+               let appStoreVersion = results[0]["version"] as? String { return appStoreVersion }
+        } catch {
+            print("앱스토어 버전을 가져오지 못했습니다❌ \(error)")
+        }
+
+        return ""
+    }
+
+    // 현재 번들 버전 확인
+    func checkBundleVersion() -> String {
+        let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
+        return version
+    }
+
+    // Semantic Version 비교하여 업데이트가 필요한지 판단 (Major -> Minor -> Patch)
+    func checkUpdateAlertNeeded() async -> UpdateAlertType? {
+        let bundleVersion = checkBundleVersion()
+        let appStoreVersion = await checkAppStoreVersion()
+
+        let bundleVersionArray = bundleVersion.split(separator: ".").map { $0 }
+        let appStoreVersionArray = appStoreVersion.split(separator: ".").map { $0 }
+
+        if bundleVersionArray[0] < appStoreVersionArray[0] {
+            return .majorUpdate
+        } else if bundleVersionArray[0] == appStoreVersionArray[0]
+                     && bundleVersionArray[1] < appStoreVersionArray[1] {
+            return .minorUpdate
+        } else if bundleVersionArray[0] == appStoreVersionArray[0]
+                     && bundleVersionArray[1] == appStoreVersionArray[1]
+                     && bundleVersionArray[2] < appStoreVersionArray[2] {
+            return .patchUpdate
+        } else {
+            return nil
+        }
+    }
+
+    // 업데이트 alert를 표시하는 메서드
+    func showUpdateAlert(type: UpdateAlertType, on viewController: UIViewController) {
+        let alertVC = UIAlertController(title: type.title, message: type.message, preferredStyle: .alert)
+
+//        // 선택이라면 "다음에" 허용
+//        alertVC.addAction(UIAlertAction(title: String(localized: "다음에"), style: .default))
+
+        // "업데이트"
+        alertVC.addAction(UIAlertAction(title: String(localized: "업데이트"), style: .default, handler: { _ in
+            let urlStr = "itms-apps://itunes.apple.com/app/\(self.appId)"
+            if let url = URL(string: urlStr), UIApplication.shared.canOpenURL(url) {
+                if #available(iOS 10.0, *) {
+                    UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                } else {
+                    UIApplication.shared.openURL(url)
+                }
+            }
+        }))
+
+        viewController.present(alertVC, animated: true)
+    }
+}

--- a/HowManySet/Presentation/Common/Enum/UpdateAlertType.swift
+++ b/HowManySet/Presentation/Common/Enum/UpdateAlertType.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Semantic Version에 따라 업데이트를 진행하고 있으므로, 추후에 버전 업데이트마다 Alert를 다르게 표시하기 위한 열거형입니다.
+enum UpdateAlertType {
+    case patchUpdate
+    case minorUpdate
+    case majorUpdate
+
+    var title: String {
+        switch self {
+        case .patchUpdate:
+            return String(localized: "패치 업데이트 알림")
+        case .minorUpdate:
+            return String(localized: "마이너 업데이트 알림")
+        case .majorUpdate:
+            return String(localized: "메이저 업데이트 알림")
+        }
+    }
+
+    var message: String {
+        switch self {
+        case .patchUpdate:
+            return String(localized: "HowManySet이 개선되었어요!\n 바로 패치 업데이트해 보세요")
+        case .minorUpdate:
+            return String(localized: "HowManySet이 개선되었어요!\n 바로 마이너 업데이트해 보세요")
+        case .majorUpdate:
+            return String(localized: "HowManySet이 개선되었어요!\n 바로 메이저 업데이트해 보세요")
+        }
+    }
+}

--- a/HowManySet/Resources/Localizable/Localizable.xcstrings
+++ b/HowManySet/Resources/Localizable/Localizable.xcstrings
@@ -506,6 +506,90 @@
         }
       }
     },
+    "HowManySet이 개선되었어요!\n 바로 마이너 업데이트해 보세요" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HowManySet has been improved!\nPlease update to the minor version"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¡HowManySet ha sido mejorado!\nActualiza a la versión menor"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HowManySetが改善されました！\nマイナーアップデートを行ってください"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HowManySet이 개선되었어요!\n 바로 마이너 업데이트해 보세요"
+          }
+        }
+      }
+    },
+    "HowManySet이 개선되었어요!\n 바로 메이저 업데이트해 보세요" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HowManySet has been improved!\nPlease update to the major version"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¡HowManySet ha sido mejorado!\nActualiza a la versión mayor"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HowManySetが改善されました！\nメジャーアップデートを行ってください"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HowManySet이 개선되었어요!\n 바로 메이저 업데이트해 보세요"
+          }
+        }
+      }
+    },
+    "HowManySet이 개선되었어요!\n 바로 패치 업데이트해 보세요" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HowManySet has been improved!\nPlease update to the patch version"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¡HowManySet ha sido mejorado!\nActualiza a la versión de parche"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HowManySetが改善されました！\nパッチアップデートを行ってください"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HowManySet이 개선되었어요!\n 바로 패치 업데이트해 보세요"
+          }
+        }
+      }
+    },
     "Kakao로 시작하기" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -1124,6 +1208,34 @@
         }
       }
     },
+    "마이너 업데이트 알림" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minor Update Notice"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aviso de actualización menor"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "マイナーアップデートのお知らせ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "마이너 업데이트 알림"
+          }
+        }
+      }
+    },
     "메모" : {
       "localizations" : {
         "en" : {
@@ -1232,6 +1344,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "메인"
+          }
+        }
+      }
+    },
+    "메이저 업데이트 알림" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Major Update Notice"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aviso de actualización mayor"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メジャーアップデートのお知らせ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "메이저 업데이트 알림"
           }
         }
       }
@@ -3788,6 +3928,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "탈퇴 시 모든 운동 기록과 데이터가 삭제되며, 복구할 수 없습니다."
+          }
+        }
+      }
+    },
+    "패치 업데이트 알림" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Patch Update Notice"
+          }
+        },
+        "es-419" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aviso de actualización de parche"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パッチアップデートのお知らせ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "패치 업데이트 알림"
           }
         }
       }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  closed: #331 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- 우선 Patch, Minor, Major 업데이트 모두 강제 업데이트로 구현했지만, 추후에 "다음에" 버튼을 넣을 것을 고려하여 주석처리함
- 업데이트마다 메세지를 달리하기 위해 열거형 파일을 만듦

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
|    구현 내용    |   한국어   |   영어   |   일본어   |   스페인어   |
| :-------------: | :----------: | :----------: | :----------: | :----------: |
| PNG | <img src = "https://github.com/user-attachments/assets/9e234a0b-7ac1-44eb-8fec-aac2f585304c" width ="250"> | <img src = "https://github.com/user-attachments/assets/4d741092-6fda-488f-b52e-7830a9ec2408" width ="250"> | <img src = "https://github.com/user-attachments/assets/04c38881-f1de-488a-83af-30164ede418b" width ="250"> | <img src = "https://github.com/user-attachments/assets/3d62a97c-42f3-4aba-949f-c0040874ce6a" width ="250"> |


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 시뮬에서는 앱스토어로 넘어가지 않아서 실기기 테스트 필요
- 정확하진 않지만 아마 Bundle Version값을 받아서 AppStore Version과 비교하기 때문에 앱 업데이트할 때마다 Bundle Version값을 수동으로 수정해줘야 하는 듯 합니다.
- 실수로 GoogleService-Info.plist를 같이 올려버려서 삭제하고 다시 PR 올립니다. 다시 한번 죄송합니다. 이미 closed한 PR이 reopen이 되지 않아 깃허브에 계속 GoogleService-Info.plist가 남아있어서 다시 재발급 해야 할 것 같습니다..
- gitIgnore에 혹시 몰라서 GoogleService-Info.plist를 한번 더 추가 시켰습니다.
- CLI로 하다보니 새 PR 커밋도 한번에 되어 버렸네요.. 다음부터는 신경쓰겠습니다.
